### PR TITLE
Add stop phrase and agent configuration for group chats

### DIFF
--- a/ChatClient.Api/Client/Layout/MainLayout.razor
+++ b/ChatClient.Api/Client/Layout/MainLayout.razor
@@ -21,6 +21,8 @@
 <CascadingValue Value="@useAgentResponses" Name="UseAgentResponses">
 <CascadingValue Value="@maximumInvocationCount" Name="MaximumInvocationCount">
 <CascadingValue Value="@selectedModel" Name="SelectedModel">
+<CascadingValue Value="@stopAgentName" Name="StopAgentName">
+<CascadingValue Value="@stopPhrase" Name="StopPhrase">
 <MudLayout>
     <MudAppBar Elevation="1" Dense="true">
         <MudIconButton Icon="@Icons.Material.Filled.Menu" Color="Color.Inherit" Edge="Edge.Start" OnClick="@((e) => DrawerToggle())" Size="Size.Medium" />
@@ -112,6 +114,8 @@
 </CascadingValue>
 </CascadingValue>
 </CascadingValue>
+</CascadingValue>
+</CascadingValue>
 
 <div id="blazor-error-ui" data-nosnippet>
     An unhandled error has occurred.
@@ -131,6 +135,8 @@
     private int autoSelectCount = 3;
     private List<OllamaModel> availableModels = new();
     private OllamaModel? selectedModel;
+    private string stopAgentName = string.Empty;
+    private string stopPhrase = string.Empty;
     private MudTheme? _theme = null;
 
     protected override async Task OnInitializedAsync()
@@ -146,6 +152,8 @@
         autoSelectCount = settings.DefaultAutoSelectCount > 0
             ? settings.DefaultAutoSelectCount
             : 3;
+        stopAgentName = settings.StopAgentName;
+        stopPhrase = settings.StopPhrase;
 
         try
         {

--- a/ChatClient.Api/Client/Pages/AppSettings.razor
+++ b/ChatClient.Api/Client/Pages/AppSettings.razor
@@ -132,6 +132,18 @@
 
                 <MudCard Class="mb-4" Elevation="1">
                     <MudCardHeader Class="pb-2">
+                        <MudText Class="section-header">Group Chat Stop Conditions</MudText>
+                    </MudCardHeader>
+                    <MudCardContent Class="pt-0">
+                        <MudTextField T="string" Label="Stop Agent Name" @bind-Value="_settings.StopAgentName"
+                                      Variant="Variant.Outlined" HelperText="Agent name that triggers chat termination" />
+                        <MudTextField T="string" Label="Stop Phrase" @bind-Value="_settings.StopPhrase"
+                                      Variant="Variant.Outlined" Class="mt-2" HelperText="Phrase that ends the group chat" />
+                    </MudCardContent>
+                </MudCard>
+
+                <MudCard Class="mb-4" Elevation="1">
+                    <MudCardHeader Class="pb-2">
                         <MudText Class="section-header">Embedding Model</MudText>
                     </MudCardHeader>
                     <MudCardContent Class="pt-0">

--- a/ChatClient.Api/Client/Pages/Chat.razor
+++ b/ChatClient.Api/Client/Pages/Chat.razor
@@ -232,6 +232,10 @@
     public int MaximumInvocationCount { get; set; }
     [CascadingParameter(Name = "SelectedModel")]
     public OllamaModel? SelectedModel { get; set; }
+    [CascadingParameter(Name = "StopAgentName")]
+    public string StopAgentName { get; set; } = string.Empty;
+    [CascadingParameter(Name = "StopPhrase")]
+    public string StopPhrase { get; set; } = string.Empty;
 
     private bool showAgentPrompt { get; set; } = false;
 
@@ -329,7 +333,9 @@
             UseAgentResponses,
             AutoSelectFunctions,
             AutoSelectCount,
-            MaximumInvocationCount);
+            MaximumInvocationCount,
+            StopAgentName,
+            StopPhrase);
 
         await ChatService.AddUserMessageAndAnswerAsync(messageData.text.Trim(), chatConfiguration, messageData.files);
         await ScrollToBottom();

