### PR TITLE
Fix cascading parameter for AutoSelectFunctions

### DIFF
--- a/ChatClient.Api/Client/Layout/MainLayout.razor
+++ b/ChatClient.Api/Client/Layout/MainLayout.razor
@@ -15,11 +15,11 @@
 <MudDialogProvider />
 <MudSnackbarProvider />
 <MudPopoverProvider />
-<CascadingValue Value="@selectedFunctions">
-<CascadingValue Value="@autoSelectFunctions">
-<CascadingValue Value="@autoSelectCount">
-<CascadingValue Value="@useAgentMode">
-<CascadingValue Value="@selectedModel">
+<CascadingValue Value="@selectedFunctions" Name="SelectedFunctions">
+<CascadingValue Value="@autoSelectFunctions" Name="AutoSelectFunctions">
+<CascadingValue Value="@autoSelectCount" Name="AutoSelectCount">
+<CascadingValue Value="@useAgentMode" Name="UseAgentMode">
+<CascadingValue Value="@selectedModel" Name="SelectedModel">
 <MudLayout>
     <MudAppBar Elevation="1" Dense="true">
         <MudIconButton Icon="@Icons.Material.Filled.Menu" Color="Color.Inherit" Edge="Edge.Start" OnClick="@((e) => DrawerToggle())" Size="Size.Medium" />

--- a/ChatClient.Api/Client/Pages/Chat.razor
+++ b/ChatClient.Api/Client/Pages/Chat.razor
@@ -213,16 +213,16 @@
 
     private List<SystemPrompt> systemPrompts = new();
     private SystemPrompt? selectedSystemPrompt;
-    [CascadingParameter]
+    [CascadingParameter(Name = "SelectedFunctions")]
     public List<string> SelectedFunctions { get; set; } = new();
-    [CascadingParameter]
+    [CascadingParameter(Name = "AutoSelectFunctions")]
     public bool AutoSelectFunctions { get; set; }
-    [CascadingParameter]
+    [CascadingParameter(Name = "AutoSelectCount")]
     public int AutoSelectCount { get; set; }
 
-    [CascadingParameter]
+    [CascadingParameter(Name = "UseAgentMode")]
     public bool UseAgentMode { get; set; }
-    [CascadingParameter]
+    [CascadingParameter(Name = "SelectedModel")]
     public OllamaModel? SelectedModel { get; set; }
 
     private bool showPromptContent { get; set; } = false;


### PR DESCRIPTION
## Summary
- ensure cascading values use unique names for bool values
- specify CascadingParameter names in Chat page

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_688c6d744220832abc056ca80ce2817c