### PR TITLE
Add hierarchical function grouping

### DIFF
--- a/ChatClient.Api/Client/Pages/FunctionSelector.razor
+++ b/ChatClient.Api/Client/Pages/FunctionSelector.razor
@@ -8,22 +8,34 @@
                      Color="Color.Primary" Label="Auto-select relevant functions" />
         <MudNumericField T="int" @bind-Value="AutoSelectCount" Class="mt-2" Min="1" Max="10"
                          Disabled="!AutoSelectFunctions" Variant="Variant.Outlined" Label="Function count" />
-        <MudStack Spacing="1" Class="mt-2">
-            @foreach (var fn in AvailableFunctions)
+        <MudExpansionPanels Class="mt-2">
+            @foreach (var group in AvailableFunctions.GroupBy(f => f.ServerName))
             {
-                <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="2">
-                    <MudCheckBox T="Boolean"
-                                 ValueChanged="@(async (bool v) => await OnFunctionToggled(fn.Name, v))"
-                                 Value="@internalSelectedFunctions.Contains(fn.Name)"
-                                 Dense="true" Disabled="@AutoSelectFunctions" />
-                    <div style="flex-grow:1">
-                        <MudText Typo="Typo.body2" Class="mb-0">
-                            <strong>@fn.Name</strong> - @fn.Description
-                        </MudText>
-                    </div>
-                </MudStack>
+                <MudExpansionPanel Text="@group.Key">
+                    <MudStack Spacing="1">
+                        <MudCheckBox T="bool" Label="Select All"
+                                     ValueChanged="@(async (bool v) => await OnServerToggled(group.Key, v))"
+                                     Value="@serverSelections.GetValueOrDefault(group.Key)"
+                                     Dense="true" Disabled="@AutoSelectFunctions" />
+
+                        @foreach (var fn in group)
+                        {
+                            <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="2" Class="ml-4">
+                                <MudCheckBox T="bool"
+                                             ValueChanged="@(async (bool v) => await OnFunctionToggled(fn, v))"
+                                             Value="@internalSelectedFunctions.Contains(fn.Name)"
+                                             Dense="true" Disabled="@AutoSelectFunctions" />
+                                <div style="flex-grow:1">
+                                    <MudText Typo="Typo.body2" Class="mb-0">
+                                        <strong>@fn.DisplayName</strong> - @fn.Description
+                                    </MudText>
+                                </div>
+                            </MudStack>
+                        }
+                    </MudStack>
+                </MudExpansionPanel>
             }
-        </MudStack>
+        </MudExpansionPanels>
         <MudText Typo="Typo.caption" Color="Color.Secondary">
             It is not recommended to select more than 5 functions.
         </MudText>
@@ -42,23 +54,48 @@
     [Parameter] public EventCallback<int> AutoSelectCountChanged { get; set; }
 
     private HashSet<string> internalSelectedFunctions = new();
+    private Dictionary<string, bool> serverSelections = new();
 
     protected override void OnParametersSet()
     {
         internalSelectedFunctions = new HashSet<string>(SelectedFunctions);
+        serverSelections = AvailableFunctions
+            .GroupBy(f => f.ServerName)
+            .ToDictionary(g => g.Key, g => g.All(f => internalSelectedFunctions.Contains(f.Name)));
     }
 
-    private async Task OnFunctionToggled(string name, bool isChecked)
+    private async Task OnServerToggled(string serverName, bool isChecked)
     {
+        var serverFunctions = AvailableFunctions.Where(f => f.ServerName == serverName).Select(f => f.Name);
         if (isChecked)
         {
-            if (!internalSelectedFunctions.Contains(name))
-                internalSelectedFunctions.Add(name);
+            foreach (var fn in serverFunctions)
+                internalSelectedFunctions.Add(fn);
         }
         else
         {
-            internalSelectedFunctions.Remove(name);
+            foreach (var fn in serverFunctions)
+                internalSelectedFunctions.Remove(fn);
         }
+        serverSelections[serverName] = isChecked;
+        await SelectedFunctionsChanged.InvokeAsync(internalSelectedFunctions.ToList());
+    }
+
+    private async Task OnFunctionToggled(FunctionInfo fn, bool isChecked)
+    {
+        if (isChecked)
+        {
+            if (!internalSelectedFunctions.Contains(fn.Name))
+                internalSelectedFunctions.Add(fn.Name);
+        }
+        else
+        {
+            internalSelectedFunctions.Remove(fn.Name);
+        }
+
+        serverSelections[fn.ServerName] = AvailableFunctions
+            .Where(f => f.ServerName == fn.ServerName)
+            .All(f => internalSelectedFunctions.Contains(f.Name));
 
         await SelectedFunctionsChanged.InvokeAsync(internalSelectedFunctions.ToList());
     }

