### PR TITLE
feat: add multi-agent chat page

### DIFF
--- a/ChatClient.Api/Client/Layout/MainLayout.razor
+++ b/ChatClient.Api/Client/Layout/MainLayout.razor
@@ -211,7 +211,7 @@
     private bool IsOnChatPage()
     {
         var currentPath = NavigationManager.ToAbsoluteUri(NavigationManager.Uri).LocalPath;
-        return currentPath == "/" || currentPath == "/chat";
+        return currentPath == "/" || currentPath == "/chat" || currentPath == "/multi-agent-chat";
     }
 
     private void NewChat()

--- a/ChatClient.Api/Client/Layout/NavMenu.razor
+++ b/ChatClient.Api/Client/Layout/NavMenu.razor
@@ -1,5 +1,6 @@
 ﻿<MudNavMenu>
     <MudNavLink Href="/" Match="NavLinkMatch.All" Icon="@Icons.Material.Filled.Chat">Chat</MudNavLink>
+    <MudNavLink Href="multi-agent-chat" Match="NavLinkMatch.Prefix" Icon="@Icons.Material.Filled.Groups">Multi-Agent</MudNavLink>
     <MudNavLink Href="system-prompts" Match="NavLinkMatch.Prefix" Icon="@Icons.Material.Filled.List">Agents</MudNavLink>
     <MudNavLink Href="mcp-servers" Match="NavLinkMatch.Prefix" Icon="@Icons.Material.Filled.Link">MCP Servers</MudNavLink>
     <MudNavLink Href="models" Match="NavLinkMatch.Prefix" Icon="@Icons.Material.Filled.Memory">Models</MudNavLink>

--- a/ChatClient.Api/Client/Pages/MultiAgentChat.razor
+++ b/ChatClient.Api/Client/Pages/MultiAgentChat.razor
@@ -1,5 +1,4 @@
-@page "/"
-@page "/chat"
+@page "/multi-agent-chat"
 @using Microsoft.AspNetCore.Components
 @using Microsoft.AspNetCore.Components.Web
 @using System.Collections.ObjectModel
@@ -46,7 +45,7 @@
                 }
                 else
                 {
-                    <MudSelect T="SystemPrompt" Label="Select Agent" @bind-Value="selectedAgent" Variant="Variant.Outlined" FullWidth="true" Dense="true">
+                    <MudSelect T="SystemPrompt" Label="Select Agents" SelectedValues="selectedAgents" SelectedValuesChanged="@(items => selectedAgents = items.ToList())" MultiSelection="true" Variant="Variant.Outlined" FullWidth="true" Dense="true">
                         @foreach (var agent in agents)
                         {
                             <MudSelectItem Value="@agent">@agent.Name</MudSelectItem>
@@ -54,15 +53,23 @@
                     </MudSelect>
 
                     <MudSwitch T="bool" @bind-value="showAgentPrompt" Color="Color.Primary" Class="mt-4" Style="margin-bottom: 10px;">View Agent Prompt</MudSwitch>
-                    @if (showAgentPrompt && selectedAgent != null)
+                    @if (showAgentPrompt && selectedAgents.Any())
                     {
                         <div class="prompt-preview mt-3 pa-3 mb-2">
-                            <div class="mb-2">
-                                <strong>@selectedAgent.Name</strong>
-                                <div>@(selectedAgent.Content ?? string.Empty)</div>
-                            </div>
+                            @foreach (var agent in selectedAgents)
+                            {
+                                <div class="mb-2">
+                                    <strong>@agent.Name</strong>
+                                    <div>@(agent.Content ?? string.Empty)</div>
+                                </div>
+                            }
                         </div>
                     }
+
+                    <MudNumericField T="int" @bind-Value="maximumInvocationCount" Min="1" Label="Rounds" Variant="Variant.Outlined" FullWidth="true" Class="mt-4" />
+                    <MudTextField T="string" @bind-Value="stopAgentName" Label="Stop Agent" Variant="Variant.Outlined" FullWidth="true" Class="mt-4" />
+                    <MudTextField T="string" @bind-Value="stopPhrase" Label="Stop Phrase" Variant="Variant.Outlined" FullWidth="true" Class="mt-4" />
+
                     <MudButton Variant="Variant.Filled"
                                Color="Color.Primary"
                                FullWidth="true"
@@ -215,7 +222,7 @@
     private ElementReference messagesElement;
 
     private List<SystemPrompt> agents = new();
-    private SystemPrompt? selectedAgent { get; set; }
+    private List<SystemPrompt> selectedAgents { get; set; } = new();
     [CascadingParameter(Name = "SelectedFunctions")]
     public List<string> SelectedFunctions { get; set; } = new();
     [CascadingParameter(Name = "AutoSelectFunctions")]
@@ -230,6 +237,9 @@
 
     private bool showAgentPrompt { get; set; } = false;
 
+    private int maximumInvocationCount = 1;
+    private string stopAgentName = string.Empty;
+    private string stopPhrase = string.Empty;
 
     private UserSettings userSettings = new();
 
@@ -291,7 +301,7 @@
         agents = await AgentService.GetAllPromptsAsync();
         if (agents.Count == 0)
             agents.Add(AgentService.GetDefaultSystemPrompt());
-        selectedAgent = null;
+        selectedAgents = new List<SystemPrompt>();
     }
 
     private async Task LoadUserSettings()
@@ -301,15 +311,17 @@
         AutoSelectCount = userSettings.DefaultAutoSelectCount > 0
             ? userSettings.DefaultAutoSelectCount
             : 3;
+        stopAgentName = userSettings.StopAgentName;
+        stopPhrase = userSettings.StopPhrase;
     }
 
 
     private void StartChat()
     {
-        if (selectedAgent == null)
+        if (selectedAgents.Count == 0)
             return;
 
-        ChatService.InitializeChat(new[] { selectedAgent });
+        ChatService.InitializeChat(selectedAgents);
         chatStarted = true;
         StateHasChanged();
     }
@@ -324,9 +336,9 @@
             UseAgentResponses,
             AutoSelectFunctions,
             AutoSelectCount,
-            1,
-            string.Empty,
-            string.Empty);
+            maximumInvocationCount,
+            stopAgentName,
+            stopPhrase);
 
         await ChatService.AddUserMessageAndAnswerAsync(messageData.text.Trim(), chatConfiguration, messageData.files);
         await ScrollToBottom();


### PR DESCRIPTION
## Summary
- add MultiAgentChat page for multi-agent conversations with round and stop controls
- simplify Chat page for single-agent use
- link new page in navigation and share ChatService state

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_6895bdf12348832a8315f38bdb4aef5c