### PR TITLE
Move function selector to top menu

### DIFF
--- a/ChatClient.Api/Client/Layout/MainLayout.razor
+++ b/ChatClient.Api/Client/Layout/MainLayout.razor
@@ -3,11 +3,20 @@
 @inject NavigationManager NavigationManager
 @inject IChatService ChatService
 @inject IUserSettingsService UserSettingsService
+@inject KernelService KernelService
+@inject IDialogService DialogService
+@using ChatClient.Shared.Models
+@using ChatClient.Api.Client.Pages
+@using System.Collections.Generic
+@using ChatClient.Api.Services
 
 <MudThemeProvider Theme="@_theme" IsDarkMode="_isDarkMode" />
 <MudDialogProvider />
 <MudSnackbarProvider />
 <MudPopoverProvider />
+<CascadingValue Value="@selectedFunctions">
+<CascadingValue Value="@autoSelectFunctions">
+<CascadingValue Value="@autoSelectCount">
 <CascadingValue Value="@useAgentMode">
 <MudLayout>
     <MudAppBar Elevation="1" Dense="true">
@@ -27,6 +36,11 @@
                          Size="Size.Small"
                          Dense="true"
                          Class="ml-4" />
+            <MudButton OnClick="OpenFunctionsDialog"
+                       Color="Color.Primary"
+                       Variant="Variant.Text"
+                       Size="Size.Small"
+                       Class="ml-4">Functions</MudButton>
         }
         <MudSpacer />
         <MudIconButton Icon="@(DarkLightModeButtonIcon)" Color="Color.Inherit" OnClick="@DarkModeToggle" Size="Size.Medium" />
@@ -50,6 +64,9 @@
     }
 </MudLayout>
 </CascadingValue>
+</CascadingValue>
+</CascadingValue>
+</CascadingValue>
 
 <div id="blazor-error-ui" data-nosnippet>
     An unhandled error has occurred.
@@ -62,6 +79,10 @@
     private bool _isDarkMode = true;
     private bool isLLMAnswering;
     private bool useAgentMode = false;
+    private List<FunctionInfo> availableFunctions = new();
+    private List<string> selectedFunctions = new();
+    private bool autoSelectFunctions = false;
+    private int autoSelectCount = 3;
     private MudTheme? _theme = null;
 
     protected override async Task OnInitializedAsync()
@@ -73,6 +94,20 @@
 
         var settings = await UserSettingsService.GetSettingsAsync();
         useAgentMode = settings.DefaultUseAgentMode;
+        autoSelectFunctions = settings.DefaultAutoSelectCount > 0;
+        autoSelectCount = settings.DefaultAutoSelectCount > 0
+            ? settings.DefaultAutoSelectCount
+            : 3;
+
+        try
+        {
+            availableFunctions = (await KernelService.GetAvailableFunctionsAsync()).ToList();
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine($"Error loading available functions: {ex}");
+            availableFunctions = new List<FunctionInfo>();
+        }
 
         _theme = new()
         {
@@ -108,6 +143,37 @@
     {
         ChatService.ClearChat();
         NavigationManager.NavigateTo("/chat", true);
+    }
+
+    private async Task OpenFunctionsDialog()
+    {
+        var parameters = new DialogParameters
+        {
+            ["AvailableFunctions"] = availableFunctions,
+            ["SelectedFunctions"] = selectedFunctions,
+            ["SelectedFunctionsChanged"] = EventCallback.Factory.Create<List<string>>(this, OnSelectedFunctionsChanged),
+            ["Expanded"] = true,
+            ["AutoSelectFunctions"] = autoSelectFunctions,
+            ["AutoSelectFunctionsChanged"] = EventCallback.Factory.Create<bool>(this, v => { autoSelectFunctions = v; StateHasChanged(); }),
+            ["AutoSelectCount"] = autoSelectCount,
+            ["AutoSelectCountChanged"] = EventCallback.Factory.Create<int>(this, v => { autoSelectCount = v; StateHasChanged(); })
+        };
+
+        var options = new DialogOptions
+        {
+            CloseButton = true,
+            MaxWidth = MaxWidth.Small,
+            FullWidth = true
+        };
+
+        await DialogService.ShowAsync<FunctionSelector>("Functions", parameters, options);
+    }
+
+    private Task OnSelectedFunctionsChanged(List<string> functions)
+    {
+        selectedFunctions = functions;
+        StateHasChanged();
+        return Task.CompletedTask;
     }
 
     private readonly PaletteLight _lightPalette = new()

--- a/ChatClient.Api/Client/Pages/Chat.razor
+++ b/ChatClient.Api/Client/Pages/Chat.razor
@@ -8,7 +8,6 @@
 @using System.Threading
 @using System.Text
 @using MudBlazor
-@using ChatClient.Api.Client.Pages
 @using ChatClient.Api.Client.Services
 @using ChatClient.Api.Client.Components
 @using ChatClient.Api.Client.ViewModels
@@ -226,22 +225,7 @@
                         </MudSelectItem>
                     }
                 </MudSelect>
