### PR TITLE
refactor: streamline multi-agent chat setup

### DIFF
--- a/ChatClient.Api/Client/Pages/MultiAgentChat.razor
+++ b/ChatClient.Api/Client/Pages/MultiAgentChat.razor
@@ -14,10 +14,8 @@
 @using ChatClient.Api.Client.Services
 @using ChatClient.Api.Client.Components
 @using ChatClient.Api.Client.ViewModels
-@using ChatClient.Api.Services
 
 @implements IAsyncDisposable
-@inject KernelService KernelService
 @inject IJSRuntime JSRuntime
 @inject NavigationManager NavigationManager
 @inject IDialogService DialogService
@@ -72,27 +70,6 @@
                     <MudNumericField T="int" @bind-Value="maximumInvocationCount" Min="1" Label="Rounds" Variant="Variant.Outlined" FullWidth="true" Class="mt-4" />
                     <MudTextField T="string" @bind-Value="stopAgentName" Label="Stop Agent" Variant="Variant.Outlined" FullWidth="true" Class="mt-4" />
                     <MudTextField T="string" @bind-Value="stopPhrase" Label="Stop Phrase" Variant="Variant.Outlined" FullWidth="true" Class="mt-4" />
-
-                    @if (selectedAgents.Any())
-                    {
-                        @foreach (var agent in selectedAgents)
-                        {
-                            <MudSelect T="string"
-                                       Label="@($"{agent.Name} Functions")"
-                                       SelectedValues="agent.Functions"
-                                       SelectedValuesChanged="funcs => agent.Functions = funcs.ToList()"
-                                       MultiSelection="true"
-                                       Variant="Variant.Outlined"
-                                       FullWidth="true"
-                                       Dense="true"
-                                       Class="mt-4">
-                                @foreach (var fn in availableFunctionNames)
-                                {
-                                    <MudSelectItem Value="@fn">@fn</MudSelectItem>
-                                }
-                            </MudSelect>
-                        }
-                    }
 
                     <MudButton Variant="Variant.Filled"
                                Color="Color.Primary"
@@ -269,7 +246,6 @@
     private string stopPhrase = string.Empty;
 
     private UserSettings userSettings = new();
-    private List<string> availableFunctionNames = new();
     private Dictionary<string, AgentStatistics> agentStatistics = new();
 
     private Func<ChatMessageViewModel, Task>? _messageAddedHandler;
@@ -283,7 +259,6 @@
 
         await LoadAgents();
         await LoadUserSettings();
-        await LoadAvailableFunctions();
 
         ChatService.LoadingStateChanged += OnLoadingStateChanged;
         ChatViewModelService.ChatInitialized += OnChatInitialized;
@@ -345,21 +320,6 @@
         stopAgentName = userSettings.StopAgentName;
         stopPhrase = userSettings.StopPhrase;
     }
-
-    private async Task LoadAvailableFunctions()
-    {
-        try
-        {
-            availableFunctionNames = (await KernelService.GetAvailableFunctionsAsync())
-                .Select(f => f.Name)
-                .ToList();
-        }
-        catch
-        {
-            availableFunctionNames = new List<string>();
-        }
-    }
-
 
     private void StartChat()
     {

--- a/ChatClient.Api/Client/Services/ChatService.cs
+++ b/ChatClient.Api/Client/Services/ChatService.cs
@@ -181,7 +181,13 @@ public class ChatService(
                         foreach (var desc in _agentDescriptions)
                         {
                             var agentKernel = await kernelService.CreateKernelAsync(
-                                chatConfiguration with { Functions = desc.Functions },
+                                chatConfiguration with
+                                {
+                                    Functions = desc.Functions,
+                                    ModelName = string.IsNullOrWhiteSpace(desc.ModelName)
+                                        ? chatConfiguration.ModelName
+                                        : desc.ModelName
+                                },
                                 desc.AutoSelectFunctions ? userMessage : null,
                                 desc.AutoSelectFunctions ? desc.AutoSelectCount : null);
 


### PR DESCRIPTION
## Summary
- remove MCP function selector from multi-agent chat start screen
- default to global model when agents omit their own

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68963526dd0c832aae6c335e285b469b