### PR TITLE
Track agent names in chat history

### DIFF
--- a/ChatClient.Api/Client/Layout/MainLayout.razor
+++ b/ChatClient.Api/Client/Layout/MainLayout.razor
@@ -18,7 +18,7 @@
 <CascadingValue Value="@selectedFunctions" Name="SelectedFunctions">
 <CascadingValue Value="@autoSelectFunctions" Name="AutoSelectFunctions">
 <CascadingValue Value="@autoSelectCount" Name="AutoSelectCount">
-<CascadingValue Value="@useAgentMode" Name="UseAgentMode">
+<CascadingValue Value="@useAgentResponses" Name="UseAgentResponses">
 <CascadingValue Value="@autoContinue" Name="AutoContinue">
 <CascadingValue Value="@selectedModel" Name="SelectedModel">
 <MudLayout>
@@ -33,7 +33,7 @@
                        StartIcon="@Icons.Material.Filled.AddCircle"
                        Size="Size.Small"
                        Class="ml-4">New Chat</MudButton>
-           <MudCheckBox @bind-Value="useAgentMode"
+           <MudCheckBox @bind-Value="useAgentResponses"
                          Label="Agent"
                          Color="Color.Primary"
                          Size="Size.Small"
@@ -121,7 +121,7 @@
     private bool _drawerOpen = true;
     private bool _isDarkMode = true;
     private bool isLLMAnswering;
-    private bool useAgentMode = false;
+    private bool useAgentResponses = false;
     private bool autoContinue = false;
     private List<FunctionInfo> availableFunctions = new();
     private List<string> selectedFunctions = new();
@@ -139,7 +139,7 @@
         isLLMAnswering = ChatService.IsLoading;
 
         var settings = await UserSettingsService.GetSettingsAsync();
-        useAgentMode = settings.DefaultUseAgentMode;
+        useAgentResponses = settings.DefaultUseAgentResponses;
         autoSelectFunctions = settings.DefaultAutoSelectCount > 0;
         autoSelectCount = settings.DefaultAutoSelectCount > 0
             ? settings.DefaultAutoSelectCount
