### PR TITLE
refactor: introduce group chat orchestration

### DIFF
--- a/ChatClient.Api/Client/Layout/MainLayout.razor
+++ b/ChatClient.Api/Client/Layout/MainLayout.razor
@@ -19,7 +19,7 @@
 <CascadingValue Value="@autoSelectFunctions" Name="AutoSelectFunctions">
 <CascadingValue Value="@autoSelectCount" Name="AutoSelectCount">
 <CascadingValue Value="@useAgentResponses" Name="UseAgentResponses">
-<CascadingValue Value="@autoContinue" Name="AutoContinue">
+<CascadingValue Value="@maximumInvocationCount" Name="MaximumInvocationCount">
 <CascadingValue Value="@selectedModel" Name="SelectedModel">
 <MudLayout>
     <MudAppBar Elevation="1" Dense="true">
@@ -39,12 +39,14 @@
                          Size="Size.Small"
                          Dense="true"
                          Class="ml-4" />
-           <MudCheckBox @bind-Value="autoContinue"
-                         Label="Auto"
-                         Color="Color.Primary"
-                         Size="Size.Small"
-                         Dense="true"
-                         Class="ml-2" />
+           <MudNumericField T="int"
+                           @bind-Value="maximumInvocationCount"
+                           Min="1"
+                           Label="Rounds"
+                           Variant="Variant.Filled"
+                           Margin="Margin.Dense"
+                           Class="ml-2"
+                           Style="width: 100px;" />
            <MudButton OnClick="OpenFunctionsDialog"
                       Color="Color.Primary"
                       Variant="Variant.Text"
@@ -122,7 +124,7 @@
     private bool _isDarkMode = true;
     private bool isLLMAnswering;
     private bool useAgentResponses = false;
-    private bool autoContinue = false;
+    private int maximumInvocationCount = 1;
     private List<FunctionInfo> availableFunctions = new();
     private List<string> selectedFunctions = new();
     private bool autoSelectFunctions = false;

--- a/ChatClient.Api/Client/Pages/Chat.razor
+++ b/ChatClient.Api/Client/Pages/Chat.razor
@@ -105,8 +105,8 @@
                          </MudChatHeader>
 
                         @{
-                            var displayName = message.Role == Microsoft.Extensions.AI.ChatRole.Assistant 
-                                ? GetAgentDisplayName() 
+                            var displayName = message.Role == Microsoft.Extensions.AI.ChatRole.Assistant
+                                ? (message.AgentName ?? string.Empty)
                                 : userSettings.UserName;
                             var avatarText = GetAvatarText(displayName);
                         }
@@ -228,8 +228,8 @@
 
     [CascadingParameter(Name = "UseAgentResponses")]
     public bool UseAgentResponses { get; set; }
-    [CascadingParameter(Name = "AutoContinue")]
-    public bool AutoContinue { get; set; }
+    [CascadingParameter(Name = "MaximumInvocationCount")]
+    public int MaximumInvocationCount { get; set; }
     [CascadingParameter(Name = "SelectedModel")]
     public OllamaModel? SelectedModel { get; set; }
 
@@ -330,7 +330,7 @@
             UseAgentResponses,
             AutoSelectFunctions,
             AutoSelectCount,
-            AutoContinue);
+            MaximumInvocationCount);
 
         await ChatService.AddUserMessageAndAnswerAsync(messageData.text.Trim(), chatConfiguration, messageData.files);
         await ScrollToBottom();
@@ -432,14 +432,6 @@
         };
 
         await DialogService.ShowAsync<ImageViewerDialog>("Image Viewer", parameters, options);
-    }
-
-    private string GetAgentDisplayName()
-    {
-        var agentName = ChatService.AgentDescriptions.FirstOrDefault()?.AgentName;
-        return !string.IsNullOrWhiteSpace(agentName)
-            ? agentName
-            : userSettings.AgentName;
     }
 
     private string GetAvatarText(string? name)

--- a/ChatClient.Api/Client/Services/ChatService.cs
+++ b/ChatClient.Api/Client/Services/ChatService.cs
@@ -174,9 +174,9 @@ public class ChatService(
 
                 if (chatConfiguration.UseAgentResponses && _runtime != null)
                 {
-                    if (_chatOrchestration == null)
+                    if (_chatOrchestration == null || _groupChatManager.MaximumInvocationCount != chatConfiguration.MaximumInvocationCount)
                     {
-                        _groupChatManager = new RoundRobinGroupChatManager { MaximumInvocationCount = chatConfiguration.AutoContinue ? 5 : 1 };
+                        _groupChatManager = new RoundRobinGroupChatManager { MaximumInvocationCount = chatConfiguration.MaximumInvocationCount };
 
                         _agents.Clear();
                         foreach (var desc in _agentDescriptions)

--- a/ChatClient.Shared/Models/ChatConfiguration.cs
+++ b/ChatClient.Shared/Models/ChatConfiguration.cs
@@ -6,4 +6,4 @@ public record ChatConfiguration(
     bool UseAgentResponses,
     bool AutoSelectFunctions = false,
     int AutoSelectCount = 0,
-    bool AutoContinue = false);
+    int MaximumInvocationCount = 1);

--- a/ChatClient.Tests/MultiAgentTranslationRealOllamaTests.cs
+++ b/ChatClient.Tests/MultiAgentTranslationRealOllamaTests.cs
@@ -56,9 +56,8 @@ public class MultiAgentTranslationRealOllamaTests
         var result = await chatOrchestration.InvokeAsync("Привет, как дела?", runtime);
         await result.GetValueAsync(TimeSpan.FromSeconds(30));
 
-        foreach (var message in history)
-        {
-            Console.WriteLine($"{message.Role} ({message.AuthorName}): {message.Content}");
-        }
+        Assert.Equal(2, history.Count);
+        Assert.Contains("Hello", history[0].Content, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("Hola", history[1].Content, StringComparison.OrdinalIgnoreCase);
     }
 }

--- a/README.md
+++ b/README.md
@@ -1,2 +1,20 @@
 # OllamaChat
-Ollama chat client
+
+OllamaChat is a sample chat client for local LLMs powered by
+[Semantic Kernel](https://github.com/microsoft/semantic-kernel). It now
+supports multi‑agent conversations through the `GroupChatOrchestration` API.
+
+```csharp
+var orchestrator = new GroupChatOrchestration(
+    new RoundRobinGroupChatManager { MaximumInvocationCount = 2 },
+    agent1, agent2);
+
+await using var runtime = new InProcessRuntime();
+await runtime.StartAsync();
+var result = await orchestrator.InvokeAsync("Hello", runtime);
+string final = await result.GetValueAsync();
+```
+
+Each agent is a `ChatCompletionAgent` with its own system prompt. The round‑robin
+manager automatically rotates agents and stops after the specified number of
+rounds.


### PR DESCRIPTION
## Summary
- add `MaximumInvocationCount` to chat configuration and UI for round control
- rotate agents via `GroupChatOrchestration` and display agent names in chat
- document new multi-agent setup with built-in round-robin manager

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_688f553f672c832a889631f650827a4a