### PR TITLE
Improve display of thoughts and MCP calls

### DIFF
--- a/ChatClient.Api/Client/Components/McpCallDisplay.razor
+++ b/ChatClient.Api/Client/Components/McpCallDisplay.razor
@@ -1,0 +1,41 @@
+@using Microsoft.AspNetCore.Components
+@using MudBlazor
+@using ChatClient.Shared.Models
+
+<div class="mcp-call @(isExpanded ? "expanded" : "collapsed")" @onclick="Toggle">
+    @if (isExpanded)
+    {
+        <MudText Typo="Typo.caption" Class="mud-text-secondary mcp-call-header">
+            <strong>@Call.Server</strong>@(string.IsNullOrEmpty(Call.Function) ? null : $".{Call.Function}")
+        </MudText>
+        @if (!string.IsNullOrEmpty(Call.Request))
+        {
+            <MudText Typo="Typo.caption" Class="mcp-call-label">Request:</MudText>
+            <pre class="mcp-call-pre">@Call.Request</pre>
+        }
+        @if (!string.IsNullOrEmpty(Call.Response))
+        {
+            <MudText Typo="Typo.caption" Class="mcp-call-label">Response:</MudText>
+            <pre class="mcp-call-pre">@Call.Response</pre>
+        }
+    }
+    else
+    {
+        <MudText Typo="Typo.caption" Class="mud-text-secondary" Style="font-style: italic;">
+            @CollapsedLine
+        </MudText>
+    }
+</div>
+
+@code {
+    [Parameter] public FunctionCallRecord Call { get; set; } = new("", "", "", "");
+
+    private bool isExpanded;
+
+    private void Toggle() => isExpanded = !isExpanded;
+
+    private string CollapsedLine =>
+        string.IsNullOrEmpty(Call.Function)
+            ? Call.Server
+            : $"{Call.Server}.{Call.Function}";
+}

--- a/ChatClient.Api/Client/Components/ThoughtDisplay.razor
+++ b/ChatClient.Api/Client/Components/ThoughtDisplay.razor
@@ -1,0 +1,29 @@
+@using Microsoft.AspNetCore.Components
+@using MudBlazor
+
+<div class="think-line @(isExpanded ? "expanded" : "collapsed")" @onclick="Toggle">
+    @if (isExpanded)
+    {
+        <MudText Typo="Typo.caption" Class="mud-text-secondary" Style="font-style: italic;">
+            @((MarkupString)HtmlText)
+        </MudText>
+    }
+    else
+    {
+        <MudText Typo="Typo.caption" Class="mud-text-secondary" Style="font-style: italic;">
+            @Truncate(PlainText, 100)
+        </MudText>
+    }
+</div>
+
+@code {
+    [Parameter] public string PlainText { get; set; } = string.Empty;
+    [Parameter] public string HtmlText { get; set; } = string.Empty;
+
+    private bool isExpanded;
+
+    private void Toggle() => isExpanded = !isExpanded;
+
+    private static string Truncate(string text, int length)
+        => text.Length <= length ? text : text.Substring(0, length) + "...";
+}

