### PR TITLE
Add unicode icons to collapsed blocks

### DIFF
--- a/ChatClient.Api/Client/Components/McpCallDisplay.razor
+++ b/ChatClient.Api/Client/Components/McpCallDisplay.razor
@@ -22,7 +22,7 @@
     else
     {
         <MudText Typo="Typo.caption" Class="mud-text-secondary" Style="font-style: italic;">
-            @CollapsedLine
+            @CallIcon @CollapsedLine
         </MudText>
     }
 </MudChatBubble>
@@ -31,6 +31,8 @@
     [Parameter] public FunctionCallRecord Call { get; set; } = new("", "", "", "");
 
     private bool isExpanded;
+
+    private const string CallIcon = "\uD83D\uDEE0"; // 🛠
 
     private void Toggle() => isExpanded = !isExpanded;
 

--- a/ChatClient.Api/Client/Components/ThoughtDisplay.razor
+++ b/ChatClient.Api/Client/Components/ThoughtDisplay.razor
@@ -11,7 +11,7 @@
     else
     {
         <MudText Typo="Typo.caption" Class="mud-text-secondary" Style="font-style: italic;">
-            @Truncate(PlainText, 100)
+            @ThoughtIcon @Truncate(PlainText, 100)
         </MudText>
     }
 </MudChatBubble>
@@ -21,6 +21,8 @@
     [Parameter] public string HtmlText { get; set; } = string.Empty;
 
     private bool isExpanded;
+
+    private const string ThoughtIcon = "\uD83D\uDCAD"; // 💭
 
     private void Toggle() => isExpanded = !isExpanded;
 


### PR DESCRIPTION
## Summary
- show a 💭 icon when a thought block is collapsed
- show a 🛠 icon when an MCP call block is collapsed

## Testing
- `dotnet test --no-build`
- `dotnet format --no-restore --include ChatClient.Api/Client/Components/McpCallDisplay.razor ChatClient.Api/Client/Components/ThoughtDisplay.razor`

------
https://chatgpt.com/codex/tasks/task_e_687f644b1c50832aa85516aa90184dab