### PR TITLE
Move model selector to top menu

### DIFF
--- a/ChatClient.Api/Client/Layout/MainLayout.razor
+++ b/ChatClient.Api/Client/Layout/MainLayout.razor
@@ -5,6 +5,7 @@
 @inject IUserSettingsService UserSettingsService
 @inject KernelService KernelService
 @inject IDialogService DialogService
+@inject IOllamaClientService OllamaService
 @using ChatClient.Shared.Models
 @using ChatClient.Api.Client.Pages
 @using System.Collections.Generic
@@ -18,6 +19,7 @@
 <CascadingValue Value="@autoSelectFunctions">
 <CascadingValue Value="@autoSelectCount">
 <CascadingValue Value="@useAgentMode">
+<CascadingValue Value="@selectedModel">
 <MudLayout>
     <MudAppBar Elevation="1" Dense="true">
         <MudIconButton Icon="@Icons.Material.Filled.Menu" Color="Color.Inherit" Edge="Edge.Start" OnClick="@((e) => DrawerToggle())" Size="Size.Medium" />
@@ -30,17 +32,49 @@
                        StartIcon="@Icons.Material.Filled.AddCircle"
                        Size="Size.Small"
                        Class="ml-4">New Chat</MudButton>
-            <MudCheckBox @bind-Value="useAgentMode"
+           <MudCheckBox @bind-Value="useAgentMode"
                          Label="Agent"
                          Color="Color.Primary"
                          Size="Size.Small"
                          Dense="true"
                          Class="ml-4" />
-            <MudButton OnClick="OpenFunctionsDialog"
-                       Color="Color.Primary"
-                       Variant="Variant.Text"
-                       Size="Size.Small"
-                       Class="ml-4">Functions</MudButton>
+           <MudButton OnClick="OpenFunctionsDialog"
+                      Color="Color.Primary"
+                      Variant="Variant.Text"
+                      Size="Size.Small"
+                      Class="ml-4">Functions</MudButton>
+            <MudSelect T="OllamaModel"
+                       Value="selectedModel"
+                       ValueChanged="OnModelChanged"
+                       Label="Model"
+                       Variant="Variant.Filled"
+                       Dense="true"
+                       Margin="Margin.Dense"
+                       Class="ml-4"
+                       Style="min-width: 150px;">
+                @foreach (var model in availableModels)
+                {
+                    <MudSelectItem Value="@model">
+                        <span>@model.Name</span>
+                        @if (model.SupportsImages)
+                        {
+                            <MudIcon Icon="@Icons.Material.Filled.Image"
+                                     Size="Size.Small"
+                                     Class="ml-1"
+                                     title="Supports images"
+                                     Style="color: #4caf50;" />
+                        }
+                        @if (model.SupportsFunctionCalling)
+                        {
+                            <MudIcon Icon="@Icons.Material.Filled.Settings"
+                                     Size="Size.Small"
+                                     Class="ml-1"
+                                     title="Function calling support detected (may not be accurate)"
+                                     Style="color: #2196f3;" />
+                        }
+                    </MudSelectItem>
+                }
+            </MudSelect>
         }
         <MudSpacer />
         <MudIconButton Icon="@(DarkLightModeButtonIcon)" Color="Color.Inherit" OnClick="@DarkModeToggle" Size="Size.Medium" />
@@ -67,6 +101,7 @@
 </CascadingValue>
 </CascadingValue>
 </CascadingValue>
+</CascadingValue>
 
 <div id="blazor-error-ui" data-nosnippet>
     An unhandled error has occurred.
@@ -83,6 +118,8 @@
     private List<string> selectedFunctions = new();
     private bool autoSelectFunctions = false;
     private int autoSelectCount = 3;
+    private List<OllamaModel> availableModels = new();
+    private OllamaModel? selectedModel;
     private MudTheme? _theme = null;
 
     protected override async Task OnInitializedAsync()
@@ -107,6 +144,25 @@
         {
             Console.WriteLine($"Error loading available functions: {ex}");
             availableFunctions = new List<FunctionInfo>();
+        }
+
+        try
+        {
+            availableModels = (await OllamaService.GetModelsAsync()).ToList();
+            if (!string.IsNullOrWhiteSpace(settings.DefaultModelName) &&
+                availableModels.Any(m => m.Name == settings.DefaultModelName))
+            {
+                selectedModel = availableModels.FirstOrDefault(m => m.Name == settings.DefaultModelName);
+            }
+            else
+            {
+                selectedModel = availableModels.FirstOrDefault();
+            }
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine($"Error loading available models: {ex}");
+            availableModels = new List<OllamaModel>();
         }
 
         _theme = new()
@@ -172,6 +228,12 @@
         selectedFunctions = functions;
         StateHasChanged();
         return Task.CompletedTask;
