### PR TITLE
Refactor chat history builder

### DIFF
--- a/ChatClient.Api/Program.cs
+++ b/ChatClient.Api/Program.cs
@@ -35,7 +35,7 @@ builder.Services.AddSingleton<ChatClient.Api.Services.McpSamplingService>();
 builder.Services.AddSingleton<ChatClient.Api.Services.KernelService>();
 builder.Services.AddSingleton<ChatClient.Api.Services.OllamaService>();
 builder.Services.AddSingleton<ChatClient.Api.Services.AgentService>();
-builder.Services.AddSingleton<ChatClient.Api.Services.ChatHistoryBuilder>();
+builder.Services.AddSingleton<ChatClient.Api.Services.IChatHistoryBuilder, ChatClient.Api.Services.ChatHistoryBuilder>();
 builder.Services.AddScoped<ChatClient.Api.Services.StartupOllamaChecker>();
 builder.Services.AddSingleton<ChatClient.Shared.Services.ISystemPromptService, ChatClient.Api.Services.SystemPromptService>();
 builder.Services.AddSingleton<ChatClient.Shared.Services.IUserSettingsService, ChatClient.Api.Services.UserSettingsService>();

--- a/ChatClient.Api/Services/AgentService.cs
+++ b/ChatClient.Api/Services/AgentService.cs
@@ -9,7 +9,7 @@ using Microsoft.SemanticKernel.ChatCompletion;
 
 namespace ChatClient.Api.Services;
 
-public class AgentService(KernelService kernelService, ChatHistoryBuilder historyBuilder)
+public class AgentService(KernelService kernelService)
 {
     public async Task<ChatCompletionAgent> CreateChatAgentAsync(ChatConfiguration chatConfiguration, string systemPrompt)
     {
@@ -44,12 +44,10 @@ public class AgentService(KernelService kernelService, ChatHistoryBuilder histor
                 : FunctionChoiceBehavior.None()
         };
 
-        // Build the complete chat history including the agent's instructions and apply history mode
-        var fullChatHistory = await historyBuilder.BuildForAgentAsync(chatHistory, agent.Instructions ?? string.Empty, agent.Kernel, cancellationToken);
-
+        // chatHistory already contains the agent instructions and has history mode applied
 
         await foreach (var content in chatService.GetStreamingChatMessageContentsAsync(
-            fullChatHistory,
+            chatHistory,
             executionSettings,
             agent.Kernel,
             cancellationToken: cancellationToken))

--- a/ChatClient.Api/Services/ChatHistoryBuilder.cs
+++ b/ChatClient.Api/Services/ChatHistoryBuilder.cs
@@ -7,7 +7,12 @@ using Microsoft.SemanticKernel.ChatCompletion;
 
 namespace ChatClient.Api.Services;
 
-public class ChatHistoryBuilder(IUserSettingsService settingsService)
+public interface IChatHistoryBuilder
+{
+    Task<ChatHistory> BuildChatHistoryAsync(IEnumerable<IAppChatMessage> messages, Kernel kernel, CancellationToken cancellationToken);
+}
+
+public class ChatHistoryBuilder(IUserSettingsService settingsService) : IChatHistoryBuilder
 {
     public ChatHistory BuildBaseHistory(IEnumerable<IAppChatMessage> messages)
     {
@@ -51,23 +56,9 @@ public class ChatHistoryBuilder(IUserSettingsService settingsService)
         return history;
     }
 
-    public async Task<ChatHistory> BuildForChatAsync(IEnumerable<IAppChatMessage> messages, Kernel kernel, CancellationToken cancellationToken)
+    public async Task<ChatHistory> BuildChatHistoryAsync(IEnumerable<IAppChatMessage> messages, Kernel kernel, CancellationToken cancellationToken)
     {
         var history = BuildBaseHistory(messages);
-        return await ApplyHistoryModeAsync(history, kernel, cancellationToken);
-    }
-
-    public async Task<ChatHistory> BuildForAgentAsync(ChatHistory baseHistory, string instructions, Kernel kernel, CancellationToken cancellationToken)
-    {
-        var history = new ChatHistory();
-        if (!string.IsNullOrWhiteSpace(instructions))
-        {
-            history.AddSystemMessage(instructions);
-        }
-        foreach (var message in baseHistory.Where(m => m.Role != AuthorRole.System))
-        {
-            history.Add(message);
-        }
         return await ApplyHistoryModeAsync(history, kernel, cancellationToken);
     }
 


### PR DESCRIPTION
## Summary
- add `IChatHistoryBuilder` interface
- unify history building into `BuildChatHistoryAsync`
- adjust `ChatService` to use new method for both chat and agent
- simplify `AgentService` and pass final history
- register the builder interface

## Testing
- `dotnet test --no-build`


------
https://chatgpt.com/codex/tasks/task_e_687ff8c8a6c8832a83bd4a01df043002