### PR TITLE
Move agent mode checkbox to top bar

### DIFF
--- a/ChatClient.Api/Client/Layout/MainLayout.razor
+++ b/ChatClient.Api/Client/Layout/MainLayout.razor
@@ -2,11 +2,13 @@
 @implements IAsyncDisposable
 @inject NavigationManager NavigationManager
 @inject IChatService ChatService
+@inject IUserSettingsService UserSettingsService
 
 <MudThemeProvider Theme="@_theme" IsDarkMode="_isDarkMode" />
 <MudDialogProvider />
 <MudSnackbarProvider />
 <MudPopoverProvider />
+<CascadingValue Value="@useAgentMode">
 <MudLayout>
     <MudAppBar Elevation="1" Dense="true">
         <MudIconButton Icon="@Icons.Material.Filled.Menu" Color="Color.Inherit" Edge="Edge.Start" OnClick="@((e) => DrawerToggle())" Size="Size.Medium" />
@@ -19,6 +21,12 @@
                        StartIcon="@Icons.Material.Filled.AddCircle"
                        Size="Size.Small"
                        Class="ml-4">New Chat</MudButton>
+            <MudCheckBox @bind-Value="useAgentMode"
+                         Label="Agent"
+                         Color="Color.Primary"
+                         Size="Size.Small"
+                         Dense="true"
+                         Class="ml-4" />
         }
         <MudSpacer />
         <MudIconButton Icon="@(DarkLightModeButtonIcon)" Color="Color.Inherit" OnClick="@DarkModeToggle" Size="Size.Medium" />
@@ -41,6 +49,7 @@
         </footer>
     }
 </MudLayout>
+</CascadingValue>
 
 <div id="blazor-error-ui" data-nosnippet>
     An unhandled error has occurred.
@@ -52,14 +61,18 @@
     private bool _drawerOpen = true;
     private bool _isDarkMode = true;
     private bool isLLMAnswering;
+    private bool useAgentMode = false;
     private MudTheme? _theme = null;
 
-    protected override void OnInitialized()
+    protected override async Task OnInitializedAsync()
     {
-        base.OnInitialized();
+        await base.OnInitializedAsync();
 
         ChatService.LoadingStateChanged += OnLoadingStateChanged;
         isLLMAnswering = ChatService.IsLoading;
+
+        var settings = await UserSettingsService.GetSettingsAsync();
+        useAgentMode = settings.DefaultUseAgentMode;
 
         _theme = new()
         {

--- a/ChatClient.Api/Client/Pages/Chat.razor
+++ b/ChatClient.Api/Client/Pages/Chat.razor
@@ -232,12 +232,6 @@
                            OnClick="@(() => functionsExpanded = !functionsExpanded)">
                     Functions
                 </MudButton>
-                <MudCheckBox @bind-Value="useAgentMode" 
-                             Label="Agent" 
-                             Color="Color.Primary"
-                             Size="Size.Small"
-                             Dense="true"
-                             Class="ml-2" />
             </MudStack>
           
             <FunctionSelector AvailableFunctions="availableFunctions"
@@ -272,9 +266,11 @@
     private List<FunctionInfo> availableFunctions = new();
     private List<string> selectedFunctions = new();
     private bool functionsExpanded = false;
-    private bool useAgentMode = false;
     private bool autoSelectFunctions = false;
     private int autoSelectCount = 3;
+
+    [CascadingParameter]
+    public bool UseAgentMode { get; set; }
 
     private List<OllamaModel> availableModels = new();
     private OllamaModel? selectedModel;
@@ -350,7 +346,6 @@
     private async Task LoadUserSettings()
     {
         userSettings = await UserSettingsService.GetSettingsAsync();
-        useAgentMode = userSettings.DefaultUseAgentMode;
         autoSelectFunctions = userSettings.DefaultAutoSelectCount > 0;
         autoSelectCount = userSettings.DefaultAutoSelectCount > 0
             ? userSettings.DefaultAutoSelectCount
@@ -411,7 +406,7 @@
         var chatConfiguration = new ChatConfiguration(
             selectedModel?.Name ?? string.Empty,
             selectedFunctions,
-            useAgentMode,
+            UseAgentMode,
             autoSelectFunctions,
             autoSelectCount);
 


### PR DESCRIPTION
## Summary
- place the agent mode checkbox in the app bar next to New Chat
- pass the checkbox value via CascadingValue so pages can access it
- use the cascading value in Chat page when sending messages

## Testing
- `dotnet build --nologo`
- `dotnet test --no-build --nologo`


------
https://chatgpt.com/codex/tasks/task_e_6880f324ebf0832a9dd4b913504c8e3e