--- a/ChatClient.Api/Client/Services/ChatService.cs
+++ b/ChatClient.Api/Client/Services/ChatService.cs
@@ -176,7 +176,10 @@ public class ChatService(
                 {
                     if (_chatOrchestration == null || _groupChatManager.MaximumInvocationCount != chatConfiguration.MaximumInvocationCount)
                     {
-                        _groupChatManager = new RoundRobinGroupChatManager { MaximumInvocationCount = chatConfiguration.MaximumInvocationCount };
+                        _groupChatManager = new ReasonableRoundRobinGroupChatManager(chatConfiguration.StopAgentName, chatConfiguration.StopPhrase)
+                        {
+                            MaximumInvocationCount = chatConfiguration.MaximumInvocationCount
+                        };
 
                         _agents.Clear();
                         foreach (var desc in _agentDescriptions)

--- a/ChatClient.Api/Client/Services/ReasonableRoundRobinGroupChatManager.cs
+++ b/ChatClient.Api/Client/Services/ReasonableRoundRobinGroupChatManager.cs
@@ -1,0 +1,40 @@
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.SemanticKernel.Agents.Orchestration.GroupChat;
+using Microsoft.SemanticKernel.ChatCompletion;
+
+#pragma warning disable SKEXP0110
+
+namespace ChatClient.Api.Client.Services;
+
+internal sealed class ReasonableRoundRobinGroupChatManager(string stopAgentName, string stopPhrase) : RoundRobinGroupChatManager
+{
+    private readonly string _stopAgentName = stopAgentName;
+    private readonly string _stopPhrase = stopPhrase;
+
+    public override async ValueTask<GroupChatManagerResult<bool>> ShouldTerminate(
+        ChatHistory history, CancellationToken cancellationToken = default)
+    {
+        var baseResult = await base.ShouldTerminate(history, cancellationToken);
+        if (baseResult.Value)
+        {
+            return baseResult;
+        }
+
+        if (string.IsNullOrWhiteSpace(_stopAgentName) || string.IsNullOrWhiteSpace(_stopPhrase))
+        {
+            return baseResult;
+        }
+
+        var lastByAgent = history.LastOrDefault(m => m.AuthorName == _stopAgentName);
+        if (lastByAgent?.ToString()?.Contains(_stopPhrase, StringComparison.OrdinalIgnoreCase) == true)
+        {
+            return new(true) { Reason = $"{_stopAgentName} said {_stopPhrase}" };
+        }
+
+        return baseResult;
+    }
+}
+#pragma warning restore SKEXP0110

--- a/ChatClient.Shared/Models/ChatConfiguration.cs
+++ b/ChatClient.Shared/Models/ChatConfiguration.cs
@@ -6,4 +6,6 @@ public record ChatConfiguration(
     bool UseAgentResponses,
     bool AutoSelectFunctions = false,
     int AutoSelectCount = 0,
-    int MaximumInvocationCount = 1);
+    int MaximumInvocationCount = 1,
+    string StopAgentName = "",
+    string StopPhrase = "");

--- a/ChatClient.Shared/Models/UserSettings.cs
+++ b/ChatClient.Shared/Models/UserSettings.cs
@@ -69,4 +69,10 @@ public class UserSettings
     /// </summary>
     [JsonPropertyName("embeddingModelName")]
     public string EmbeddingModelName { get; set; } = string.Empty;
+
+    [JsonPropertyName("stopAgentName")]
+    public string StopAgentName { get; set; } = string.Empty;
+
+    [JsonPropertyName("stopPhrase")]
+    public string StopPhrase { get; set; } = string.Empty;
 }


### PR DESCRIPTION
## Summary
- allow configuring stop agent name and phrase for multi-agent chats
- honor stop conditions in chat service via ReasonableRoundRobinGroupChatManager
- expose stop condition fields in user settings and chat UI

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_6895aadf84b8832aa5870431d6f64a69