### PR TITLE
Add descriptions to chat agents

### DIFF
--- a/ChatClient.Api/Client/Services/ChatService.cs
+++ b/ChatClient.Api/Client/Services/ChatService.cs
@@ -184,6 +184,7 @@ public class ChatService(
                             _agents.Add(new ChatCompletionAgent
                             {
                                 Name = !string.IsNullOrWhiteSpace(desc.AgentName) ? desc.AgentName : desc.Name,
+                                Description = desc.Name,
                                 Instructions = desc.Content,
                                 Kernel = kernel
                             });

--- a/ChatClient.Tests/MultiAgentTranslationRealOllamaTests.cs
+++ b/ChatClient.Tests/MultiAgentTranslationRealOllamaTests.cs
@@ -25,6 +25,7 @@ public class MultiAgentTranslationRealOllamaTests
         var ruToEn = new ChatCompletionAgent
         {
             Name = "ru_to_en",
+            Description = "Russian to English translator",
             Instructions = "Translate the last message from Russian to English. Only reply with the English translation. If the last message isn't Russian, reply with nothing.",
             Kernel = kernel
         };
@@ -32,6 +33,7 @@ public class MultiAgentTranslationRealOllamaTests
         var enToEs = new ChatCompletionAgent
         {
             Name = "en_to_es",
+            Description = "English to Spanish translator",
             Instructions = "Translate the last message from English to Spanish. Only reply with the Spanish translation. If the last message isn't English, reply with 'OK'.",
             Kernel = kernel
         };

--- a/docs/multi-agent-chat.md
+++ b/docs/multi-agent-chat.md
@@ -8,6 +8,7 @@ multi-agent conversations. Every selected system prompt becomes a
 var ruToEn = new ChatCompletionAgent
 {
     Name = "ru_to_en",
+    Description = "Russian to English translator",
     Kernel = kernel,
     Instructions = "If last message is Russian, translate it to English."
 };
@@ -15,6 +16,7 @@ var ruToEn = new ChatCompletionAgent
 var enToEs = new ChatCompletionAgent
 {
     Name = "en_to_es",
+    Description = "English to Spanish translator",
     Kernel = kernel,
     Instructions = "If last message is English, translate it to Spanish."
 };


### PR DESCRIPTION
## Summary
- ensure ChatCompletionAgent instances provide required descriptions
- document agent descriptions in multi-agent chat example

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_688f646ddfe8832abf77afe493c825cb