### PR TITLE
feat: support agent-specific function selection

### DIFF
--- a/ChatClient.Api/Client/Pages/Chat.razor
+++ b/ChatClient.Api/Client/Pages/Chat.razor
@@ -216,8 +216,6 @@
 
     private List<AgentDescription> agents = new();
     private AgentDescription? selectedAgent { get; set; }
-    public bool AutoSelectFunctions { get; set; }
-    public int AutoSelectCount { get; set; }
 
     [CascadingParameter(Name = "UseAgentResponses")]
     public bool UseAgentResponses { get; set; }
@@ -293,10 +291,6 @@
     private async Task LoadUserSettings()
     {
         userSettings = await UserSettingsService.GetSettingsAsync();
-        AutoSelectFunctions = userSettings.DefaultAutoSelectCount > 0;
-        AutoSelectCount = userSettings.DefaultAutoSelectCount > 0
-            ? userSettings.DefaultAutoSelectCount
-            : 3;
     }
 
 
@@ -318,12 +312,7 @@
         var chatConfiguration = new ChatConfiguration(
             SelectedModel?.Name ?? string.Empty,
             functions,
-            UseAgentResponses,
-            AutoSelectFunctions,
-            AutoSelectCount,
-            1,
-            string.Empty,
-            string.Empty);
+            UseAgentResponses);
 
         await ChatService.AddUserMessageAndAnswerAsync(messageData.text.Trim(), chatConfiguration, messageData.files);
         await ScrollToBottom();

--- a/ChatClient.Api/Client/Pages/MultiAgentChat.razor
+++ b/ChatClient.Api/Client/Pages/MultiAgentChat.razor
@@ -256,8 +256,6 @@
 
     private List<AgentDescription> agents = new();
     private List<AgentDescription> selectedAgents { get; set; } = new();
-    public bool AutoSelectFunctions { get; set; }
-    public int AutoSelectCount { get; set; }
 
     [CascadingParameter(Name = "UseAgentResponses")]
     public bool UseAgentResponses { get; set; }
@@ -344,10 +342,6 @@
     private async Task LoadUserSettings()
     {
         userSettings = await UserSettingsService.GetSettingsAsync();
-        AutoSelectFunctions = userSettings.DefaultAutoSelectCount > 0;
-        AutoSelectCount = userSettings.DefaultAutoSelectCount > 0
-            ? userSettings.DefaultAutoSelectCount
-            : 3;
         stopAgentName = userSettings.StopAgentName;
         stopPhrase = userSettings.StopPhrase;
     }
@@ -390,8 +384,6 @@
             SelectedModel?.Name ?? string.Empty,
             allFunctions,
             UseAgentResponses,
-            AutoSelectFunctions,
-            AutoSelectCount,
             maximumInvocationCount,
             stopAgentName,
             stopPhrase);

--- a/ChatClient.Api/Client/Services/ChatService.cs
+++ b/ChatClient.Api/Client/Services/ChatService.cs
@@ -182,8 +182,8 @@ public class ChatService(
                         {
                             var agentKernel = await kernelService.CreateKernelAsync(
                                 chatConfiguration with { Functions = desc.Functions },
-                                chatConfiguration.AutoSelectFunctions ? userMessage : null,
-                                chatConfiguration.AutoSelectFunctions ? chatConfiguration.AutoSelectCount : null);
+                                desc.AutoSelectFunctions ? userMessage : null,
+                                desc.AutoSelectFunctions ? desc.AutoSelectCount : null);
 
                             agentKernel.FunctionInvocationFilters.Add(trackingFilter);
                             kernels.Add(agentKernel);

--- a/ChatClient.Api/Client/Services/StreamingMessageManager.cs
+++ b/ChatClient.Api/Client/Services/StreamingMessageManager.cs
@@ -92,11 +92,7 @@ public class StreamingMessageManager
         var statisticsBuilder = new System.Text.StringBuilder();
         statisticsBuilder.Append($"⏱️ {processingTime.TotalSeconds:F1}s");
         statisticsBuilder.Append($" • 🤖 {chatConfiguration.ModelName}");
-        if (chatConfiguration.AutoSelectFunctions && chatConfiguration.AutoSelectCount > 0)
-        {
-            statisticsBuilder.Append($" • 🔧 auto {chatConfiguration.AutoSelectCount}");
-        }
-        else if (chatConfiguration.Functions.Any())
+        if (chatConfiguration.Functions.Any())
         {
             statisticsBuilder.Append($" • 🔧 {chatConfiguration.Functions.Count} funcs");
         }

--- a/ChatClient.Shared/Models/ChatConfiguration.cs
+++ b/ChatClient.Shared/Models/ChatConfiguration.cs
@@ -4,8 +4,6 @@ public record ChatConfiguration(
     string ModelName,
     IReadOnlyCollection<string> Functions,
     bool UseAgentResponses,
-    bool AutoSelectFunctions = false,
-    int AutoSelectCount = 0,
     int MaximumInvocationCount = 1,
     string StopAgentName = "",
     string StopPhrase = "");

--- a/ChatClient.Tests/AgentDescriptionServiceTests.cs
+++ b/ChatClient.Tests/AgentDescriptionServiceTests.cs
@@ -29,7 +29,7 @@ public class AgentDescriptionServiceTests
                 Name = "Test",
                 Content = "Test content",
                 ModelName = "test-model",
-                Functions = ["fn1", "fn2"],
+                Functions = ["srv:fn1", "srv:fn2"],
                 AutoSelectFunctions = true,
                 AutoSelectCount = 3
             };
@@ -41,7 +41,7 @@ public class AgentDescriptionServiceTests
 
             Assert.NotNull(retrieved);
             Assert.Equal("test-model", retrieved!.ModelName);
-            Assert.Equal(["fn1", "fn2"], retrieved.Functions);
+            Assert.Equal(["srv:fn1", "srv:fn2"], retrieved.Functions);
             Assert.True(retrieved.AutoSelectFunctions);
             Assert.Equal(3, retrieved.AutoSelectCount);
         }


### PR DESCRIPTION
## Summary
- store per-agent function selections using full `server:function` names
- allow each agent to configure AutoSelect flags and counts independently
- simplify chat configuration and statistics to rely on agent settings

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68963229fb58832a9925ca93b88e4bf7