### PR TITLE
Add UI for auto-select defaults

### DIFF
--- a/ChatClient.Api/Client/Pages/AppSettings.razor
+++ b/ChatClient.Api/Client/Pages/AppSettings.razor
@@ -107,15 +107,28 @@
                         <MudCardHeader Class="pb-2">
                             <MudText Class="section-header">Default Chat Mode</MudText>
                         </MudCardHeader>
-                        <MudCardContent Class="pt-0">
-                            <MudCheckBox @bind-Value="_settings.DefaultUseAgentMode" 
-                                         Label="Agent Mode by Default" 
-                                         Color="Color.Primary" />
-                            <MudText Typo="Typo.caption" Class="mt-2">
-                                When enabled, new chats will start in Agent mode instead of Ask mode.
-                            </MudText>
-                        </MudCardContent>
-                    </MudCard>
+                    <MudCardContent Class="pt-0">
+                        <MudCheckBox @bind-Value="_settings.DefaultUseAgentMode"
+                                     Label="Agent Mode by Default"
+                                     Color="Color.Primary" />
+                        <MudText Typo="Typo.caption" Class="mt-2">
+                            When enabled, new chats will start in Agent mode instead of Ask mode.
+                        </MudText>
+                    </MudCardContent>
+                </MudCard>
+
+                <MudCard Class="mb-4" Elevation="1">
+                    <MudCardHeader Class="pb-2">
+                        <MudText Class="section-header">Function Auto-Selection</MudText>
+                    </MudCardHeader>
+                    <MudCardContent Class="pt-0">
+                        <MudNumericField T="int" @bind-Value="_settings.DefaultAutoSelectCount" Min="0" Max="10"
+                                         Variant="Variant.Outlined" Class="mt-2" Label="Auto-select Count" />
+                        <MudText Typo="Typo.caption" Class="mt-2">
+                            Number of functions to auto-select for new chats. Set to 0 to disable auto-selection.
+                        </MudText>
+                    </MudCardContent>
+                </MudCard>
 
                     <MudButtonGroup Class="mt-4">
                         <MudButton Variant="Variant.Filled" Color="Color.Primary" OnClick="SaveSettings" Size="Size.Medium">

--- a/ChatClient.Api/Client/Pages/Chat.razor
+++ b/ChatClient.Api/Client/Pages/Chat.razor
@@ -243,7 +243,11 @@
             <FunctionSelector AvailableFunctions="availableFunctions"
                               SelectedFunctions="selectedFunctions"
                               SelectedFunctionsChanged="OnSelectedFunctionsChanged"
-                              Expanded="@functionsExpanded" />
+                              Expanded="@functionsExpanded"
+                              AutoSelectFunctions="autoSelectFunctions"
+                              AutoSelectFunctionsChanged="@(v => autoSelectFunctions = v)"
+                              AutoSelectCount="autoSelectCount"
+                              AutoSelectCountChanged="@(v => autoSelectCount = v)" />
 
             <MudStack Direction="Direction.Column">
                 <ChatInput OnSend="SendChatMessageAsync" 
@@ -280,6 +284,8 @@
     private List<string> selectedFunctions = new();
     private bool functionsExpanded = false;
     private bool useAgentMode = false;
+    private bool autoSelectFunctions = false;
+    private int autoSelectCount = 3;
 
     private List<OllamaModel> availableModels = new();
     private OllamaModel? selectedModel;
@@ -354,8 +360,12 @@
 
     private async Task LoadUserSettings()
     {
-            userSettings = await UserSettingsService.GetSettingsAsync();
-            useAgentMode = userSettings.DefaultUseAgentMode;
+        userSettings = await UserSettingsService.GetSettingsAsync();
+        useAgentMode = userSettings.DefaultUseAgentMode;
+        autoSelectFunctions = userSettings.DefaultAutoSelectCount > 0;
+        autoSelectCount = userSettings.DefaultAutoSelectCount > 0
+            ? userSettings.DefaultAutoSelectCount
+            : 3;
     }
 
     private async Task LoadAvailableFunctions()
@@ -416,9 +426,11 @@
             return;
 
         var chatConfiguration = new ChatConfiguration(
-            selectedModel?.Name ?? string.Empty, 
+            selectedModel?.Name ?? string.Empty,
             selectedFunctions,
-            useAgentMode);
+            useAgentMode,
+            autoSelectFunctions,
+            autoSelectCount);
 
         await ChatService.AddUserMessageAndAnswerAsync(messageData.text.Trim(), chatConfiguration, messageData.files);
         await ScrollToBottom();

--- a/ChatClient.Api/Client/Pages/FunctionSelector.razor
+++ b/ChatClient.Api/Client/Pages/FunctionSelector.razor
@@ -4,14 +4,18 @@
 <MudCollapse Expanded="@Expanded" ExpandedChanged="@(v => ExpandedChanged.InvokeAsync(v))">
     <MudPaper Class="pa-4">
         <MudText Typo="Typo.subtitle1">Select Functions to use:</MudText>
