### PR TITLE
Fix agent display name

### DIFF
--- a/ChatClient.Shared/Models/SystemPrompt.cs
+++ b/ChatClient.Shared/Models/SystemPrompt.cs
@@ -9,4 +9,6 @@ public class SystemPrompt
     public string? ModelName { get; set; }
     public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
     public DateTime UpdatedAt { get; set; } = DateTime.UtcNow;
+
+    public override string ToString() => Name;
 }


### PR DESCRIPTION
## Summary
- override `SystemPrompt.ToString` to show agent name instead of type

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_688e544d0234832a9ce046b25a3eaa7e