### PR TITLE
Fix function dialog settings persistence

### DIFF
--- a/ChatClient.Api/Client/Pages/FunctionSelector.razor
+++ b/ChatClient.Api/Client/Pages/FunctionSelector.razor
@@ -7,7 +7,8 @@
         <MudCheckBox T="bool" @bind-Value="AutoSelectFunctions" Class="mt-2"
                      Color="Color.Primary" Label="Auto-select relevant functions" />
         <MudNumericField T="int" @bind-Value="AutoSelectCount" Class="mt-2" Min="1" Max="10"
-                         Disabled="!AutoSelectFunctions" Variant="Variant.Outlined" Label="Function count" />
+                         Disabled="!AutoSelectFunctions" Variant="Variant.Outlined" Label="Function count"
+                         Immediate="true" />
         <MudExpansionPanels Class="mt-2">
             @foreach (var group in AvailableFunctions.GroupBy(f => f.ServerName))
             {


### PR DESCRIPTION
## Summary
- ensure auto-select function count updates even if dialog closes immediately

## Testing
- `dotnet test ChatClient.Tests/ChatClient.Tests.csproj --logger "console;verbosity=normal"`

------
https://chatgpt.com/codex/tasks/task_e_688149bff738832a84ba712769c46185