### PR TITLE
Add math parsing for \( \) delimiters

### DIFF
--- a/ChatClient.Api/Client/Markdown/SlashParensMathExtension.cs
+++ b/ChatClient.Api/Client/Markdown/SlashParensMathExtension.cs
@@ -1,0 +1,43 @@
+using Markdig;
+using Markdig.Parsers;
+using Markdig.Parsers.Inlines;
+using Markdig.Renderers;
+
+namespace ChatClient.Api.Client.MarkdownExtensions;
+
+/// <summary>
+/// Markdown extension that enables parsing LaTeX inline math using \( and \) delimiters.
+/// </summary>
+public class SlashParensMathExtension : IMarkdownExtension
+{
+    /// <inheritdoc />
+    public void Setup(MarkdownPipelineBuilder pipeline)
+    {
+        if (!pipeline.InlineParsers.Contains<SlashParensMathInlineParser>())
+        {
+            // Insert before the escape parser so that backslashes are preserved
+            pipeline.InlineParsers.InsertBefore<EscapeInlineParser>(new SlashParensMathInlineParser());
+        }
+    }
+
+    /// <inheritdoc />
+    public void Setup(MarkdownPipeline pipeline, IMarkdownRenderer renderer)
+    {
+        // Rendering handled by default math renderers from UseMathematics
+    }
+}
+
+/// <summary>
+/// Helper methods for enabling <see cref="SlashParensMathExtension"/>.
+/// </summary>
+public static class SlashParensMathExtensionMethods
+{
+    /// <summary>
+    /// Adds support for inline math delimited by \( and \) to the pipeline.
+    /// </summary>
+    public static MarkdownPipelineBuilder UseSlashParensMath(this MarkdownPipelineBuilder pipeline)
+    {
+        pipeline.Extensions.AddIfNotAlready<SlashParensMathExtension>();
+        return pipeline;
+    }
+}

--- a/ChatClient.Api/Client/Markdown/SlashParensMathInlineParser.cs
+++ b/ChatClient.Api/Client/Markdown/SlashParensMathInlineParser.cs
@@ -1,0 +1,84 @@
+using Markdig.Extensions.Mathematics;
+using Markdig.Helpers;
+using Markdig.Parsers;
+using Markdig.Syntax;
+using Markdig.Syntax.Inlines;
+
+namespace ChatClient.Api.Client.MarkdownExtensions;
+
+/// <summary>
+/// Inline parser supporting LaTeX math delimited by \( and \).
+/// Produces <see cref="MathInline"/> elements for Markdig.
+/// </summary>
+public class SlashParensMathInlineParser : InlineParser
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SlashParensMathInlineParser"/> class.
+    /// </summary>
+    public SlashParensMathInlineParser()
+    {
+        OpeningCharacters = ['\\'];
+        DefaultClass = "math";
+    }
+
+    /// <summary>
+    /// Gets or sets the default CSS class for created math inlines.
+    /// </summary>
+    public string? DefaultClass { get; set; }
+
+    /// <inheritdoc />
+    public override bool Match(InlineProcessor processor, ref StringSlice slice)
+    {
+        var startPosition = slice.Start;
+        if (slice.CurrentChar != '\\' || slice.PeekChar() != '(')
+        {
+            return false;
+        }
+
+        // Skip the opening '\(' sequence
+        slice.NextChar(); // skip '\'
+        slice.NextChar(); // skip '('
+
+        var contentStart = slice.Start;
+        char previous = '\0';
+        char c = slice.CurrentChar;
+        while (c != '\0')
+        {
+            if (c == '\\' && slice.PeekChar() == ')' && previous != '\\')
+            {
+                // Found closing '\)'
+                var inline = new MathInline
+                {
+                    Span = new SourceSpan(
+                        processor.GetSourcePosition(startPosition, out int line, out int column),
+                        processor.GetSourcePosition(slice.Start + 1)),
+                    Line = line,
+                    Column = column,
+                    Delimiter = '\\',
+                    DelimiterCount = 1,
+                    Content = new StringSlice(slice.Text, contentStart, slice.Start - 1)
+                };
+                processor.Inline = inline;
+
+                // Skip the closing '\)' sequence
+                slice.NextChar();
+                slice.NextChar();
+                return true;
+            }
+
+            if (c == '\n' || c == '\r')
+            {
+                // New lines are not allowed inside inline math
+                slice.Start = startPosition;
+                return false;
+            }
+
+            previous = c;
+            c = slice.NextChar();
+        }
+
+        // No closing delimiter found, rewind
+        slice.Start = startPosition;
+        return false;
+    }
+}

--- a/ChatClient.Api/Client/ViewModels/ChatMessageViewModel.cs
+++ b/ChatClient.Api/Client/ViewModels/ChatMessageViewModel.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 
+using ChatClient.Api.Client.MarkdownExtensions;
 using ChatClient.Shared.Models;
 
 using DimonSmart.AiUtils;
@@ -32,6 +33,7 @@ public class ChatMessageViewModel
     private static readonly MarkdownPipeline Pipeline = new MarkdownPipelineBuilder()
         .UseAdvancedExtensions()
         .UseMathematics()
+        .UseSlashParensMath()
         .Build();
     private ChatMessageViewModel Populate(IAppChatMessage message)
     {


### PR DESCRIPTION
## Summary
- implement a custom Markdig extension to parse LaTeX `\( ... \)` expressions
- use the new extension alongside `UseMathematics` for existing `$` math support

## Testing
- `dotnet test -p:EnableNETAnalyzers=false -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_688bc68b7034832a9ea36e8c0f970cb2