### PR TITLE
Use awaited message events

### DIFF
--- a/ChatClient.Api/Client/Pages/Chat.razor
+++ b/ChatClient.Api/Client/Pages/Chat.razor
@@ -238,13 +238,9 @@
 
     private UserSettings userSettings = new();
 
-    private readonly EventCallback<ChatMessageViewModel> _messageAddedCallback;
-    private readonly EventCallback<ChatMessageViewModel> _messageUpdatedCallback;
-
-    public Chat()
-    {
-        _messageAddedCallback = EventCallback.Factory.Create<ChatMessageViewModel>(this, OnMessageAdded);        _messageUpdatedCallback = EventCallback.Factory.Create<ChatMessageViewModel>(this, OnMessageUpdated);
-    }
+    private Func<ChatMessageViewModel, Task>? _messageAddedHandler;
+    private Func<ChatMessageViewModel, Task>? _messageUpdatedHandler;
+    private Func<ChatMessageViewModel, Task>? _messageDeletedHandler;
 
     protected override async Task OnInitializedAsync()
     {
@@ -256,9 +252,12 @@
 
         ChatService.LoadingStateChanged += OnLoadingStateChanged;
         ChatViewModelService.ChatInitialized += OnChatInitialized;
-        ChatViewModelService.MessageAdded += async (msg) => await _messageAddedCallback.InvokeAsync(msg);
-        ChatViewModelService.MessageUpdated += async (msg) => await _messageUpdatedCallback.InvokeAsync(msg);
-        ChatViewModelService.MessageDeleted += OnMessageDeleted;
+        _messageAddedHandler = msg => InvokeAsync(() => OnMessageAdded(msg));
+        _messageUpdatedHandler = msg => InvokeAsync(() => OnMessageUpdated(msg));
+        _messageDeletedHandler = msg => InvokeAsync(() => OnMessageDeleted(msg));
+        ChatViewModelService.MessageAdded += _messageAddedHandler;
+        ChatViewModelService.MessageUpdated += _messageUpdatedHandler;
+        ChatViewModelService.MessageDeleted += _messageDeletedHandler;
 
         isLoadingInitialData = false;
         StateHasChanged();
@@ -377,9 +376,12 @@
     {
         ChatService.LoadingStateChanged -= OnLoadingStateChanged;
         ChatViewModelService.ChatInitialized -= OnChatInitialized;
-        ChatViewModelService.MessageAdded -= async (msg) => await InvokeAsync(() => OnMessageAdded(msg));
-        ChatViewModelService.MessageUpdated -= (msg) => InvokeAsync(() => OnMessageUpdated(msg));
-        ChatViewModelService.MessageDeleted -= OnMessageDeleted;
+        if (_messageAddedHandler != null)
+            ChatViewModelService.MessageAdded -= _messageAddedHandler;
+        if (_messageUpdatedHandler != null)
+            ChatViewModelService.MessageUpdated -= _messageUpdatedHandler;
+        if (_messageDeletedHandler != null)
+            ChatViewModelService.MessageDeleted -= _messageDeletedHandler;
         return ValueTask.CompletedTask;
     }
 

--- a/ChatClient.Api/Client/Services/IChatViewModelService.cs
+++ b/ChatClient.Api/Client/Services/IChatViewModelService.cs
@@ -7,7 +7,7 @@ public interface IChatViewModelService
     bool IsLoading { get; }
     event Action<bool>? LoadingStateChanged;
     event Action? ChatInitialized;
-    event Action<ChatMessageViewModel>? MessageAdded;
+    event Func<ChatMessageViewModel, Task>? MessageAdded;
     event Func<ChatMessageViewModel, Task>? MessageUpdated;
-    event Action<ChatMessageViewModel>? MessageDeleted;
+    event Func<ChatMessageViewModel, Task>? MessageDeleted;
 }

