### PR TITLE
feat: add function selection to system prompts

### DIFF
--- a/ChatClient.Api/Client/Pages/SystemPrompts.razor
+++ b/ChatClient.Api/Client/Pages/SystemPrompts.razor
@@ -5,6 +5,7 @@
 @inject ISystemPromptService AgentService
 @inject ISnackbar Snackbar
 @inject IOllamaClientService OllamaService
+@inject KernelService KernelService
 
 <PageTitle>Agents Management</PageTitle>
 
@@ -174,6 +175,17 @@
             </MudSelect>
             <MudText Typo="Typo.caption">Leave blank to use chat's default model.</MudText>
 
+            <div class="mt-4">
+                <FunctionSelector AvailableFunctions="@availableFunctions"
+                                   SelectedFunctions="@editingAgent.Functions"
+                                   SelectedFunctionsChanged="@(v => editingAgent.Functions = v)"
+                                   @bind-Expanded="functionsExpanded"
+                                   AutoSelectFunctions="@editingAgent.AutoSelectFunctions"
+                                   AutoSelectFunctionsChanged="@(v => editingAgent.AutoSelectFunctions = v)"
+                                   AutoSelectCount="@editingAgent.AutoSelectCount"
+                                   AutoSelectCountChanged="@(v => editingAgent.AutoSelectCount = v)" />
+            </div>
+
             <MudTextField @bind-Value="editingAgent.Content"
                           Label="Agent Prompt"
                           Lines="10"
@@ -202,6 +214,8 @@
     private MudForm? editAgentForm;
     private MudDataGrid<SystemPrompt>? dataGrid;
     private List<OllamaModel> availableModels = new();
+    private List<FunctionInfo> availableFunctions = new();
+    private bool functionsExpanded;
     private DialogOptions dialogOptions = new()
     {
         CloseOnEscapeKey = true,
@@ -221,6 +235,7 @@
     {
         await LoadAgents();
         await LoadAvailableModels();
+        await LoadAvailableFunctions();
     }
 
     private async Task LoadAgents()
@@ -257,6 +272,18 @@
         }
     }
 
+    private async Task LoadAvailableFunctions()
+    {
+        try
+        {
+            availableFunctions = (await KernelService.GetAvailableFunctionsAsync()).ToList();
+        }
+        catch
+        {
+            availableFunctions = new();
+        }
+    }
+
     private void AddNewAgent()
     {
         editingAgent = new SystemPrompt
@@ -267,7 +294,9 @@
             Name = "",
             Content = "",
             ModelName = null,
-            Functions = new()
+            Functions = new(),
+            AutoSelectFunctions = false,
+            AutoSelectCount = 0
         };
 
         showEditAgentDialog = true;
@@ -304,7 +333,9 @@
             ModelName = agent.ModelName,
             CreatedAt = agent.CreatedAt,
             UpdatedAt = agent.UpdatedAt,
-            Functions = new List<string>(agent.Functions)
+            Functions = new List<string>(agent.Functions),
+            AutoSelectFunctions = agent.AutoSelectFunctions,
+            AutoSelectCount = agent.AutoSelectCount
         };
 
         showEditAgentDialog = true;

--- a/ChatClient.Shared/Models/SystemPrompt.cs
+++ b/ChatClient.Shared/Models/SystemPrompt.cs
@@ -10,6 +10,8 @@ public class SystemPrompt
     public string? AgentName { get; set; }
     public string? ModelName { get; set; }
     public List<string> Functions { get; set; } = new();
+    public bool AutoSelectFunctions { get; set; }
+    public int AutoSelectCount { get; set; }
     public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
     public DateTime UpdatedAt { get; set; } = DateTime.UtcNow;
 

--- a/ChatClient.Tests/SystemPromptServiceTests.cs
+++ b/ChatClient.Tests/SystemPromptServiceTests.cs
@@ -29,7 +29,9 @@ public class SystemPromptServiceTests
                 Name = "Test",
                 Content = "Test content",
                 ModelName = "test-model",
-                Functions = ["fn1", "fn2"]
+                Functions = ["fn1", "fn2"],
+                AutoSelectFunctions = true,
+                AutoSelectCount = 3
             };
 
             var created = await service.CreatePromptAsync(prompt);
@@ -40,6 +42,8 @@ public class SystemPromptServiceTests
             Assert.NotNull(retrieved);
             Assert.Equal("test-model", retrieved!.ModelName);
             Assert.Equal(["fn1", "fn2"], retrieved.Functions);
+            Assert.True(retrieved.AutoSelectFunctions);
+            Assert.Equal(3, retrieved.AutoSelectCount);
         }
         finally
         {


### PR DESCRIPTION
## Summary
- embed `FunctionSelector` in system prompt editor and load server functions
- track agent function preferences with new auto-select fields
- ensure prompt persistence through updated tests

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_6895f9a0faa0832abbad592156145ce5