### PR TITLE
feat: allow multi-agent chat start

### DIFF
--- a/ChatClient.Api/Client/Pages/Chat.razor
+++ b/ChatClient.Api/Client/Pages/Chat.razor
@@ -46,7 +46,7 @@
                 }
                 else
                 {
-                    <MudSelect T="SystemPrompt" Label="Select Agent" @bind-Value="selectedAgent" Variant="Variant.Outlined" FullWidth="true" Dense="true">
+                    <MudSelect T="SystemPrompt" Label="Select Agents" SelectedValues="selectedAgents" SelectedValuesChanged="@(items => selectedAgents = items.ToList())" MultiSelection="true" Variant="Variant.Outlined" FullWidth="true" Dense="true">
                         @foreach (var agent in agents)
                         {
                             <MudSelectItem Value="@agent">@agent.Name</MudSelectItem>
@@ -54,10 +54,16 @@
                     </MudSelect>
 
                     <MudSwitch T="bool" @bind-value="showAgentPrompt" Color="Color.Primary" Class="mt-4" Style="margin-bottom: 10px;">View Agent Prompt</MudSwitch>
-                    @if (showAgentPrompt)
+                    @if (showAgentPrompt && selectedAgents.Any())
                     {
                         <div class="prompt-preview mt-3 pa-3 mb-2">
-                            @(selectedAgent?.Content ?? string.Empty)
+                            @foreach (var agent in selectedAgents)
+                            {
+                                <div class="mb-2">
+                                    <strong>@agent.Name</strong>
+                                    <div>@(agent.Content ?? string.Empty)</div>
+                                </div>
+                            }
                         </div>
                     }
                     <MudButton Variant="Variant.Filled"
@@ -212,7 +218,7 @@
     private ElementReference messagesElement;
 
     private List<SystemPrompt> agents = new();
-    private SystemPrompt? selectedAgent;
+    private List<SystemPrompt> selectedAgents { get; set; } = new();
     [CascadingParameter(Name = "SelectedFunctions")]
     public List<string> SelectedFunctions { get; set; } = new();
     [CascadingParameter(Name = "AutoSelectFunctions")]
@@ -291,7 +297,7 @@
         agents = await AgentService.GetAllPromptsAsync();
         if (agents.Count == 0)
             agents.Add(AgentService.GetDefaultSystemPrompt());
-        selectedAgent = agents.FirstOrDefault();
+        selectedAgents = new List<SystemPrompt>();
     }
 
     private async Task LoadUserSettings()
@@ -306,11 +312,7 @@
 
     private void StartChat()
     {
-        if (selectedAgent == null)
-        {
-            selectedAgent = AgentService.GetDefaultSystemPrompt();
-        }
-        var agentsToInitialize = selectedAgent != null ? new[] { selectedAgent } : null;
+        IEnumerable<SystemPrompt>? agentsToInitialize = selectedAgents.Any() ? selectedAgents : null;
         ChatService.InitializeChat(agentsToInitialize);
         chatStarted = true;
         StateHasChanged();


### PR DESCRIPTION
## Summary
- Allow selecting multiple agents before starting chat
- Display prompts for each selected agent
- Initialize chat with selected agents or none

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_688e37c0aadc832ab6b5756b125f50c2