### PR TITLE
Improve thought and MCP call layout

### DIFF
--- a/ChatClient.Api/Client/Components/McpCallDisplay.razor
+++ b/ChatClient.Api/Client/Components/McpCallDisplay.razor
@@ -2,7 +2,7 @@
 @using MudBlazor
 @using ChatClient.Shared.Models
 
-<div class="mcp-call @(isExpanded ? "expanded" : "collapsed")" @onclick="Toggle">
+<MudChatBubble Class="@($"mcp-call {(isExpanded ? "expanded" : "collapsed")}")" OnClick="Toggle">
     @if (isExpanded)
     {
         <MudText Typo="Typo.caption" Class="mud-text-secondary mcp-call-header">
@@ -25,7 +25,7 @@
             @CollapsedLine
         </MudText>
     }
-</div>
+</MudChatBubble>
 
 @code {
     [Parameter] public FunctionCallRecord Call { get; set; } = new("", "", "", "");

--- a/ChatClient.Api/Client/Components/ThoughtDisplay.razor
+++ b/ChatClient.Api/Client/Components/ThoughtDisplay.razor
@@ -1,7 +1,7 @@
 @using Microsoft.AspNetCore.Components
 @using MudBlazor
 
-<div class="think-line @(isExpanded ? "expanded" : "collapsed")" @onclick="Toggle">
+<MudChatBubble Class="@($"think-line {(isExpanded ? "expanded" : "collapsed")}")" OnClick="Toggle">
     @if (isExpanded)
     {
         <MudText Typo="Typo.caption" Class="mud-text-secondary" Style="font-style: italic;">
@@ -14,7 +14,7 @@
             @Truncate(PlainText, 100)
         </MudText>
     }
-</div>
+</MudChatBubble>
 
 @code {
     [Parameter] public string PlainText { get; set; } = string.Empty;

--- a/ChatClient.Api/wwwroot/css/chat.css
+++ b/ChatClient.Api/wwwroot/css/chat.css
@@ -121,6 +121,12 @@
 }
 
 /* Compact thought and MCP call displays */
+.mud-chat-bubble.think-line,
+.mud-chat-bubble.mcp-call {
+    padding: 0.25rem 0.5rem;
+    min-height: auto;
+}
+
 .think-line,
 .mcp-call {
     font-size: 0.75rem;


### PR DESCRIPTION
## Summary
- use `MudChatBubble` for thoughts and MCP call displays
- reduce bubble padding for these micro messages

## Testing
- `dotnet test OllamaChat.sln --no-build`


------
https://chatgpt.com/codex/tasks/task_e_687ea9a06498832aa5f47a598063e90c