### PR TITLE
Add copy buttons for chat

### DIFF
--- a/ChatClient.Api/Client/Pages/Chat.razor
+++ b/ChatClient.Api/Client/Pages/Chat.razor
@@ -7,6 +7,7 @@
 @using ChatClient.Shared.Models
 @using System.Threading
 @using System.Text
+@using System.Linq
 @using MudBlazor
 @using ChatClient.Api.Client.Services
 @using ChatClient.Api.Client.Components
@@ -91,6 +92,8 @@
                              <time>@message.MsgDateTime.ToString("g")</time>
                              @if (!isLLMAnswering)
                              {
+                                <span class="copy-button" title="Copy answer" @onclick="(() => CopyVisibleMessage(message))">📋</span>
+                                <span class="copy-button" title="Copy raw" @onclick="(() => CopyRawMessage(message))">🚪</span>
                                 <span class="delete-button" title="Delete" @onclick="(() => DeleteMessage(message))">🗑</span>
                              }
                          </MudChatHeader>
@@ -346,6 +349,19 @@
             return;
 
         await ChatService.DeleteMessageAsync(message.Id);
+    }
+
+    private async Task CopyVisibleMessage(ChatMessageViewModel message)
+    {
+        await JSRuntime.InvokeVoidAsync("copyText", message.Content);
+    }
+
+    private async Task CopyRawMessage(ChatMessageViewModel message)
+    {
+        if (!string.IsNullOrEmpty(message.RawContent))
+        {
+            await JSRuntime.InvokeVoidAsync("copyText", message.RawContent);
+        }
     }
 
     public ValueTask DisposeAsync()

--- a/ChatClient.Api/Client/ViewModels/ChatMessageViewModel.cs
+++ b/ChatClient.Api/Client/ViewModels/ChatMessageViewModel.cs
@@ -15,6 +15,7 @@ namespace ChatClient.Api.Client.ViewModels;
 public class ChatMessageViewModel
 {
     public Guid Id { get; set; }
+    public string RawContent { get; set; } = string.Empty;
     public string Content { get; set; } = string.Empty;
     public string HtmlContent { get; set; } = string.Empty;
     public IReadOnlyCollection<string> ThinkSegments { get; set; } = [];
@@ -35,7 +36,7 @@ public class ChatMessageViewModel
     private ChatMessageViewModel Populate(IAppChatMessage message)
     {
         Id = message.Id;
-        Content = message.Content;
+        RawContent = message.Content;
         MsgDateTime = message.MsgDateTime;
         Role = message.Role;
         Statistics = message.Statistics;

--- a/ChatClient.Api/Pages/Shared/_Layout.cshtml
+++ b/ChatClient.Api/Pages/Shared/_Layout.cshtml
@@ -38,6 +38,9 @@
                 element.scrollTop = element.scrollHeight;
             }
         }
+        window.copyText = function (text) {
+            navigator.clipboard.writeText(text);
+        }
     </script>
 </body>
 </html>

--- a/ChatClient.Api/wwwroot/css/chat.css
+++ b/ChatClient.Api/wwwroot/css/chat.css
@@ -90,6 +90,13 @@
     cursor: default;
 }
 
+/* Copy button style */
+.copy-button {
+    cursor: pointer;
+    margin-left: 0.25rem;
+    color: var(--mud-palette-text-secondary);
+}
+
 @keyframes blink {
     0%, 50% {
         opacity: 1;

--- a/ChatClient.Api/wwwroot/index.html
+++ b/ChatClient.Api/wwwroot/index.html
@@ -40,6 +40,9 @@
                 element.scrollTop = element.scrollHeight;
             }
         }
+        window.copyText = function (text) {
+            navigator.clipboard.writeText(text);
+        }
     </script>
 </body>
 


### PR DESCRIPTION
## Summary
- show copy buttons in chat message headers
- allow copying visible text and raw message via JS
- store raw content in view model
- expose copy helper in index layout
- style copy icons
- fix duplicate assignment for chat message content

## Testing
- `dotnet test ChatClient.Tests/ChatClient.Tests.csproj -v minimal`


------
https://chatgpt.com/codex/tasks/task_e_688b9d54c578832aa9e60635e6f7b73c