### PR TITLE
Add math rendering support

### DIFF
--- a/ChatClient.Api/Client/ViewModels/ChatMessageViewModel.cs
+++ b/ChatClient.Api/Client/ViewModels/ChatMessageViewModel.cs
@@ -30,6 +30,7 @@ public class ChatMessageViewModel
 
     private static readonly MarkdownPipeline Pipeline = new MarkdownPipelineBuilder()
         .UseAdvancedExtensions()
+        .UseMathematics()
         .Build();
     private ChatMessageViewModel Populate(IAppChatMessage message)
     {

--- a/ChatClient.Api/wwwroot/index.html
+++ b/ChatClient.Api/wwwroot/index.html
@@ -32,6 +32,7 @@
 
     <script src="_framework/blazor.webassembly.js"></script>
     <script src="_content/MudBlazor/MudBlazor.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 
     <script>
         window.scrollToBottom = function (element) {


### PR DESCRIPTION
## Summary
- enable math extension in Markdown pipeline
- add MathJax script to index

## Testing
- `dotnet test --no-build`

------
https://chatgpt.com/codex/tasks/task_e_688b80130740832a85587379053a8cfc