### PR TITLE
Centralize default Ollama URL

### DIFF
--- a/ChatClient.Api/Client/Pages/Settings.razor
+++ b/ChatClient.Api/Client/Pages/Settings.razor
@@ -3,6 +3,7 @@
 @using ChatClient.Api.Services
 @using ChatClient.Shared.Models
 @using ChatClient.Shared.Services
+@using ChatClient.Shared.Constants
 @using System.Text.Json
 @inject IUserSettingsService UserSettingsService
 @inject OllamaService OllamaService
@@ -56,7 +57,7 @@
                         <MudTextField T="string" Label="Server URL" @bind-Value="_settings.OllamaServerUrl"
                                       Variant="Variant.Outlined"
                                       HelperText="Ollama server URL including protocol and port (e.g., https://my-server:11434)"
-                                      Placeholder="http://localhost:11434" />
+                                      Placeholder="@OllamaDefaults.ServerUrl" />
                         <MudTextField T="string" Label="Basic Auth Password" @bind-Value="_settings.OllamaBasicAuthPassword"
                                       Variant="Variant.Outlined" InputType="InputType.Password"
                                       HelperText="Password for basic authentication (leave empty if not required)"

--- a/ChatClient.Api/Services/KernelService.cs
+++ b/ChatClient.Api/Services/KernelService.cs
@@ -1,5 +1,6 @@
 using ChatClient.Shared.Models;
 using ChatClient.Shared.Services;
+using ChatClient.Shared.Constants;
 
 using Microsoft.SemanticKernel;
 
@@ -35,7 +36,7 @@ public class KernelService(
         var settings = await userSettingsService.GetSettingsAsync();
         var baseUrl = !string.IsNullOrWhiteSpace(settings.OllamaServerUrl)
             ? settings.OllamaServerUrl
-            : configuration["Ollama:BaseUrl"] ?? "http://localhost:11434";
+            : configuration["Ollama:BaseUrl"] ?? OllamaDefaults.ServerUrl;
 
         IKernelBuilder builder = Kernel.CreateBuilder();
 

--- a/ChatClient.Api/Services/OllamaService.cs
+++ b/ChatClient.Api/Services/OllamaService.cs
@@ -4,6 +4,7 @@ using System.Text;
 
 using ChatClient.Shared.Models;
 using ChatClient.Shared.Services;
+using ChatClient.Shared.Constants;
 
 using OllamaSharp;
 
@@ -84,7 +85,7 @@ public sealed class OllamaService(
         return new SettingsSnapshot(
             !string.IsNullOrWhiteSpace(user.OllamaServerUrl)
                 ? user.OllamaServerUrl
-                : configuration["Ollama:BaseUrl"] ?? "http://localhost:11434",
+                : configuration["Ollama:BaseUrl"] ?? OllamaDefaults.ServerUrl,
             user.OllamaBasicAuthPassword,
             user.IgnoreSslErrors);
     }

--- a/ChatClient.Shared/Constants/OllamaDefaults.cs
+++ b/ChatClient.Shared/Constants/OllamaDefaults.cs
@@ -1,0 +1,6 @@
+namespace ChatClient.Shared.Constants;
+
+public static class OllamaDefaults
+{
+    public const string ServerUrl = "http://localhost:11434";
+}

--- a/ChatClient.Shared/Models/UserSettings.cs
+++ b/ChatClient.Shared/Models/UserSettings.cs
@@ -1,4 +1,5 @@
 using System.Text.Json.Serialization;
+using ChatClient.Shared.Constants;
 
 namespace ChatClient.Shared.Models;
 
@@ -26,7 +27,7 @@ public class UserSettings
     /// Ollama server URL (including protocol and port)
     /// </summary>
     [JsonPropertyName("ollamaServerUrl")]
-    public string OllamaServerUrl { get; set; } = "http://localhost:11434";
+    public string OllamaServerUrl { get; set; } = OllamaDefaults.ServerUrl;
 
     /// <summary>
     /// Basic authentication password for Ollama server


### PR DESCRIPTION
## Summary
- add `OllamaDefaults.ServerUrl`
- use the constant in user settings, services and UI

## Testing
- `dotnet test --no-build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c37d7fcbc832a8027298359959157