### PR TITLE
Ensure Blazor dispatcher handles Chat events

### DIFF
--- a/ChatClient.Api/Client/Pages/Chat.razor
+++ b/ChatClient.Api/Client/Pages/Chat.razor
@@ -256,13 +256,19 @@
 
         ChatService.LoadingStateChanged += OnLoadingStateChanged;
         ChatViewModelService.ChatInitialized += OnChatInitialized;
-        ChatViewModelService.MessageAdded += async (msg) => await _messageAddedCallback.InvokeAsync(msg);
-        ChatViewModelService.MessageUpdated += async (msg) => await _messageUpdatedCallback.InvokeAsync(msg);
+        ChatViewModelService.MessageAdded += HandleMessageAdded;
+        ChatViewModelService.MessageUpdated += HandleMessageUpdated;
         ChatViewModelService.MessageDeleted += OnMessageDeleted;
 
         isLoadingInitialData = false;
         StateHasChanged();
     }
+
+    private void HandleMessageAdded(ChatMessageViewModel message) =>
+        _ = InvokeAsync(() => _messageAddedCallback.InvokeAsync(message));
+
+    private Task HandleMessageUpdated(ChatMessageViewModel message) =>
+        InvokeAsync(() => _messageUpdatedCallback.InvokeAsync(message));
 
     private void OnLoadingStateChanged(bool loading)
     {
@@ -274,7 +280,8 @@
     {
         StateHasChanged();
         await ScrollToBottom();
-    }    
+    }
+
     private void OnMessageUpdated(ChatMessageViewModel message)
     {
         StateHasChanged();
@@ -377,8 +384,8 @@
     {
         ChatService.LoadingStateChanged -= OnLoadingStateChanged;
         ChatViewModelService.ChatInitialized -= OnChatInitialized;
-        ChatViewModelService.MessageAdded -= async (msg) => await InvokeAsync(() => OnMessageAdded(msg));
-        ChatViewModelService.MessageUpdated -= (msg) => InvokeAsync(() => OnMessageUpdated(msg));
+        ChatViewModelService.MessageAdded -= HandleMessageAdded;
+        ChatViewModelService.MessageUpdated -= HandleMessageUpdated;
         ChatViewModelService.MessageDeleted -= OnMessageDeleted;
         return ValueTask.CompletedTask;
     }


### PR DESCRIPTION
## Summary
- Ensure UI event handlers in Chat component run on the Blazor dispatcher
- Use named handlers for message updates and properly unsubscribe on dispose

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_689469a906d8832a96e6f5e639d8d086