--- a/ChatClient.Api/Services/KernelService.cs
+++ b/ChatClient.Api/Services/KernelService.cs
@@ -107,7 +107,9 @@ public class KernelService(
                     continue;
                 }
 
-                var toolsToRegister = mcpTools.Where(t => functionNames.Contains(t.Name)).ToList();
+                var toolsToRegister = mcpTools
+                    .Where(t => functionNames.Contains($"{mcpClient.ServerInfo.Name}:{t.Name}"))
+                    .ToList();
                 if (toolsToRegister.Count == 0)
                 {
                     logger.LogWarning($"No MCP tools matched the requested function names. In mcp server: {mcpClient.ServerInfo.Name}");
@@ -149,7 +151,9 @@ public class KernelService(
                 var toolFuncs = mcpTools.Select(tool =>
                     new FunctionInfo
                     {
-                        Name = tool.Name,
+                        Name = $"{mcpClient.ServerInfo.Name}:{tool.Name}",
+                        ServerName = mcpClient.ServerInfo.Name ?? string.Empty,
+                        DisplayName = tool.Name,
                         Description = tool.Description
                     });
                 functions.AddRange(toolFuncs);

--- a/ChatClient.Api/Services/McpFunctionIndexService.cs
+++ b/ChatClient.Api/Services/McpFunctionIndexService.cs
@@ -70,7 +70,7 @@ public class McpFunctionIndexService
         await BuildIndexAsync(cancellationToken);
         var queryEmbedding = await _ollamaService.GenerateEmbeddingAsync(query, _modelId, cancellationToken);
         return _index
-            .Select(kvp => new { Name = kvp.Key.Split(':').Last(), Score = Dot(queryEmbedding.AsSpan(), kvp.Value) })
+            .Select(kvp => new { Name = kvp.Key, Score = Dot(queryEmbedding.AsSpan(), kvp.Value) })
             .OrderByDescending(e => e.Score)
             .Take(topK)
             .Select(e => e.Name)

--- a/ChatClient.Shared/Models/FunctionInfo.cs
+++ b/ChatClient.Shared/Models/FunctionInfo.cs
@@ -2,6 +2,21 @@ namespace ChatClient.Shared.Models;
 
 public class FunctionInfo
 {
+    /// <summary>
+    /// Unique name of the function used internally. Formatted as
+    /// "ServerName:FunctionName" to avoid collisions between servers.
+    /// </summary>
     public string Name { get; set; } = string.Empty;
+
+    /// <summary>
+    /// The MCP server providing this function.
+    /// </summary>
+    public string ServerName { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Name of the function as provided by the server.
+    /// </summary>
+    public string DisplayName { get; set; } = string.Empty;
+
     public string Description { get; set; } = string.Empty;
 }

--- a/ChatClient.Tests/McpFunctionIndexServiceRealOllamaTests.cs
+++ b/ChatClient.Tests/McpFunctionIndexServiceRealOllamaTests.cs
@@ -61,7 +61,7 @@ public class McpFunctionIndexServiceRealOllamaTests
         var result = await indexService.SelectRelevantFunctionsAsync("How does a transistor work?", 2);
 
         Assert.Equal(2, result.Count);
-        Assert.Contains("TransTool1", result);
-        Assert.Contains("TransTool2", result);
+        Assert.Contains("srv:TransTool1", result);
+        Assert.Contains("srv:TransTool2", result);
     }
 }


### PR DESCRIPTION
## Summary
- extend `FunctionInfo` to include server info and display name
- namespace functions by server when retrieving available functions
- ensure MCP function registration matches new qualified names
- update function index service to return qualified names
- show functions grouped by server with select-all options
- adjust tests for new function naming

## Testing
- `dotnet build OllamaChat.sln`
- `dotnet test OllamaChat.sln`


------
https://chatgpt.com/codex/tasks/task_e_6881208491bc832aa49dfd91837653d3