### PR TITLE
Enable group chat orchestration for all chats

### DIFF
--- a/ChatClient.Tests/ChatServiceTests.cs
+++ b/ChatClient.Tests/ChatServiceTests.cs
@@ -4,6 +4,7 @@ using ChatClient.Shared.Models;
 using Microsoft.Extensions.Logging;
 using Microsoft.SemanticKernel;
 using Microsoft.SemanticKernel.ChatCompletion;
+using Microsoft.Extensions.AI;
 
 namespace ChatClient.Tests;
 
@@ -24,5 +25,21 @@ public class ChatServiceTests
             logger: new LoggerFactory().CreateLogger<ChatService>());
 
         Assert.Throws<ArgumentException>(() => chatService.InitializeChat([]));
+    }
+
+    [Fact]
+    public void InitializeChat_SingleAgent_AddsSystemMessage()
+    {
+        var chatService = new ChatService(
+            kernelService: null!,
+            historyBuilder: new DummyHistoryBuilder(),
+            logger: new LoggerFactory().CreateLogger<ChatService>());
+
+        var prompt = new SystemPrompt { Name = "Agent", Content = "Hello" };
+        chatService.InitializeChat([prompt]);
+
+        Assert.Single(chatService.Messages);
+        Assert.Equal(ChatRole.System, chatService.Messages[0].Role);
+        Assert.Equal("Hello", chatService.Messages[0].Content);
     }
 }

--- a/docs/multi-agent-chat.md
+++ b/docs/multi-agent-chat.md
@@ -1,8 +1,10 @@
 # Multi-Agent Chat
 
 OllamaChat now relies on Semantic Kernel's built-in **GroupChatOrchestration** for
-multi-agent conversations. Every selected system prompt becomes a
-`ChatCompletionAgent`, and a `RoundRobinGroupChatManager` rotates agents in turn.
+all conversations. Every selected system prompt becomes a `ChatCompletionAgent`,
+and a `RoundRobinGroupChatManager` rotates agents in turn. When only one agent is
+chosen, the orchestrator streams tokens through its `ResponseCallback`, so the
+client never talks to `IChatCompletionService` directly.
 
 ```csharp
 var ruToEn = new ChatCompletionAgent


### PR DESCRIPTION
## Summary
- Always orchestrate chats using GroupChatOrchestration and start runtime automatically
- Stream single-agent responses through ResponseCallback instead of IChatCompletionService
- Document that all conversations use orchestrator and add test for single agent initialization

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_6894d1927a74832aba4231dfaa2bb176