### PR TITLE
Enable dialog mode selection

### DIFF
--- a/ChatClient.Api/ChatClient.Api.csproj
+++ b/ChatClient.Api/ChatClient.Api.csproj
@@ -11,6 +11,7 @@
         <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.6" />
         <PackageReference Include="Microsoft.Extensions.Http" Version="9.0.6" />
         <PackageReference Include="Microsoft.Extensions.AI" Version="9.6.0" />
+        <PackageReference Include="Microsoft.Extensions.AI.Agents" Version="9.6.0" />
         <PackageReference Include="Microsoft.SemanticKernel" Version="1.56.0" />
         <PackageReference Include="Microsoft.SemanticKernel.Abstractions" Version="1.56.0" />
         <PackageReference Include="Microsoft.SemanticKernel.Connectors.Ollama" Version="1.56.0-alpha" />

--- a/ChatClient.Api/Client/Pages/Chat.razor
+++ b/ChatClient.Api/Client/Pages/Chat.razor
@@ -433,7 +433,7 @@
             return;
 
         var modelName = selectedModel?.Name ?? "";
-        await ChatService.AddUserMessageAndAnswerAsync(messageData.text.Trim(), selectedFunctions, modelName, messageData.files);
+        await ChatService.AddUserMessageAndAnswerAsync(messageData.text.Trim(), selectedFunctions, modelName, messageData.files, DialogMode.Agent);
         await ScrollToBottom();
     }
 

--- a/ChatClient.Api/Client/Services/IChatService.cs
+++ b/ChatClient.Api/Client/Services/IChatService.cs
@@ -12,5 +12,10 @@ public interface IChatService
     void InitializeChat(SystemPrompt? initialPrompt);
     void ClearChat();
     Task CancelAsync();
-    Task AddUserMessageAndAnswerAsync(string text, IReadOnlyCollection<string> selectedFunctions, string modelName, IReadOnlyList<ChatMessageFile> files);
+    Task AddUserMessageAndAnswerAsync(
+        string text,
+        IReadOnlyCollection<string> selectedFunctions,
+        string modelName,
+        IReadOnlyList<ChatMessageFile> files,
+        DialogMode mode = DialogMode.Ask);
 }

--- a/ChatClient.Shared/Models/DialogMode.cs
+++ b/ChatClient.Shared/Models/DialogMode.cs
@@ -1,0 +1,7 @@
+namespace ChatClient.Shared.Models;
+
+public enum DialogMode
+{
+    Ask,
+    Agent
+}


### PR DESCRIPTION
## Summary
- add a `DialogMode` enum to switch between simple Q&A and agent-based chat
- accept `DialogMode` parameter in `AddUserMessageAndAnswerAsync`
- centralize response handling into a new `ProcessResponseAsync` method

## Testing
- `dotnet format --verify-no-changes` *(fails: command not found)*
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685101a0e978832a83f3b7964aadabea