--- a/ChatClient.Api/Client/Pages/Chat.razor
+++ b/ChatClient.Api/Client/Pages/Chat.razor
@@ -141,38 +141,21 @@
                         @if (message.ThinkSegments.Any())
                         {
                             var validThoughts = message.ThinkSegments
-                                .Select((segment, index) => new { segment, index, htmlSegment = message.HtmlThinkSegments.ElementAt(index) })
+                                .Select((segment, index) => new { segment, html = message.HtmlThinkSegments.ElementAt(index) })
                                 .Where(x => !string.IsNullOrWhiteSpace(x.segment))
                                 .ToList();
-                            
-                            @foreach (var thoughtItem in validThoughts)
-                            {
-                                var segment = thoughtItem.htmlSegment;
-                                var thinkId = $"{message.Id}_{thoughtItem.index}";
-                                var isExpanded = ExpandedThoughts.Contains(thinkId);
 
-                                <MudChatBubble>
-                                    <div class="d-flex align-center justify-space-between">
-                                        <MudIconButton Icon="@(isExpanded ? Icons.Material.Filled.ExpandLess : Icons.Material.Filled.ExpandMore)"
-                                                       Size="Size.Small"
-                                                       OnClick="@(() => ToggleThinkExpansion(thinkId))" />
-                                    </div>
-                                    
-                                    <div class="@(isExpanded ? "think-content-expanded" : "think-content-collapsed")"
-                                         @onclick="@(() => ToggleThinkExpansion(thinkId))">
-                                        <MudText Typo="Typo.caption" Class="think-text">@((MarkupString)segment)</MudText>
-                                    </div>
-                                </MudChatBubble>
+                            foreach (var thought in validThoughts)
+                            {
+                                <ThoughtDisplay PlainText="@thought.segment" HtmlText="@thought.html" />
                             }
                         }
 
-                        @if (message.HtmlFunctionCalls.Any())
+                        @if (message.FunctionCalls.Any())
                         {
-                            foreach (var callSegment in message.HtmlFunctionCalls)
+                            foreach (var call in message.FunctionCalls)
                             {
-                                <MudChatBubble>
-                                    <MudText Typo="Typo.caption" Class="think-text">@((MarkupString)callSegment)</MudText>
-                                </MudChatBubble>
+                                <McpCallDisplay Call="@call" />
                             }
                         }
 
@@ -297,8 +280,6 @@
 
     private bool showPromptContent { get; set; } = false;
 
-    // Track expanded thoughts for individual segments
-    private HashSet<string> ExpandedThoughts { get; set; } = new();
 
     private UserSettings userSettings = new();
 
@@ -414,7 +395,6 @@
     private void RestartChat()
     {
         chatStarted = false;
-        ExpandedThoughts.Clear();
         ChatService.ClearChat();
         StateHasChanged();
     }
@@ -446,19 +426,6 @@
 
     private void Cancel()
     {        ChatService.CancelAsync();
-    }
-
-    private void ToggleThinkExpansion(string thinkId)
-    {
-        if (ExpandedThoughts.Contains(thinkId))
-        {
-            ExpandedThoughts.Remove(thinkId);
-        }
-        else
-        {
-            ExpandedThoughts.Add(thinkId);
-        }
-        StateHasChanged();
     }
 
     private void OnModelChanged(OllamaModel model)

--- a/ChatClient.Api/Client/ViewModels/ChatMessageViewModel.cs
+++ b/ChatClient.Api/Client/ViewModels/ChatMessageViewModel.cs
@@ -1,3 +1,7 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
 using ChatClient.Shared.Models;
 
 using DimonSmart.AiUtils;
@@ -5,9 +9,6 @@ using DimonSmart.AiUtils;
 using Markdig;
 
 using Microsoft.Extensions.AI;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 
 namespace ChatClient.Api.Client.ViewModels;
 
@@ -55,9 +56,20 @@ public class ChatMessageViewModel
             .Select(call =>
             {
                 var sb = new System.Text.StringBuilder();
-                if (!string.IsNullOrEmpty(call.Server))
+                if (!string.IsNullOrEmpty(call.Server) || !string.IsNullOrEmpty(call.Function))
                 {
-                    sb.AppendLine($"**{call.Server}**  ");
+                    sb.Append("**");
+                    if (!string.IsNullOrEmpty(call.Server))
+                    {
+                        sb.Append(call.Server);
+                    }
+                    if (!string.IsNullOrEmpty(call.Function))
+                    {
+                        if (!string.IsNullOrEmpty(call.Server))
+                            sb.Append('.');
+                        sb.Append(call.Function);
+                    }
+                    sb.AppendLine("**  ");
                 }
                 sb.AppendLine("**Request:**");
                 sb.AppendLine("```");

--- a/ChatClient.Api/wwwroot/css/chat.css
+++ b/ChatClient.Api/wwwroot/css/chat.css
@@ -119,3 +119,37 @@
     color: var(--mud-palette-text-secondary);
     margin: 0;
 }
+
+/* Compact thought and MCP call displays */
+.think-line,
+.mcp-call {
+    font-size: 0.75rem;
+    color: var(--mud-palette-text-secondary);
+    cursor: pointer;
+    font-style: italic;
+    margin: 0.25rem 0;
+}
+
+.think-line.collapsed,
+.mcp-call.collapsed {
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.mcp-call-pre {
+    background-color: var(--mud-palette-background-grey, #f5f5f5);
+    padding: 0.25rem;
+    border-radius: 4px;
+    font-size: 0.75rem;
+    white-space: pre-wrap;
+    overflow-x: auto;
+}
+.mcp-call-label {
+    font-size: 0.75rem;
+    font-style: italic;
+    margin-top: 0.25rem;
+}
+.mcp-call-header {
+    margin-bottom: 0.25rem;
+}

--- a/ChatClient.Shared/Models/FunctionCallRecord.cs
+++ b/ChatClient.Shared/Models/FunctionCallRecord.cs
@@ -1,3 +1,10 @@
 namespace ChatClient.Shared.Models;
 
-public record FunctionCallRecord(string Server, string Request, string Response);
+/// <summary>
+/// Represents a call to a function on an MCP server.
+/// </summary>
+/// <param name="Server">The server name.</param>
+/// <param name="Function">The function name.</param>
+/// <param name="Request">The request parameters as text.</param>
+/// <param name="Response">The response from the server.</param>
+public record FunctionCallRecord(string Server, string Function, string Request, string Response);


### PR DESCRIPTION
## Summary
- add compact `ThoughtDisplay` and `McpCallDisplay` components
- record function name in `FunctionCallRecord`
- show thoughts and MCP calls using the new components
- style compact views in `chat.css`

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_687ea20f1038832aa42526ed3cf10a79