### PR TITLE
Use subtle trash icon for deleting chat messages

### DIFF
--- a/ChatClient.Api/Client/Pages/Chat.razor
+++ b/ChatClient.Api/Client/Pages/Chat.razor
@@ -93,7 +93,7 @@
                              <time>@message.MsgDateTime.ToString("g")</time>
                              @if (!isLLMAnswering)
                              {
-                                 <span class="delete-button" title="Delete" @onclick="(() => DeleteMessage(message))">❌</span>
+                                <span class="delete-button" title="Delete" @onclick="(() => DeleteMessage(message))">🗑</span>
                              }
                          </MudChatHeader>
 

--- a/ChatClient.Api/wwwroot/css/chat.css
+++ b/ChatClient.Api/wwwroot/css/chat.css
@@ -83,7 +83,7 @@
 .delete-button {
     cursor: pointer;
     margin-left: 0.25rem;
-    color: red;
+    color: var(--mud-palette-text-secondary);
 }
 .delete-button.disabled {
     color: gray;


### PR DESCRIPTION
## Summary
- swap the "❌" delete icon for a trash can symbol
- tone down delete button color using MudBlazor's secondary text color

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_6880185da620832abafde8926a5eb515