### PR TITLE
Fix truncation reducer usage

### DIFF
--- a/ChatClient.Api/Services/ChatHistoryBuilder.cs
+++ b/ChatClient.Api/Services/ChatHistoryBuilder.cs
@@ -71,10 +71,12 @@ public class ChatHistoryBuilder(IUserSettingsService settingsService) : IChatHis
         {
             case ChatHistoryMode.Truncate:
                 var trunc = new ChatHistoryTruncationReducer(5, 8);
-                return new ChatHistory(await trunc.ReduceAsync(history, cancellationToken) ?? []);
+                var truncated = await trunc.ReduceAsync(history, cancellationToken);
+                return truncated is not null ? new ChatHistory(truncated) : history;
             case ChatHistoryMode.Summarize:
                 var sum = new ChatHistorySummarizationReducer(chatService, 5, 8);
-                return new ChatHistory(await sum.ReduceAsync(history, cancellationToken) ?? []);
+                var summarized = await sum.ReduceAsync(history, cancellationToken);
+                return summarized is not null ? new ChatHistory(summarized) : history;
             default:
                 return history;
         }

--- a/ChatClient.Tests/ChatHistoryTruncationReducerTests.cs
+++ b/ChatClient.Tests/ChatHistoryTruncationReducerTests.cs
@@ -1,0 +1,20 @@
+using Microsoft.SemanticKernel.ChatCompletion;
+
+namespace ChatClient.Tests;
+
+public class ChatHistoryTruncationReducerTests
+{
+    [Fact]
+    public async Task ReduceAsync_ShortHistory_ReturnsNull()
+    {
+        var reducer = new ChatHistoryTruncationReducer(5, 8);
+        var history = new ChatHistory();
+        history.AddSystemMessage("sys");
+        history.AddUserMessage("hi");
+        history.AddAssistantMessage("hello");
+
+        var result = await reducer.ReduceAsync(history);
+
+        Assert.Null(result);
+    }
+}


### PR DESCRIPTION
## Summary
- handle `null` results from `ChatHistoryTruncationReducer`
- add unit test verifying reducer behavior

## Testing
- `dotnet test --no-build --verbosity minimal`

------
https://chatgpt.com/codex/tasks/task_e_6888e16d220c832ab79b63ab26bac202