-        <MudStack Spacing="1">
+        <MudCheckBox T="bool" @bind-Value="AutoSelectFunctions" Class="mt-2"
+                     Color="Color.Primary" Label="Auto-select relevant functions" />
+        <MudNumericField T="int" @bind-Value="AutoSelectCount" Class="mt-2" Min="1" Max="10"
+                         Disabled="!AutoSelectFunctions" Variant="Variant.Outlined" Label="Function count" />
+        <MudStack Spacing="1" Class="mt-2">
             @foreach (var fn in AvailableFunctions)
             {
                 <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="2">
                     <MudCheckBox T="Boolean"
                                  ValueChanged="@(async (bool v) => await OnFunctionToggled(fn.Name, v))"
                                  Value="@internalSelectedFunctions.Contains(fn.Name)"
-                                 Dense="true" />
+                                 Dense="true" Disabled="@AutoSelectFunctions" />
                     <div style="flex-grow:1">
                         <MudText Typo="Typo.body2" Class="mb-0">
                             <strong>@fn.Name</strong> - @fn.Description
@@ -32,6 +36,10 @@
     [Parameter] public EventCallback<List<string>> SelectedFunctionsChanged { get; set; }
     [Parameter] public bool Expanded { get; set; }
     [Parameter] public EventCallback<bool> ExpandedChanged { get; set; }
+    [Parameter] public bool AutoSelectFunctions { get; set; }
+    [Parameter] public EventCallback<bool> AutoSelectFunctionsChanged { get; set; }
+    [Parameter] public int AutoSelectCount { get; set; }
+    [Parameter] public EventCallback<int> AutoSelectCountChanged { get; set; }
 
     private HashSet<string> internalSelectedFunctions = new();
 

--- a/ChatClient.Api/Client/Services/StreamingMessageManager.cs
+++ b/ChatClient.Api/Client/Services/StreamingMessageManager.cs
@@ -1,5 +1,6 @@
-using ChatClient.Shared.Models;
 using System.Collections.Generic;
+
+using ChatClient.Shared.Models;
 
 using Microsoft.Extensions.AI;
 
@@ -67,7 +68,11 @@ public class StreamingMessageManager
         var statisticsBuilder = new System.Text.StringBuilder();
         statisticsBuilder.Append($"⏱️ {processingTime.TotalSeconds:F1}s");
         statisticsBuilder.Append($" • 🤖 {chatConfiguration.ModelName}");
-        if (chatConfiguration.Functions.Any())
+        if (chatConfiguration.AutoSelectFunctions && chatConfiguration.AutoSelectCount > 0)
+        {
+            statisticsBuilder.Append($" • 🔧 auto {chatConfiguration.AutoSelectCount}");
+        }
+        else if (chatConfiguration.Functions.Any())
         {
             statisticsBuilder.Append($" • 🔧 {chatConfiguration.Functions.Count} funcs");
         }

--- a/ChatClient.Shared/Models/ChatConfiguration.cs
+++ b/ChatClient.Shared/Models/ChatConfiguration.cs
@@ -1,3 +1,8 @@
 namespace ChatClient.Shared.Models;
 
-public record ChatConfiguration(string ModelName, IReadOnlyCollection<string> Functions, bool UseAgentMode);
+public record ChatConfiguration(
+    string ModelName,
+    IReadOnlyCollection<string> Functions,
+    bool UseAgentMode,
+    bool AutoSelectFunctions = false,
+    int AutoSelectCount = 0);

--- a/ChatClient.Shared/Models/UserSettings.cs
+++ b/ChatClient.Shared/Models/UserSettings.cs
@@ -52,6 +52,13 @@ public class UserSettings
     public bool DefaultUseAgentMode { get; set; } = false;
 
     /// <summary>
+    /// Number of functions to auto-select for new chats. Set to 0 to disable
+    /// auto-selection.
+    /// </summary>
+    [JsonPropertyName("defaultAutoSelectCount")]
+    public int DefaultAutoSelectCount { get; set; } = 0;
+
+    /// <summary>
     /// Defines how chat history should be prepared before sending to the LLM
     /// </summary>
     [JsonPropertyName("chatHistoryMode")]


### PR DESCRIPTION
## Summary
- simplify auto-select default setting: remove boolean and treat count=0 as disabled
- update application settings page to use numeric field only
- load auto-select defaults accordingly in chat

## Testing
- `dotnet restore`
- `dotnet build --no-restore`
- `dotnet test --no-build`


------
https://chatgpt.com/codex/tasks/task_e_6880c0a70458832a8c63ef908a764ea6