@@ -206,6 +206,11 @@
 
     private void NewChat()
     {
+        if (ChatService.AgentDescriptions.Count == 0)
+        {
+            return;
+        }
+
         ChatService.InitializeChat(ChatService.AgentDescriptions);
         if (!IsOnChatPage())
         {

--- a/ChatClient.Api/Client/Pages/AppSettings.razor
+++ b/ChatClient.Api/Client/Pages/AppSettings.razor
@@ -108,11 +108,11 @@
                             <MudText Class="section-header">Default Chat Mode</MudText>
                         </MudCardHeader>
                     <MudCardContent Class="pt-0">
-                        <MudCheckBox @bind-Value="_settings.DefaultUseAgentMode"
-                                     Label="Agent Mode by Default"
+                        <MudCheckBox @bind-Value="_settings.DefaultUseAgentResponses"
+                                     Label="Agent Responses by Default"
                                      Color="Color.Primary" />
                         <MudText Typo="Typo.caption" Class="mt-2">
-                            When enabled, new chats will start in Agent mode instead of Ask mode.
+                            When enabled, new chats will start with agent responses instead of standard responses.
                         </MudText>
                     </MudCardContent>
                 </MudCard>

--- a/ChatClient.Api/Client/Pages/Chat.razor
+++ b/ChatClient.Api/Client/Pages/Chat.razor
@@ -226,8 +226,8 @@
     [CascadingParameter(Name = "AutoSelectCount")]
     public int AutoSelectCount { get; set; }
 
-    [CascadingParameter(Name = "UseAgentMode")]
-    public bool UseAgentMode { get; set; }
+    [CascadingParameter(Name = "UseAgentResponses")]
+    public bool UseAgentResponses { get; set; }
     [CascadingParameter(Name = "AutoContinue")]
     public bool AutoContinue { get; set; }
     [CascadingParameter(Name = "SelectedModel")]
@@ -312,8 +312,10 @@
 
     private void StartChat()
     {
-        IEnumerable<SystemPrompt>? agentsToInitialize = selectedAgents.Any() ? selectedAgents : null;
-        ChatService.InitializeChat(agentsToInitialize);
+        if (selectedAgents.Count == 0)
+            return;
+
+        ChatService.InitializeChat(selectedAgents);
         chatStarted = true;
         StateHasChanged();
     }
@@ -325,7 +327,7 @@
         var chatConfiguration = new ChatConfiguration(
             SelectedModel?.Name ?? string.Empty,
             SelectedFunctions,
-            UseAgentMode,
+            UseAgentResponses,
             AutoSelectFunctions,
             AutoSelectCount,
             AutoContinue);

--- a/ChatClient.Api/Client/Services/IChatService.cs
+++ b/ChatClient.Api/Client/Services/IChatService.cs
@@ -1,5 +1,5 @@
 using ChatClient.Shared.Models;
-using ChatClient.Shared.Agents;
+using ChatClient.Shared.LlmAgents;
 using System.Collections.Generic;
 
 namespace ChatClient.Api.Client.Services;
@@ -8,13 +8,13 @@ public interface IChatService
 {
     bool IsLoading { get; }
     IReadOnlyList<SystemPrompt> AgentDescriptions { get; }
-    IReadOnlyList<IAgent> ActiveAgents { get; }
+    IReadOnlyList<ILlmAgent> ActiveLlmAgents { get; }
     event Action<bool>? LoadingStateChanged;
     event Action? ChatInitialized;
     event Func<IAppChatMessage, Task>? MessageAdded;
     event Func<IAppChatMessage, Task>? MessageUpdated;
     event Func<Guid, Task>? MessageDeleted;
-    void InitializeChat(IEnumerable<SystemPrompt>? initialAgents);
+    void InitializeChat(IEnumerable<SystemPrompt> initialAgents);
     void ClearChat();
     Task CancelAsync();
     Task AddUserMessageAndAnswerAsync(string text, ChatConfiguration chatConfiguration, IReadOnlyList<ChatMessageFile> files);

--- a/ChatClient.Api/Client/Services/StreamingMessageManager.cs
+++ b/ChatClient.Api/Client/Services/StreamingMessageManager.cs
@@ -21,9 +21,9 @@ public class StreamingMessageManager
     /// <summary>
     /// Creates a new streaming message
     /// </summary>
-    public StreamingAppChatMessage CreateStreamingMessage(List<FunctionCallRecord>? functionCalls = null)
+    public StreamingAppChatMessage CreateStreamingMessage(List<FunctionCallRecord>? functionCalls = null, string? agentName = null)
     {
-        return new StreamingAppChatMessage(string.Empty, DateTime.Now, ChatRole.Assistant, functionCalls);
+        return new StreamingAppChatMessage(string.Empty, DateTime.Now, ChatRole.Assistant, functionCalls, agentName);
     }
 
 
@@ -37,7 +37,7 @@ public class StreamingMessageManager
         {
             streamingMessage.SetStatistics(statistics);
         }
-        var finalMessage = new AppChatMessage(streamingMessage.Content, streamingMessage.MsgDateTime, ChatRole.Assistant, streamingMessage.Statistics, streamingMessage.Files, streamingMessage.FunctionCalls);
+        var finalMessage = new AppChatMessage(streamingMessage.Content, streamingMessage.MsgDateTime, ChatRole.Assistant, streamingMessage.Statistics, streamingMessage.Files, streamingMessage.FunctionCalls, streamingMessage.AgentName);
         finalMessage.Id = streamingMessage.Id; // Preserve the original ID
         finalMessage.IsCanceled = streamingMessage.IsCanceled;
         return finalMessage;
@@ -50,7 +50,7 @@ public class StreamingMessageManager
     {
         streamingMessage.SetCanceled();
 
-        var finalMessage = new AppChatMessage(streamingMessage.Content, streamingMessage.MsgDateTime, ChatRole.Assistant, streamingMessage.Statistics, streamingMessage.Files, streamingMessage.FunctionCalls);
+        var finalMessage = new AppChatMessage(streamingMessage.Content, streamingMessage.MsgDateTime, ChatRole.Assistant, streamingMessage.Statistics, streamingMessage.Files, streamingMessage.FunctionCalls, streamingMessage.AgentName);
         finalMessage.Id = streamingMessage.Id; // Preserve the original ID
         finalMessage.IsCanceled = true;
         return finalMessage;

--- a/ChatClient.Api/Client/ViewModels/ChatMessageViewModel.cs
+++ b/ChatClient.Api/Client/ViewModels/ChatMessageViewModel.cs
@@ -29,6 +29,7 @@ public class ChatMessageViewModel
     public bool IsStreaming { get; set; }
     public bool IsCanceled { get; set; }
     public IReadOnlyList<ChatMessageFile> Files { get; set; } = [];
+    public string? AgentName { get; set; }
 
     private static readonly MarkdownPipeline Pipeline = new MarkdownPipelineBuilder()
         .UseAdvancedExtensions()
@@ -41,6 +42,7 @@ public class ChatMessageViewModel
         RawContent = message.Content;
         MsgDateTime = message.MsgDateTime;
         Role = message.Role;
+        AgentName = message.AgentName;
         Statistics = message.Statistics;
         IsStreaming = message.IsStreaming;
         IsCanceled = message.IsCanceled;

--- a/ChatClient.Api/Program.cs
+++ b/ChatClient.Api/Program.cs
@@ -40,8 +40,8 @@ builder.Services.AddScoped<ChatClient.Api.Services.StartupOllamaChecker>();
 builder.Services.AddSingleton<ChatClient.Shared.Services.ISystemPromptService, ChatClient.Api.Services.SystemPromptService>();
 builder.Services.AddSingleton<ChatClient.Shared.Services.IUserSettingsService, ChatClient.Api.Services.UserSettingsService>();
 
-builder.Services.AddScoped<ChatClient.Shared.Agents.IAgent>(sp => new ChatClient.Api.Services.KernelAgent("Default"));
-builder.Services.AddScoped<ChatClient.Shared.Agents.IAgentCoordinator, ChatClient.Api.Services.DefaultAgentCoordinator>();
+builder.Services.AddScoped<ChatClient.Shared.LlmAgents.ILlmAgent>(sp => new ChatClient.Api.Services.KernelLlmAgent("Default"));
+builder.Services.AddScoped<ChatClient.Shared.LlmAgents.ILlmAgentCoordinator, ChatClient.Api.Services.DefaultLlmAgentCoordinator>();
 
 builder.Services.AddScoped<ChatClient.Api.Client.Services.IChatService, ChatClient.Api.Client.Services.ChatService>();
 builder.Services.AddScoped<ChatClient.Api.Client.Services.IChatViewModelService, ChatClient.Api.Client.Services.ChatViewModelService>();

--- a/ChatClient.Api/Services/ChatHistoryBuilder.cs
+++ b/ChatClient.Api/Services/ChatHistoryBuilder.cs
@@ -52,7 +52,9 @@ public class ChatHistoryBuilder(IUserSettingsService settingsService) : IChatHis
             {
                 role = AuthorRole.User;
             }
-            history.Add(new ChatMessageContent(role, items));
+            // Semantic Kernel's ChatMessageContent accepts an optional name parameter
+            // that we use to preserve the agent identity for each message.
+            history.Add(new ChatMessageContent(role, items, msg.AgentName));
         }
         return history;
     }

--- a/ChatClient.Api/Services/DefaultLlmAgentCoordinator.cs
+++ b/ChatClient.Api/Services/DefaultLlmAgentCoordinator.cs
@@ -1,15 +1,15 @@
-using ChatClient.Shared.Agents;
+using ChatClient.Shared.LlmAgents;
 
 namespace ChatClient.Api.Services;
 
 /// <summary>
 /// Basic agent coordinator that always returns a single agent instance.
 /// </summary>
-public class DefaultAgentCoordinator(IAgent agent) : IAgentCoordinator
+public class DefaultLlmAgentCoordinator(ILlmAgent agent) : ILlmAgentCoordinator
 {
-    private readonly IAgent _agent = agent;
+    private readonly ILlmAgent _agent = agent;
 
-    public IAgent GetNextAgent() => _agent;
+    public ILlmAgent GetNextAgent() => _agent;
 
     public bool ShouldContinueConversation(int cycleCount) => false;
 }

--- a/ChatClient.Api/Services/KernelLlmAgent.cs
+++ b/ChatClient.Api/Services/KernelLlmAgent.cs
@@ -1,5 +1,6 @@
-using ChatClient.Shared.Agents;
+using ChatClient.Shared.LlmAgents;
 using ChatClient.Shared.Models;
+
 using Microsoft.SemanticKernel;
 using Microsoft.SemanticKernel.ChatCompletion;
 
@@ -8,7 +9,7 @@ namespace ChatClient.Api.Services;
 /// <summary>
 /// Default agent implementation that proxies chat completion requests to the kernel.
 /// </summary>
-public class KernelAgent(string name, SystemPrompt? agentDescription = null) : AgentBase(name, agentDescription)
+public class KernelLlmAgent(string name, SystemPrompt? agentDescription = null) : LlmAgentBase(name, agentDescription)
 {
     public override async IAsyncEnumerable<StreamingChatMessageContent> GetResponseAsync(
         ChatHistory chatHistory,

--- a/ChatClient.Api/Services/ManagerLlmAgent.cs
+++ b/ChatClient.Api/Services/ManagerLlmAgent.cs
@@ -4,7 +4,7 @@ using System.Linq;
 using Microsoft.SemanticKernel;
 using Microsoft.SemanticKernel.ChatCompletion;
 
-using ChatClient.Shared.Agents;
+using ChatClient.Shared.LlmAgents;
 using ChatClient.Shared.Models;
 
 namespace ChatClient.Api.Services;
@@ -13,7 +13,7 @@ namespace ChatClient.Api.Services;
 /// Agent responsible for selecting which worker agent should handle the next message.
 /// Currently it does not produce user-facing responses and relies on simple policies.
 /// </summary>
-public class ManagerAgent(string name, SystemPrompt? agentDescription = null) : AgentBase(name, agentDescription)
+public class ManagerLlmAgent(string name, SystemPrompt? agentDescription = null) : LlmAgentBase(name, agentDescription)
 {
     public override IAsyncEnumerable<StreamingChatMessageContent> GetResponseAsync(
         ChatHistory chatHistory,

--- a/ChatClient.Api/Services/MultiLlmAgentCoordinator.cs
+++ b/ChatClient.Api/Services/MultiLlmAgentCoordinator.cs
@@ -1,7 +1,7 @@
 using System.Collections.Generic;
 using System.Linq;
 
-using ChatClient.Shared.Agents;
+using ChatClient.Shared.LlmAgents;
 
 namespace ChatClient.Api.Services;
 
@@ -9,14 +9,14 @@ namespace ChatClient.Api.Services;
 /// Coordinates multiple worker agents using a simple round-robin policy.
 /// A manager agent is retained for future, more advanced coordination logic.
 /// </summary>
-public class MultiAgentCoordinator : IAgentCoordinator
+public class MultiLlmAgentCoordinator : ILlmAgentCoordinator
 {
-    private readonly IAgent _managerAgent;
-    private readonly IReadOnlyList<IAgent> _workerAgents;
+    private readonly ILlmAgent _managerAgent;
+    private readonly IReadOnlyList<ILlmAgent> _workerAgents;
     private int _currentIndex;
     private readonly int _maxCyclesWithoutUser;
 
-    public MultiAgentCoordinator(IAgent managerAgent, IEnumerable<IAgent> workerAgents, int maxCyclesWithoutUser = 5)
+    public MultiLlmAgentCoordinator(ILlmAgent managerAgent, IEnumerable<ILlmAgent> workerAgents, int maxCyclesWithoutUser = 5)
     {
         _managerAgent = managerAgent;
         _workerAgents = workerAgents.ToList();
@@ -24,7 +24,7 @@ public class MultiAgentCoordinator : IAgentCoordinator
         _maxCyclesWithoutUser = maxCyclesWithoutUser;
     }
 
-    public IAgent GetNextAgent()
+    public ILlmAgent GetNextAgent()
     {
         if (_workerAgents.Count == 0)
         {

--- a/ChatClient.Shared/LlmAgents/ILlmAgent.cs
+++ b/ChatClient.Shared/LlmAgents/ILlmAgent.cs
@@ -1,10 +1,10 @@
-namespace ChatClient.Shared.Agents;
+namespace ChatClient.Shared.LlmAgents;
 
 using ChatClient.Shared.Models;
 using Microsoft.SemanticKernel;
 using Microsoft.SemanticKernel.ChatCompletion;
 
-public interface IAgent
+public interface ILlmAgent
 {
     string Name { get; }
     SystemPrompt? AgentDescription { get; }

--- a/ChatClient.Shared/LlmAgents/ILlmAgentCoordinator.cs
+++ b/ChatClient.Shared/LlmAgents/ILlmAgentCoordinator.cs
@@ -1,8 +1,8 @@
-namespace ChatClient.Shared.Agents;
+namespace ChatClient.Shared.LlmAgents;
 
-public interface IAgentCoordinator
+public interface ILlmAgentCoordinator
 {
-    IAgent GetNextAgent();
+    ILlmAgent GetNextAgent();
 
     /// <summary>
     /// Determines if agents should continue exchanging messages without user input.

--- a/ChatClient.Shared/LlmAgents/LlmAgentBase.cs
+++ b/ChatClient.Shared/LlmAgents/LlmAgentBase.cs
@@ -1,12 +1,13 @@
-namespace ChatClient.Shared.Agents;
+namespace ChatClient.Shared.LlmAgents;
 
 using ChatClient.Shared.Models;
+
 using Microsoft.SemanticKernel;
 using Microsoft.SemanticKernel.ChatCompletion;
 
-public abstract class AgentBase : IAgent
+public abstract class LlmAgentBase : ILlmAgent
 {
-    protected AgentBase(string name, SystemPrompt? agentDescription = null)
+    protected LlmAgentBase(string name, SystemPrompt? agentDescription = null)
     {
         Name = name;
         AgentDescription = agentDescription;

--- a/ChatClient.Shared/Models/AppChatMessage.cs
+++ b/ChatClient.Shared/Models/AppChatMessage.cs
@@ -10,6 +10,7 @@ public class AppChatMessage : IAppChatMessage
     public string Content { get; set; }
     public DateTime MsgDateTime { get; set; }
     public ChatRole Role { get; set; }
+    public string? AgentName { get; set; }
     public string? Statistics { get; set; }
     public bool IsCanceled { get; set; }
     public IReadOnlyList<ChatMessageFile> Files { get; set; } = [];
@@ -52,18 +53,20 @@ public class AppChatMessage : IAppChatMessage
         Content = message.Content;
         MsgDateTime = message.MsgDateTime;
         Role = message.Role;
+        AgentName = message.AgentName;
         Statistics = message.Statistics;
         IsCanceled = message.IsCanceled;
         Files = message.Files;
         FunctionCalls = message.FunctionCalls;
     }
 
-    public AppChatMessage(string content, DateTime msgDateTime, ChatRole role, string? statistics = null, IReadOnlyList<ChatMessageFile>? files = null, IReadOnlyCollection<FunctionCallRecord>? functionCalls = null)
+    public AppChatMessage(string content, DateTime msgDateTime, ChatRole role, string? statistics = null, IReadOnlyList<ChatMessageFile>? files = null, IReadOnlyCollection<FunctionCallRecord>? functionCalls = null, string? agentName = null)
     {
         Id = Guid.NewGuid();
         Content = content ?? string.Empty;
         MsgDateTime = msgDateTime;
         Role = role;
+        AgentName = agentName;
         Statistics = statistics;
         Files = files ?? [];
         FunctionCalls = functionCalls ?? [];

--- a/ChatClient.Shared/Models/ChatConfiguration.cs
+++ b/ChatClient.Shared/Models/ChatConfiguration.cs
@@ -3,7 +3,7 @@ namespace ChatClient.Shared.Models;
 public record ChatConfiguration(
     string ModelName,
     IReadOnlyCollection<string> Functions,
-    bool UseAgentMode,
+    bool UseAgentResponses,
     bool AutoSelectFunctions = false,
     int AutoSelectCount = 0,
     bool AutoContinue = false);

--- a/ChatClient.Shared/Models/IAppChatMessage.cs
+++ b/ChatClient.Shared/Models/IAppChatMessage.cs
@@ -8,6 +8,7 @@ public interface IAppChatMessage : IEquatable<IAppChatMessage>
     string Content { get; }
     DateTime MsgDateTime { get; }
     ChatRole Role { get; }
+    string? AgentName { get; }
     string? Statistics { get; }
     bool IsStreaming { get; }
     bool IsCanceled { get; }

--- a/ChatClient.Shared/Models/StreamingAppChatMessage.cs
+++ b/ChatClient.Shared/Models/StreamingAppChatMessage.cs
@@ -5,7 +5,7 @@ using Microsoft.Extensions.AI;
 
 namespace ChatClient.Shared.Models;
 
-public class StreamingAppChatMessage(string initialContent, DateTime msgDateTime, ChatRole role, List<FunctionCallRecord>? functionCalls = null) : IAppChatMessage
+public class StreamingAppChatMessage(string initialContent, DateTime msgDateTime, ChatRole role, List<FunctionCallRecord>? functionCalls = null, string? agentName = null) : IAppChatMessage
 {
     private readonly StringBuilder _contentBuilder = new(initialContent);
     public string Content => _contentBuilder.ToString();
@@ -16,6 +16,7 @@ public class StreamingAppChatMessage(string initialContent, DateTime msgDateTime
     public IReadOnlyList<ChatMessageFile> Files { get; private set; } = [];
     private readonly List<FunctionCallRecord> _functionCalls = functionCalls ?? [];
     public IReadOnlyCollection<FunctionCallRecord> FunctionCalls => _functionCalls.AsReadOnly();
+    public string? AgentName { get; private set; } = agentName;
 
     public Guid Id { get; private set; } = Guid.NewGuid();
 

--- a/ChatClient.Shared/Models/UserSettings.cs
+++ b/ChatClient.Shared/Models/UserSettings.cs
@@ -46,10 +46,10 @@ public class UserSettings
     public int McpSamplingTimeoutSeconds { get; set; } = 30 * 60;
 
     /// <summary>
-    /// Default mode for new chats: true for Agent mode, false for Ask mode
+    /// Default response mode for new chats: true for Agent responses, false for standard responses
     /// </summary>
-    [JsonPropertyName("defaultUseAgentMode")]
-    public bool DefaultUseAgentMode { get; set; } = false;
+    [JsonPropertyName("defaultUseAgentResponses")]
+    public bool DefaultUseAgentResponses { get; set; } = false;
 
     /// <summary>
     /// Number of functions to auto-select for new chats. Set to 0 to disable

--- a/ChatClient.Tests/ChatServiceTests.cs
+++ b/ChatClient.Tests/ChatServiceTests.cs
@@ -1,0 +1,45 @@
+using ChatClient.Api.Client.Services;
+using ChatClient.Api.Services;
+using ChatClient.Shared.LlmAgents;
+using ChatClient.Shared.Models;
+using Microsoft.Extensions.Logging;
+using Microsoft.SemanticKernel;
+using Microsoft.SemanticKernel.ChatCompletion;
+
+namespace ChatClient.Tests;
+
+public class ChatServiceTests
+{
+    private class DummyAgent : ILlmAgent
+    {
+        public string Name => "dummy";
+        public SystemPrompt? AgentDescription => null;
+        public async IAsyncEnumerable<StreamingChatMessageContent> GetResponseAsync(
+            ChatHistory chatHistory,
+            PromptExecutionSettings promptExecutionSettings,
+            Kernel kernel,
+            [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken cancellationToken = default)
+        {
+            await Task.Yield();
+            yield break;
+        }
+    }
+
+    private class DummyHistoryBuilder : IChatHistoryBuilder
+    {
+        public Task<ChatHistory> BuildChatHistoryAsync(IEnumerable<IAppChatMessage> messages, Kernel kernel, CancellationToken cancellationToken)
+            => Task.FromResult(new ChatHistory());
+    }
+
+    [Fact]
+    public void InitializeChat_NoAgents_Throws()
+    {
+        var chatService = new ChatService(
+            kernelService: null!,
+            historyBuilder: new DummyHistoryBuilder(),
+            llmAgentCoordinator: new DefaultLlmAgentCoordinator(new DummyAgent()),
+            logger: new LoggerFactory().CreateLogger<ChatService>());
+
+        Assert.Throws<ArgumentException>(() => chatService.InitializeChat([]));
+    }
+}

--- a/ChatClient.Tests/StreamingMessageManagerTests.cs
+++ b/ChatClient.Tests/StreamingMessageManagerTests.cs
@@ -34,4 +34,15 @@ public class StreamingMessageManagerTests
         Assert.Equal("Hello", finalMessage.Content);
         Assert.Equal("stats", finalMessage.Statistics);
     }
+
+    [Fact]
+    public void CompleteStreaming_PreservesAgentName()
+    {
+        var manager = new StreamingMessageManager(null);
+        var streamingMessage = new StreamingAppChatMessage("Hello", DateTime.Now, ChatRole.Assistant, agentName: "Agent1");
+
+        var finalMessage = manager.CompleteStreaming(streamingMessage);
+
+        Assert.Equal("Agent1", finalMessage.AgentName);
+    }
 }

--- a/docs/multi-agent-chat.md
+++ b/docs/multi-agent-chat.md
@@ -6,7 +6,7 @@ This document outlines a proposal to extend **OllamaChat** with multi-agent conv
 ## Current State
 - `SystemPrompt` entries persist name, content, `AgentName`, and optional `ModelName` for each agent.
 - The system prompt editor (`SystemPrompts.razor`) lets users edit content, agent name, and choose an optional model.
-- Chats can initialize multiple `KernelAgent` instances, and a `ManagerAgent` with a `MultiAgentCoordinator` currently rotates responses in a round-robin fashion.
+- Chats can initialize multiple `KernelLlmAgent` instances, and a `ManagerLlmAgent` with a `MultiLlmAgentCoordinator` currently rotates responses in a round-robin fashion.
 - An `AutoContinue` toggle allows agents to keep responding without additional user input until the coordinator stops the loop.
 
 ## Design Goals
@@ -25,29 +25,29 @@ This document outlines a proposal to extend **OllamaChat** with multi-agent conv
 - Allow leaving the selection blank to fall back to the chat's main model.
 
 ### 3. Treat prompts as agents ✅
-- When initializing a chat, create a `KernelAgent` instance for each selected prompt, passing along its model preference.
-- Modify `ChatService` and `IChatService` to manage a list of active agents instead of a single prompt.
+- When initializing a chat, create a `KernelLlmAgent` instance for each selected prompt, passing along its model preference.
+- Modify `ChatService` and `IChatService` to manage a list of active LLM agents instead of a single prompt.
 
 ### 4. Manager agent and coordination ✅
-- Introduce a `ManagerAgent` derived from `AgentBase`. It receives the user's message and decides which agent should answer.
-- Implement a `MultiAgentCoordinator` that holds the manager and worker agents. It exposes `GetNextAgent()` by consulting the manager's response or, for now, a simple round-robin policy.
+- Introduce a `ManagerLlmAgent` derived from `LlmAgentBase`. It receives the user's message and decides which agent should answer.
+- Implement a `MultiLlmAgentCoordinator` that holds the manager and worker agents. It exposes `GetNextAgent()` by consulting the manager's response or, for now, a simple round-robin policy.
 
 ### 5. Automatic agent continuation ✅
 - Add an `AutoContinue` toggle allowing agents to converse without additional user messages.
-- Extend `IAgentCoordinator` with `ShouldContinueConversation` so it can stop the dialog after a defined number of cycles.
+- Extend `ILlmAgentCoordinator` with `ShouldContinueConversation` so it can stop the dialog after a defined number of cycles.
 
 ### 6. Multi-agent chat UI
 - Extend the chat-start screen to allow selection of multiple agents plus a manager prompt.
 - During conversation, display messages with each agent's name/Avatar to distinguish speakers.
 - Ensure a fallback to existing single-agent UI when only one agent is chosen.
 
-### 7. Service and history updates
+### 7. Service and history updates ✅
 - Adjust `ChatHistoryBuilder` to track messages from multiple agents; include agent names when constructing `ChatHistory` entries.
 - Ensure streaming responses and cancellation flow handle multiple simultaneous agent operations gracefully.
 
 ### 8. Testing
 - Add unit tests verifying that `SystemPromptService` correctly stores and retrieves `ModelName`.
-- Add tests for `MultiAgentCoordinator` to confirm agent rotation/selection logic.
+- Add tests for `MultiLlmAgentCoordinator` to confirm agent rotation/selection logic.
 
 ### 9. Documentation and examples
 - Create user-facing docs demonstrating how to create agents, assign models, and start a multi-agent chat.


### PR DESCRIPTION
## Summary
- rename agent response toggle to `UseAgentResponses` and update user settings
- rename agent abstractions to `LlmAgent` variants and update chat workflow and DI
- track originating agent names in chat history
- require at least one agent to start a chat and streamline coordinator selection

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_688e562e01f8832aad6534a95b5e48ae