### PR TITLE
Refactor chat history building

### DIFF
--- a/ChatClient.Api/Client/Pages/AppSettings.razor
+++ b/ChatClient.Api/Client/Pages/AppSettings.razor
@@ -65,6 +65,22 @@
 
                     <MudCard Class="mb-4" Elevation="1">
                         <MudCardHeader Class="pb-2">
+                            <MudText Class="section-header">Chat History Mode</MudText>
+                        </MudCardHeader>
+                        <MudCardContent Class="pt-0">
+                            <MudSelect T="ChatHistoryMode" Label="History Processing" @bind-Value="_settings.ChatHistoryMode" Variant="Variant.Outlined" Dense="true">
+                                <MudSelectItem Value="@ChatHistoryMode.None">None</MudSelectItem>
+                                <MudSelectItem Value="@ChatHistoryMode.Truncate">Truncate</MudSelectItem>
+                                <MudSelectItem Value="@ChatHistoryMode.Summarize">Summarize</MudSelectItem>
+                            </MudSelect>
+                            <MudText Typo="Typo.caption" Class="mt-2">
+                                Determines how message history is prepared before sending to the model.
+                            </MudText>
+                        </MudCardContent>
+                    </MudCard>
+
+                    <MudCard Class="mb-4" Elevation="1">
+                        <MudCardHeader Class="pb-2">
                             <MudText Class="section-header">Default Chat Message</MudText>
                         </MudCardHeader>
                         <MudCardContent Class="pt-0">

--- a/ChatClient.Api/Program.cs
+++ b/ChatClient.Api/Program.cs
@@ -35,6 +35,7 @@ builder.Services.AddSingleton<ChatClient.Api.Services.McpSamplingService>();
 builder.Services.AddSingleton<ChatClient.Api.Services.KernelService>();
 builder.Services.AddSingleton<ChatClient.Api.Services.OllamaService>();
 builder.Services.AddSingleton<ChatClient.Api.Services.AgentService>();
+builder.Services.AddSingleton<ChatClient.Api.Services.ChatHistoryBuilder>();
 builder.Services.AddScoped<ChatClient.Api.Services.StartupOllamaChecker>();
 builder.Services.AddSingleton<ChatClient.Shared.Services.ISystemPromptService, ChatClient.Api.Services.SystemPromptService>();
 builder.Services.AddSingleton<ChatClient.Shared.Services.IUserSettingsService, ChatClient.Api.Services.UserSettingsService>();

--- a/ChatClient.Api/Services/ChatHistoryBuilder.cs
+++ b/ChatClient.Api/Services/ChatHistoryBuilder.cs
@@ -1,0 +1,90 @@
+using ChatClient.Shared.Models;
+using ChatClient.Shared.Services;
+using DimonSmart.AiUtils;
+using Microsoft.Extensions.AI;
+using Microsoft.SemanticKernel;
+using Microsoft.SemanticKernel.ChatCompletion;
+
+namespace ChatClient.Api.Services;
+
+public class ChatHistoryBuilder(IUserSettingsService settingsService)
+{
+    public ChatHistory BuildBaseHistory(IEnumerable<IAppChatMessage> messages)
+    {
+        var history = new ChatHistory();
+        foreach (var msg in messages.Where(m => !m.IsStreaming))
+        {
+            var items = new ChatMessageContentItemCollection();
+            if (!string.IsNullOrEmpty(msg.Content))
+            {
+                var answer = ThinkTagParser.ExtractThinkAnswer(msg.Content).Answer;
+                items.Add(new Microsoft.SemanticKernel.TextContent(answer));
+            }
+            foreach (var file in msg.Files)
+            {
+                if (file.ContentType.StartsWith("image/", StringComparison.OrdinalIgnoreCase))
+                {
+                    items.Add(new ImageContent(new BinaryData(file.Data), file.ContentType));
+                }
+                else
+                {
+                    string fileDescription = $"File: {file.Name} ({file.ContentType})";
+                    items.Add(new Microsoft.SemanticKernel.TextContent(fileDescription));
+                }
+            }
+
+            AuthorRole role;
+            if (msg.Role == Microsoft.Extensions.AI.ChatRole.System)
+            {
+                role = AuthorRole.System;
+            }
+            else if (msg.Role == Microsoft.Extensions.AI.ChatRole.Assistant)
+            {
+                role = AuthorRole.Assistant;
+            }
+            else
+            {
+                role = AuthorRole.User;
+            }
+            history.Add(new ChatMessageContent(role, items));
+        }
+        return history;
+    }
+
+    public async Task<ChatHistory> BuildForChatAsync(IEnumerable<IAppChatMessage> messages, Kernel kernel, CancellationToken cancellationToken)
+    {
+        var history = BuildBaseHistory(messages);
+        return await ApplyHistoryModeAsync(history, kernel, cancellationToken);
+    }
+
+    public async Task<ChatHistory> BuildForAgentAsync(ChatHistory baseHistory, string instructions, Kernel kernel, CancellationToken cancellationToken)
+    {
+        var history = new ChatHistory();
+        if (!string.IsNullOrWhiteSpace(instructions))
+        {
+            history.AddSystemMessage(instructions);
+        }
+        foreach (var message in baseHistory.Where(m => m.Role != AuthorRole.System))
+        {
+            history.Add(message);
+        }
+        return await ApplyHistoryModeAsync(history, kernel, cancellationToken);
+    }
+
+    private async Task<ChatHistory> ApplyHistoryModeAsync(ChatHistory history, Kernel kernel, CancellationToken cancellationToken)
+    {
+        var settings = await settingsService.GetSettingsAsync();
+        var chatService = kernel.GetRequiredService<IChatCompletionService>();
+        switch (settings.ChatHistoryMode)
+        {
+            case ChatHistoryMode.Truncate:
+                var trunc = new ChatHistoryTruncationReducer(5, 8);
+                return new ChatHistory(await trunc.ReduceAsync(history, cancellationToken) ?? []);
+            case ChatHistoryMode.Summarize:
+                var sum = new ChatHistorySummarizationReducer(chatService, 5, 8);
+                return new ChatHistory(await sum.ReduceAsync(history, cancellationToken) ?? []);
+            default:
+                return history;
+        }
+    }
+}

--- a/ChatClient.Shared/Models/ChatHistoryMode.cs
+++ b/ChatClient.Shared/Models/ChatHistoryMode.cs
@@ -1,0 +1,8 @@
+namespace ChatClient.Shared.Models;
+
+public enum ChatHistoryMode
+{
+    None,
+    Truncate,
+    Summarize
+}

--- a/ChatClient.Shared/Models/UserSettings.cs
+++ b/ChatClient.Shared/Models/UserSettings.cs
@@ -50,4 +50,10 @@ public class UserSettings
     /// </summary>
     [JsonPropertyName("defaultUseAgentMode")]
     public bool DefaultUseAgentMode { get; set; } = false;
+
+    /// <summary>
+    /// Defines how chat history should be prepared before sending to the LLM
+    /// </summary>
+    [JsonPropertyName("chatHistoryMode")]
+    public ChatHistoryMode ChatHistoryMode { get; set; } = ChatHistoryMode.None;
 }


### PR DESCRIPTION
## Summary
- add `ChatHistoryMode` option and setting
- implement `ChatHistoryBuilder` service to centralize building and reducing chat history
- inject new builder into services and update `ChatService`
- expose history mode selector in app settings UI
- register new service in DI container

## Testing
- `dotnet build --no-restore`
- `dotnet test --no-build`

------
https://chatgpt.com/codex/tasks/task_e_687fb49de1c0832a86f19ba086990f33