### PR TITLE
Fix function selector state not persisting

### DIFF
--- a/ChatClient.Api/Client/Layout/MainLayout.razor
+++ b/ChatClient.Api/Client/Layout/MainLayout.razor
@@ -154,9 +154,17 @@
             ["SelectedFunctionsChanged"] = EventCallback.Factory.Create<List<string>>(this, OnSelectedFunctionsChanged),
             ["Expanded"] = true,
             ["AutoSelectFunctions"] = autoSelectFunctions,
-            ["AutoSelectFunctionsChanged"] = EventCallback.Factory.Create<bool>(this, v => { autoSelectFunctions = v; StateHasChanged(); }),
+            ["AutoSelectFunctionsChanged"] = EventCallback.Factory.Create<bool>(this, async v =>
+            {
+                autoSelectFunctions = v;
+                await InvokeAsync(StateHasChanged);
+            }),
             ["AutoSelectCount"] = autoSelectCount,
-            ["AutoSelectCountChanged"] = EventCallback.Factory.Create<int>(this, v => { autoSelectCount = v; StateHasChanged(); })
+            ["AutoSelectCountChanged"] = EventCallback.Factory.Create<int>(this, async v =>
+            {
+                autoSelectCount = v;
+                await InvokeAsync(StateHasChanged);
+            })
         };
 
         var options = new DialogOptions

--- a/ChatClient.Api/Client/Pages/FunctionSelector.razor
+++ b/ChatClient.Api/Client/Pages/FunctionSelector.razor
@@ -104,12 +104,14 @@
     private async Task OnAutoSelectFunctionsChanged(bool value)
     {
         AutoSelectFunctions = value;
+        StateHasChanged();
         await AutoSelectFunctionsChanged.InvokeAsync(value);
     }
 
     private async Task OnAutoSelectCountChanged(int value)
     {
         AutoSelectCount = value;
+        StateHasChanged();
         await AutoSelectCountChanged.InvokeAsync(value);
     }
 }


### PR DESCRIPTION
## Summary
- adjust callbacks to update layout state on UI thread
- force UI refresh when auto-select options change

## Testing
- `dotnet test --no-build --verbosity minimal`
- `dotnet build`

------
https://chatgpt.com/codex/tasks/task_e_6883ee569c38832a9fde05c07c75eb32