### PR TITLE
Add tests for SystemPromptService and MultiLlmAgentCoordinator

### DIFF
--- a/ChatClient.Tests/MultiLlmAgentCoordinatorTests.cs
+++ b/ChatClient.Tests/MultiLlmAgentCoordinatorTests.cs
@@ -1,0 +1,43 @@
+using ChatClient.Api.Services;
+using ChatClient.Shared.LlmAgents;
+using ChatClient.Shared.Models;
+using Microsoft.SemanticKernel;
+using Microsoft.SemanticKernel.ChatCompletion;
+
+namespace ChatClient.Tests;
+
+public class MultiLlmAgentCoordinatorTests
+{
+    private class DummyAgent(string name) : ILlmAgent
+    {
+        public string Name { get; } = name;
+        public SystemPrompt? AgentDescription => null;
+        public IAsyncEnumerable<StreamingChatMessageContent> GetResponseAsync(
+            ChatHistory chatHistory,
+            PromptExecutionSettings promptExecutionSettings,
+            Kernel kernel,
+            CancellationToken cancellationToken = default) => AsyncEnumerable.Empty<StreamingChatMessageContent>();
+    }
+
+    [Fact]
+    public void GetNextAgent_RotatesThroughWorkers()
+    {
+        var manager = new DummyAgent("manager");
+        var worker1 = new DummyAgent("worker1");
+        var worker2 = new DummyAgent("worker2");
+        var coordinator = new MultiLlmAgentCoordinator(manager, new[] { worker1, worker2 });
+
+        Assert.Same(worker1, coordinator.GetNextAgent());
+        Assert.Same(worker2, coordinator.GetNextAgent());
+        Assert.Same(worker1, coordinator.GetNextAgent());
+    }
+
+    [Fact]
+    public void GetNextAgent_NoWorkers_ReturnsManager()
+    {
+        var manager = new DummyAgent("manager");
+        var coordinator = new MultiLlmAgentCoordinator(manager, Enumerable.Empty<ILlmAgent>());
+
+        Assert.Same(manager, coordinator.GetNextAgent());
+    }
+}

--- a/ChatClient.Tests/SystemPromptServiceTests.cs
+++ b/ChatClient.Tests/SystemPromptServiceTests.cs
@@ -1,0 +1,47 @@
+using ChatClient.Api.Services;
+using ChatClient.Shared.Models;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+
+namespace ChatClient.Tests;
+
+public class SystemPromptServiceTests
+{
+    [Fact]
+    public async Task CreatePrompt_PersistsModelName()
+    {
+        var tempFile = Path.GetTempFileName();
+        File.WriteAllText(tempFile, "[]");
+        try
+        {
+            var config = new ConfigurationBuilder()
+                .AddInMemoryCollection(new Dictionary<string, string?>
+                {
+                    ["SystemPrompts:FilePath"] = tempFile
+                })
+                .Build();
+
+            var logger = new LoggerFactory().CreateLogger<SystemPromptService>();
+            var service = new SystemPromptService(config, logger);
+
+            var prompt = new SystemPrompt
+            {
+                Name = "Test",
+                Content = "Test content",
+                ModelName = "test-model"
+            };
+
+            var created = await service.CreatePromptAsync(prompt);
+
+            var serviceReloaded = new SystemPromptService(config, logger);
+            var retrieved = await serviceReloaded.GetPromptByIdAsync(created.Id!.Value);
+
+            Assert.NotNull(retrieved);
+            Assert.Equal("test-model", retrieved!.ModelName);
+        }
+        finally
+        {
+            File.Delete(tempFile);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add coverage ensuring SystemPromptService persists and retrieves ModelName
- test MultiLlmAgentCoordinator's round-robin rotation and manager fallback

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_688e784d1e90832a854243da1bbb7798