### PR TITLE
Introduce group chat strategy interface and stubs

### DIFF
--- a/ChatClient.Api/Client/Services/IGroupChatStrategy.cs
+++ b/ChatClient.Api/Client/Services/IGroupChatStrategy.cs
@@ -1,0 +1,22 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.SemanticKernel.Agents.Orchestration.GroupChat;
+using Microsoft.SemanticKernel.ChatCompletion;
+
+#pragma warning disable SKEXP0110
+
+namespace ChatClient.Api.Client.Services;
+
+internal interface IGroupChatStrategy
+{
+    ValueTask<GroupChatManagerResult<string>> SelectNextAgent(
+        ChatHistory history,
+        GroupChatTeam team,
+        CancellationToken cancellationToken = default);
+
+    ValueTask<GroupChatManagerResult<bool>> ShouldTerminate(
+        ChatHistory history,
+        CancellationToken cancellationToken = default);
+}
+
+#pragma warning restore SKEXP0110

--- a/ChatClient.Api/Client/Services/RandomGroupChatStrategy.cs
+++ b/ChatClient.Api/Client/Services/RandomGroupChatStrategy.cs
@@ -1,0 +1,25 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.SemanticKernel.Agents.Orchestration.GroupChat;
+using Microsoft.SemanticKernel.ChatCompletion;
+
+#pragma warning disable SKEXP0110
+
+namespace ChatClient.Api.Client.Services;
+
+internal sealed class RandomGroupChatStrategy : IGroupChatStrategy
+{
+    public ValueTask<GroupChatManagerResult<string>> SelectNextAgent(
+        ChatHistory history,
+        GroupChatTeam team,
+        CancellationToken cancellationToken = default)
+        => throw new NotImplementedException();
+
+    public ValueTask<GroupChatManagerResult<bool>> ShouldTerminate(
+        ChatHistory history,
+        CancellationToken cancellationToken = default)
+        => throw new NotImplementedException();
+}
+
+#pragma warning restore SKEXP0110

--- a/ChatClient.Api/Client/Services/SingleAgentGroupChatStrategy.cs
+++ b/ChatClient.Api/Client/Services/SingleAgentGroupChatStrategy.cs
@@ -1,0 +1,25 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.SemanticKernel.Agents.Orchestration.GroupChat;
+using Microsoft.SemanticKernel.ChatCompletion;
+
+#pragma warning disable SKEXP0110
+
+namespace ChatClient.Api.Client.Services;
+
+internal sealed class SingleAgentGroupChatStrategy : IGroupChatStrategy
+{
+    public ValueTask<GroupChatManagerResult<string>> SelectNextAgent(
+        ChatHistory history,
+        GroupChatTeam team,
+        CancellationToken cancellationToken = default)
+        => throw new NotImplementedException();
+
+    public ValueTask<GroupChatManagerResult<bool>> ShouldTerminate(
+        ChatHistory history,
+        CancellationToken cancellationToken = default)
+        => throw new NotImplementedException();
+}
+
+#pragma warning restore SKEXP0110

--- a/ChatClient.Api/Client/Services/StopPhraseEvaluator.cs
+++ b/ChatClient.Api/Client/Services/StopPhraseEvaluator.cs
@@ -1,0 +1,32 @@
+using System;
+using System.Linq;
+using Microsoft.SemanticKernel.Agents.Orchestration.GroupChat;
+using Microsoft.SemanticKernel.ChatCompletion;
+
+#pragma warning disable SKEXP0110
+
+namespace ChatClient.Api.Client.Services;
+
+internal sealed class StopPhraseEvaluator(string agentName, string phrase)
+{
+    public bool Evaluate(ChatHistory history, out GroupChatManagerResult<bool> result)
+    {
+        result = new(false);
+
+        if (string.IsNullOrWhiteSpace(agentName) || string.IsNullOrWhiteSpace(phrase))
+        {
+            return false;
+        }
+
+        var lastByAgent = history.LastOrDefault(m => m.AuthorName == agentName);
+        if (lastByAgent?.ToString()?.Contains(phrase, StringComparison.OrdinalIgnoreCase) == true)
+        {
+            result = new(true) { Reason = $"{agentName} said {phrase}" };
+            return true;
+        }
+
+        return false;
+    }
+}
+
+#pragma warning restore SKEXP0110


### PR DESCRIPTION
## Summary
- define `IGroupChatStrategy` for agent selection and termination
- refactor `ReasonableRoundRobinGroupChatManager` to use `StopPhraseEvaluator`
- add placeholder strategies for future extensions

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_6895f65aa33c832aba42f6f54edd2978