### PR TITLE
Enable multi-agent streaming and stats

### DIFF
--- a/ChatClient.Api/Client/Pages/MultiAgentChat.razor
+++ b/ChatClient.Api/Client/Pages/MultiAgentChat.razor
@@ -8,6 +8,8 @@
 @using System.Threading
 @using System.Text
 @using System.Linq
+@using System.Text.RegularExpressions
+@using System.Globalization
 @using MudBlazor
 @using ChatClient.Api.Client.Services
 @using ChatClient.Api.Client.Components
@@ -115,8 +117,17 @@
     else
     {
         <div class="chat-messages-container" @ref="messagesElement">
+            @if (agentStatistics.Any())
+            {
+                <MudPaper Class="pa-2 mb-2">
+                    @foreach (var stat in agentStatistics)
+                    {
+                        <MudText Typo="Typo.caption">@stat.Key: ⏱️ @stat.Value.TotalTime.TotalSeconds:F1s • 📊 @stat.Value.TokenCount tokens</MudText>
+                    }
+                </MudPaper>
+            }
             @foreach (var message in ChatViewModelService.Messages)
-            {                
+            {
                 @if (message.Role != Microsoft.Extensions.AI.ChatRole.System)
                 {
                     <MudChat Dense="true" ChatPosition="@(message.Role == Microsoft.Extensions.AI.ChatRole.Assistant ? ChatBubblePosition.Start : ChatBubblePosition.End)" @key="message.Id">
@@ -261,6 +272,7 @@
 
     private UserSettings userSettings = new();
     private List<string> availableFunctionNames = new();
+    private Dictionary<string, AgentStatistics> agentStatistics = new();
 
     private Func<ChatMessageViewModel, Task>? _messageAddedHandler;
     private Func<ChatMessageViewModel, Task>? _messageUpdatedHandler;
@@ -301,6 +313,10 @@
     }    
     private void OnMessageUpdated(ChatMessageViewModel message)
     {
+        if (!message.IsStreaming && !message.IsCanceled && !string.IsNullOrEmpty(message.AgentName) && !string.IsNullOrEmpty(message.Statistics))
+        {
+            UpdateAgentStatistics(message.AgentName!, message.Statistics!);
+        }
         StateHasChanged();
     }
 
@@ -312,6 +328,7 @@
     private void OnChatInitialized()
     {
         chatStarted = true;
+        agentStatistics.Clear();
         StateHasChanged();
     }
 
@@ -490,5 +507,39 @@
             return string.Empty;
 
         return name;
+    }
+
+    private void UpdateAgentStatistics(string agentName, string statistics)
+    {
+        double seconds = 0;
+        var timeMatch = Regex.Match(statistics, "⏱️\\s*([0-9]+(?:\\.[0-9]+)?)s");
+        if (timeMatch.Success)
+        {
+            double.TryParse(timeMatch.Groups[1].Value, NumberStyles.Float, CultureInfo.InvariantCulture, out seconds);
+        }
+
+        int tokens = 0;
+        var tokenMatch = Regex.Match(statistics, "📊\\s*([0-9]+) tokens");
+        if (tokenMatch.Success)
+        {
+            int.TryParse(tokenMatch.Groups[1].Value, NumberStyles.Integer, CultureInfo.InvariantCulture, out tokens);
+        }
+
+        if (!agentStatistics.TryGetValue(agentName, out var stats))
+        {
+            stats = new AgentStatistics();
+            agentStatistics[agentName] = stats;
+        }
+
+        stats.TotalTime += TimeSpan.FromSeconds(seconds);
+        stats.TokenCount += tokens;
+        stats.Messages++;
+    }
+
+    private sealed class AgentStatistics
+    {
+        public TimeSpan TotalTime { get; set; }
+        public int TokenCount { get; set; }
+        public int Messages { get; set; }
     }
 }

--- a/ChatClient.Tests/StreamingMessageManagerTests.cs
+++ b/ChatClient.Tests/StreamingMessageManagerTests.cs
@@ -1,3 +1,5 @@
+using System.Collections.Generic;
+
 using ChatClient.Api.Client.Services;
 using ChatClient.Shared.Models;
 
@@ -44,5 +46,26 @@ public class StreamingMessageManagerTests
         var finalMessage = manager.CompleteStreaming(streamingMessage);
 
         Assert.Equal("Agent1", finalMessage.AgentName);
+    }
+
+    [Fact]
+    public async Task AppendToMessageAsync_MultipleStreams_UpdatesCorrectly()
+    {
+        List<IAppChatMessage> updated = [];
+        var manager = new StreamingMessageManager(msg =>
+        {
+            updated.Add(msg);
+            return Task.CompletedTask;
+        });
+
+        var msg1 = manager.CreateStreamingMessage(agentName: "Agent1");
+        var msg2 = manager.CreateStreamingMessage(agentName: "Agent2");
+
+        await manager.AppendToMessageAsync(msg1.Id, "hi");
+        await manager.AppendToMessageAsync(msg2.Id, "bye");
+
+        Assert.Equal("hi", msg1.Content);
+        Assert.Equal("bye", msg2.Content);
+        Assert.Equal(2, updated.Count);
     }
 }


### PR DESCRIPTION
## Summary
- allow StreamingMessageManager to track multiple concurrent streams and append updates
- refactor ChatService to stream responses per agent and finalize with stats
- show per-agent streaming statistics in MultiAgentChat

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_6895f0043e50832a9ff39f750a5a643e