+    }
+
+    private void OnModelChanged(OllamaModel model)
+    {
+        selectedModel = model;
+        StateHasChanged();
     }
 
     private readonly PaletteLight _lightPalette = new()

--- a/ChatClient.Api/Client/Pages/Chat.razor
+++ b/ChatClient.Api/Client/Pages/Chat.razor
@@ -22,7 +22,6 @@
 @inject IChatService ChatService
 @inject ISystemPromptService PromptService
 @inject IUserSettingsService UserSettingsService
-@inject IOllamaClientService OllamaService
 
 <PageTitle>Chat with AI Assistant</PageTitle>
 
@@ -193,43 +192,9 @@
         
         <!-- Fixed input panel at bottom -->
         <div class="chat-input-panel">
-            <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="1">
-                <MudSelect T="OllamaModel"
-                           Value="selectedModel"
-                           ValueChanged="OnModelChanged"
-                           Label="Model"
-                           Variant="Variant.Filled"
-                           Dense="true"
-                           Margin="Margin.Dense">
-                    @foreach (var model in availableModels)
-                    {
-                        <MudSelectItem Value="@model">
-                                <span>@model.Name</span>
-                                @if (model.SupportsImages)
-                                {
-                                    <MudIcon Icon="@Icons.Material.Filled.Image" 
-                                             Size="Size.Small" 
-                                             Class="ml-1" 
-                                             title="Supports images"
-                                             Style="color: #4caf50;" />
-                                }
-                                
-                                @if (model.SupportsFunctionCalling)
-                                {
-                                    <MudIcon Icon="@Icons.Material.Filled.Settings" 
-                                             Size="Size.Small" 
-                                             Class="ml-1" 
-                                             title="Function calling support detected (may not be accurate)"
-                                             Style="color: #2196f3;" />
-                                }
-                        </MudSelectItem>
-                    }
-                </MudSelect>
-            </MudStack>
-
             <MudStack Direction="Direction.Column">
-                <ChatInput OnSend="SendChatMessageAsync" 
-                          ShowStopButton="isLLMAnswering" 
+                <ChatInput OnSend="SendChatMessageAsync"
+                          ShowStopButton="isLLMAnswering"
                           OnStopClick="Cancel" />
             </MudStack>
         </div>
@@ -254,9 +219,8 @@
 
     [CascadingParameter]
     public bool UseAgentMode { get; set; }
-
-    private List<OllamaModel> availableModels = new();
-    private OllamaModel? selectedModel;
+    [CascadingParameter]
+    public OllamaModel? SelectedModel { get; set; }
 
     private bool showPromptContent { get; set; } = false;
 
@@ -277,7 +241,6 @@
         StateHasChanged();
 
         await LoadSystemPrompts();
-        await LoadAvailableModels();
         await LoadUserSettings();
 
         ChatService.LoadingStateChanged += OnLoadingStateChanged;
@@ -328,29 +291,6 @@
             : 3;
     }
 
-    private async Task LoadAvailableModels()
-    {
-        try
-        {
-            availableModels = (await OllamaService.GetModelsAsync()).ToList();
-            // Get user settings to find default model
-            var settings = await UserSettingsService.GetSettingsAsync();
-            if (!string.IsNullOrWhiteSpace(settings.DefaultModelName) && 
-                availableModels.Any(m => m.Name == settings.DefaultModelName))
-            {
-                selectedModel = availableModels.FirstOrDefault(m => m.Name == settings.DefaultModelName);
-            }
-            else
-            {
-                selectedModel = availableModels.FirstOrDefault();
-            }
-        }
-        catch (Exception ex)
-        {
-            Console.WriteLine($"Error loading available models: {ex}");
-            availableModels = new List<OllamaModel>();
-        }
-    }
 
     private void StartChat()
     {
@@ -367,7 +307,7 @@
             return;
 
         var chatConfiguration = new ChatConfiguration(
-            selectedModel?.Name ?? string.Empty,
+            SelectedModel?.Name ?? string.Empty,
             SelectedFunctions,
             UseAgentMode,
             AutoSelectFunctions,
@@ -391,12 +331,6 @@
 
     private void Cancel()
     {        ChatService.CancelAsync();
-    }
-
-    private void OnModelChanged(OllamaModel model)
-    {
-        selectedModel = model;
-        Console.WriteLine($"Selected model changed to: {model.Name}");
     }
 
     private async Task DeleteMessage(ChatMessageViewModel message)


### PR DESCRIPTION
## Summary
- move model selection dropdown from chat input area to the application bar
- expose selected model as a cascading parameter
- load models in `MainLayout` and share the chosen model with pages

## Testing
- `dotnet build -v minimal`
- `dotnet test -v minimal`


------
https://chatgpt.com/codex/tasks/task_e_688683c53f0c832ab101d56da4c34867