### PR TITLE
Add ability to delete chat messages

### DIFF
--- a/ChatClient.Api/Client/Pages/Chat.razor
+++ b/ChatClient.Api/Client/Pages/Chat.razor
@@ -89,7 +89,13 @@
                 @if (message.Role != Microsoft.Extensions.AI.ChatRole.System)
                 {
                     <MudChat Dense="true" ChatPosition="@(message.Role == Microsoft.Extensions.AI.ChatRole.Assistant ? ChatBubblePosition.Start : ChatBubblePosition.End)" @key="message.Id">
-                         <MudChatHeader Time="@message.MsgDateTime.ToString("g")" />
+                         <MudChatHeader>
+                             <time>@message.MsgDateTime.ToString("g")</time>
+                             @if (!isLLMAnswering)
+                             {
+                                 <span class="delete-button" title="Delete" @onclick="(() => DeleteMessage(message))">❌</span>
+                             }
+                         </MudChatHeader>
 
                         @{
                             var displayName = message.Role == Microsoft.Extensions.AI.ChatRole.Assistant 
@@ -304,6 +310,7 @@
         ChatService.LoadingStateChanged += OnLoadingStateChanged;
         ChatViewModelService.MessageAdded += async (msg) => await _messageAddedCallback.InvokeAsync(msg);
         ChatViewModelService.MessageUpdated += async (msg) => await _messageUpdatedCallback.InvokeAsync(msg);
+        ChatViewModelService.MessageDeleted += OnMessageDeleted;
 
         isLoadingInitialData = false;
         StateHasChanged();
@@ -321,6 +328,11 @@
         await ScrollToBottom();
     }    
     private void OnMessageUpdated(ChatMessageViewModel message)
+    {
+        StateHasChanged();
+    }
+
+    private void OnMessageDeleted(ChatMessageViewModel message)
     {
         StateHasChanged();
     }
@@ -432,13 +444,22 @@
     {
         selectedModel = model;
         Console.WriteLine($"Selected model changed to: {model.Name}");
-    }    
+    }
+
+    private async Task DeleteMessage(ChatMessageViewModel message)
+    {
+        if (isLLMAnswering)
+            return;
+
+        await ChatService.DeleteMessageAsync(message.Id);
+    }
 
     public ValueTask DisposeAsync()
     {
         ChatService.LoadingStateChanged -= OnLoadingStateChanged;
         ChatViewModelService.MessageAdded -= async (msg) => await InvokeAsync(() => OnMessageAdded(msg));
         ChatViewModelService.MessageUpdated -= (msg) => InvokeAsync(() => OnMessageUpdated(msg));
+        ChatViewModelService.MessageDeleted -= OnMessageDeleted;
         return ValueTask.CompletedTask;
     }
 

--- a/ChatClient.Api/Client/Services/ChatService.cs
+++ b/ChatClient.Api/Client/Services/ChatService.cs
@@ -28,6 +28,7 @@ public class ChatService(
     public event Action? ChatInitialized;
     public event Func<IAppChatMessage, Task>? MessageAdded;
     public event Func<IAppChatMessage, Task>? MessageUpdated;
+    public event Func<Guid, Task>? MessageDeleted;
 
     public bool IsLoading { get; private set; }
     public ObservableCollection<IAppChatMessage> Messages { get; } = [];
@@ -241,6 +242,19 @@ public class ChatService(
     {
         IsLoading = isLoading;
         LoadingStateChanged?.Invoke(isLoading);
+    }
+
+    public async Task DeleteMessageAsync(Guid id)
+    {
+        if (IsLoading)
+            return;
+
+        var message = Messages.FirstOrDefault(m => m.Id == id);
+        if (message == null)
+            return;
+
+        Messages.Remove(message);
+        await (MessageDeleted?.Invoke(id) ?? Task.CompletedTask);
     }
 }
 

--- a/ChatClient.Api/Client/Services/ChatViewModelService.cs
+++ b/ChatClient.Api/Client/Services/ChatViewModelService.cs
@@ -14,6 +14,7 @@ public class ChatViewModelService : IChatViewModelService
     public event Action? ChatInitialized;
     public event Action<ChatMessageViewModel>? MessageAdded;
     public event Func<ChatMessageViewModel, Task>? MessageUpdated;
+    public event Action<ChatMessageViewModel>? MessageDeleted;
 
     public bool IsLoading => _chatService.IsLoading;
 
@@ -24,6 +25,7 @@ public class ChatViewModelService : IChatViewModelService
         _chatService.ChatInitialized += OnChatInitialized;
         _chatService.MessageAdded += OnMessageAdded;
         _chatService.MessageUpdated += OnMessageUpdated;
+        _chatService.MessageDeleted += OnMessageDeleted;
     }
 
     private Task OnMessageAdded(IAppChatMessage domainMessage)
@@ -62,5 +64,16 @@ public class ChatViewModelService : IChatViewModelService
         existingMessage.UpdateFromDomainModel(domainMessage);
 
         await (MessageUpdated?.Invoke(existingMessage) ?? Task.CompletedTask);
+    }
+
+    private Task OnMessageDeleted(Guid id)
+    {
+        var message = _messages.FirstOrDefault(m => m.Id == id);
+        if (message != null)
+        {
+            _messages.Remove(message);
+            MessageDeleted?.Invoke(message);
+        }
+        return Task.CompletedTask;
     }
 }

--- a/ChatClient.Api/Client/Services/IChatService.cs
+++ b/ChatClient.Api/Client/Services/IChatService.cs
@@ -10,8 +10,10 @@ public interface IChatService
     event Action? ChatInitialized;
     event Func<IAppChatMessage, Task>? MessageAdded;
     event Func<IAppChatMessage, Task>? MessageUpdated;
+    event Func<Guid, Task>? MessageDeleted;
     void InitializeChat(SystemPrompt? initialPrompt);
     void ClearChat();
     Task CancelAsync();
     Task AddUserMessageAndAnswerAsync(string text, ChatConfiguration chatConfiguration, IReadOnlyList<ChatMessageFile> files);
+    Task DeleteMessageAsync(Guid id);
 }

--- a/ChatClient.Api/Client/Services/IChatViewModelService.cs
+++ b/ChatClient.Api/Client/Services/IChatViewModelService.cs
@@ -9,4 +9,5 @@ public interface IChatViewModelService
     event Action? ChatInitialized;
     event Action<ChatMessageViewModel>? MessageAdded;
     event Func<ChatMessageViewModel, Task>? MessageUpdated;
+    event Action<ChatMessageViewModel>? MessageDeleted;
 }

--- a/ChatClient.Api/wwwroot/css/chat.css
+++ b/ChatClient.Api/wwwroot/css/chat.css
@@ -79,6 +79,17 @@
     animation: blink 1.5s infinite;
 }
 
+/* Delete button style */
+.delete-button {
+    cursor: pointer;
+    margin-left: 0.25rem;
+    color: red;
+}
+.delete-button.disabled {
+    color: gray;
+    cursor: default;
+}
+
 @keyframes blink {
     0%, 50% {
         opacity: 1;


### PR DESCRIPTION
## Summary
- allow removing a message from the chat service
- propagate deletions to the view model service
- add delete events to chat services
- show a red ❌ button near the timestamp for deleting a message
- style delete button
- wire up deletion logic on the chat page

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_688012822d3c832a8f7a9ee25ec201e1