### PR TITLE
Fix function call background color

### DIFF
--- a/ChatClient.Api/wwwroot/css/chat.css
+++ b/ChatClient.Api/wwwroot/css/chat.css
@@ -155,7 +155,7 @@
 }
 
 .mcp-call-pre {
-    background-color: var(--mud-palette-background-grey, #f5f5f5);
+    background-color: var(--mud-palette-background-gray, #f5f5f5);
     padding: 0.25rem;
     border-radius: 4px;
     font-size: 0.75rem;


### PR DESCRIPTION
## Summary
- ensure MCP call code blocks use theme-aware variable

## Testing
- `dotnet test --verbosity minimal`

------
https://chatgpt.com/codex/tasks/task_e_68874da4e6bc832a89cef42f5cc6a4a7