--- a/ChatClient.Tests/ChatViewModelServiceTests.cs
+++ b/ChatClient.Tests/ChatViewModelServiceTests.cs
@@ -1,0 +1,98 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+using ChatClient.Api.Client.Services;
+using ChatClient.Shared.Models;
+
+using Microsoft.Extensions.AI;
+
+namespace ChatClient.Tests;
+
+public class ChatViewModelServiceTests
+{
+    private class StubChatService : IChatService
+    {
+        public bool IsLoading => false;
+        public IReadOnlyList<SystemPrompt> AgentDescriptions { get; } = [];
+        public event Action<bool>? LoadingStateChanged;
+        public event Action? ChatInitialized;
+        public event Func<IAppChatMessage, Task>? MessageAdded;
+        public event Func<IAppChatMessage, Task>? MessageUpdated;
+        public event Func<Guid, Task>? MessageDeleted;
+
+        public void InitializeChat(IEnumerable<SystemPrompt> initialAgents) { }
+        public void ClearChat() { }
+        public Task CancelAsync() => Task.CompletedTask;
+        public Task AddUserMessageAndAnswerAsync(string text, ChatConfiguration chatConfiguration, IReadOnlyList<ChatMessageFile> files) => Task.CompletedTask;
+        public Task DeleteMessageAsync(Guid id) => Task.CompletedTask;
+
+        public Task RaiseMessageAdded(IAppChatMessage message) => MessageAdded?.Invoke(message) ?? Task.CompletedTask;
+        public Task RaiseMessageUpdated(IAppChatMessage message) => MessageUpdated?.Invoke(message) ?? Task.CompletedTask;
+        public Task RaiseMessageDeleted(Guid id) => MessageDeleted?.Invoke(id) ?? Task.CompletedTask;
+    }
+
+    [Fact]
+    public async Task MessageEvents_AreAwaitedInOrder()
+    {
+        var chatService = new StubChatService();
+        var vmService = new ChatViewModelService(chatService);
+        var log = new List<string>();
+
+        vmService.MessageAdded += async vm => { log.Add("added-start"); await Task.Delay(10); log.Add("added-end"); };
+        vmService.MessageUpdated += async vm => { log.Add("updated-start"); await Task.Delay(10); log.Add("updated-end"); };
+        vmService.MessageDeleted += async vm => { log.Add("deleted-start"); await Task.Delay(10); log.Add("deleted-end"); };
+
+        var msg = new AppChatMessage("hello", DateTime.UtcNow, ChatRole.User);
+        await chatService.RaiseMessageAdded(msg);
+        log.Add("after-add");
+
+        var updated = new AppChatMessage(msg) { Content = "updated" };
+        await chatService.RaiseMessageUpdated(updated);
+        log.Add("after-update");
+
+        await chatService.RaiseMessageDeleted(msg.Id);
+        log.Add("after-delete");
+
+        Assert.Equal(new[]
+        {
+            "added-start", "added-end", "after-add",
+            "updated-start", "updated-end", "after-update",
+            "deleted-start", "deleted-end", "after-delete"
+        }, log);
+    }
+
+    [Fact]
+    public async Task MessageAddedHandler_ExceptionPropagates()
+    {
+        var chatService = new StubChatService();
+        var vmService = new ChatViewModelService(chatService);
+        vmService.MessageAdded += vm => throw new InvalidOperationException("boom");
+        var msg = new AppChatMessage("hi", DateTime.UtcNow, ChatRole.User);
+        await Assert.ThrowsAsync<InvalidOperationException>(() => chatService.RaiseMessageAdded(msg));
+    }
+
+    [Fact]
+    public async Task MessageUpdatedHandler_ExceptionPropagates()
+    {
+        var chatService = new StubChatService();
+        var vmService = new ChatViewModelService(chatService);
+        var msg = new AppChatMessage("hi", DateTime.UtcNow, ChatRole.User);
+        await chatService.RaiseMessageAdded(msg);
+        vmService.MessageUpdated += vm => throw new InvalidOperationException("boom");
+        var updated = new AppChatMessage(msg) { Content = "new" };
+        await Assert.ThrowsAsync<InvalidOperationException>(() => chatService.RaiseMessageUpdated(updated));
+    }
+
+    [Fact]
+    public async Task MessageDeletedHandler_ExceptionPropagates()
+    {
+        var chatService = new StubChatService();
+        var vmService = new ChatViewModelService(chatService);
+        var msg = new AppChatMessage("hi", DateTime.UtcNow, ChatRole.User);
+        await chatService.RaiseMessageAdded(msg);
+        vmService.MessageDeleted += vm => throw new InvalidOperationException("boom");
+        await Assert.ThrowsAsync<InvalidOperationException>(() => chatService.RaiseMessageDeleted(msg.Id));
+    }
+}
+


### PR DESCRIPTION
## Summary
- await view-model message events for safe background thread invocation
- hook Chat.razor to dispatcher with Task-returning handlers
- add tests ensuring message events are awaited and propagate errors

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68948c3c8a4c832a9bf3a7450b653bf3