-                <MudButton Variant="Variant.Text"
-                           Color="Color.Primary"
-                           Size="Size.Small"
-                           OnClick="@(() => functionsExpanded = !functionsExpanded)">
-                    Functions
-                </MudButton>
             </MudStack>
-          
-            <FunctionSelector AvailableFunctions="availableFunctions"
-                              SelectedFunctions="selectedFunctions"
-                              SelectedFunctionsChanged="OnSelectedFunctionsChanged"
-                              Expanded="@functionsExpanded"
-                              AutoSelectFunctions="autoSelectFunctions"
-                              AutoSelectFunctionsChanged="@(v => autoSelectFunctions = v)"
-                              AutoSelectCount="autoSelectCount"
-                              AutoSelectCountChanged="@(v => autoSelectCount = v)" />
 
             <MudStack Direction="Direction.Column">
                 <ChatInput OnSend="SendChatMessageAsync" 
@@ -263,11 +247,12 @@
 
     private List<SystemPrompt> systemPrompts = new();
     private SystemPrompt? selectedSystemPrompt;
-    private List<FunctionInfo> availableFunctions = new();
-    private List<string> selectedFunctions = new();
-    private bool functionsExpanded = false;
-    private bool autoSelectFunctions = false;
-    private int autoSelectCount = 3;
+    [CascadingParameter]
+    public List<string> SelectedFunctions { get; set; } = new();
+    [CascadingParameter]
+    public bool AutoSelectFunctions { get; set; }
+    [CascadingParameter]
+    public int AutoSelectCount { get; set; }
 
     [CascadingParameter]
     public bool UseAgentMode { get; set; }
@@ -294,7 +279,6 @@
         StateHasChanged();
 
         await LoadSystemPrompts();
-        await LoadAvailableFunctions();
         await LoadAvailableModels();
         await LoadUserSettings();
 
@@ -328,12 +312,6 @@
         StateHasChanged();
     }
 
-    private Task OnSelectedFunctionsChanged(List<string> functions)
-    {
-        selectedFunctions = functions;
-        StateHasChanged();
-        return Task.CompletedTask;
-    }
 
     private async Task LoadSystemPrompts()
     {
@@ -346,23 +324,10 @@
     private async Task LoadUserSettings()
     {
         userSettings = await UserSettingsService.GetSettingsAsync();
-        autoSelectFunctions = userSettings.DefaultAutoSelectCount > 0;
-        autoSelectCount = userSettings.DefaultAutoSelectCount > 0
+        AutoSelectFunctions = userSettings.DefaultAutoSelectCount > 0;
+        AutoSelectCount = userSettings.DefaultAutoSelectCount > 0
             ? userSettings.DefaultAutoSelectCount
             : 3;
-    }
-
-    private async Task LoadAvailableFunctions()
-    {
-        try
-        {
-            availableFunctions = (await KernelService.GetAvailableFunctionsAsync()).ToList();
-        }
-        catch (Exception ex)        
-        {
-            Console.WriteLine($"Error loading available functions: {ex}");
-            availableFunctions = new List<FunctionInfo>();
-        }
     }
 
     private async Task LoadAvailableModels()
@@ -405,10 +370,10 @@
 
         var chatConfiguration = new ChatConfiguration(
             selectedModel?.Name ?? string.Empty,
-            selectedFunctions,
+            SelectedFunctions,
             UseAgentMode,
-            autoSelectFunctions,
-            autoSelectCount);
+            AutoSelectFunctions,
+            AutoSelectCount);
 
         await ChatService.AddUserMessageAndAnswerAsync(messageData.text.Trim(), chatConfiguration, messageData.files);
         await ScrollToBottom();


### PR DESCRIPTION
## Summary
- update layout to manage function selection state
- show "Functions" button in the top app bar
- open function selector in a dialog from the menu
- expose selected function settings to chat via cascading parameters
- clean up old function selection code in Chat page

## Testing
- `dotnet build --no-restore`
- `dotnet test --no-build`


------
https://chatgpt.com/codex/tasks/task_e_6880f88f7218832ab79d5cd6c0dd73b3