### PR TITLE
Move UI update debouncer to frontend

### DIFF
--- a/ChatClient.Api/Client/Pages/Chat.razor
+++ b/ChatClient.Api/Client/Pages/Chat.razor
@@ -209,6 +209,8 @@
 </OllamaCheck>
 
 @code {
+    private const int UpdateIntervalMs = 500;
+
     private bool isLLMAnswering { get; set; } = false;
     private bool isLoadingInitialData = true;
     private bool chatStarted = false;
@@ -227,8 +229,10 @@
 
     private UserSettings userSettings = new();
 
+    private StreamingDebouncer _renderDebouncer = null!;
+
     private Func<ChatMessageViewModel, Task>? _messageAddedHandler;
-    private Func<ChatMessageViewModel, Task>? _messageUpdatedHandler;
+    private Func<ChatMessageViewModel, bool, Task>? _messageUpdatedHandler;
     private Func<ChatMessageViewModel, Task>? _messageDeletedHandler;
 
     protected override async Task OnInitializedAsync()
@@ -241,8 +245,9 @@
 
         ChatService.LoadingStateChanged += OnLoadingStateChanged;
         ChatViewModelService.ChatInitialized += OnChatInitialized;
+        _renderDebouncer = new StreamingDebouncer(UpdateIntervalMs, () => InvokeAsync(StateHasChanged));
         _messageAddedHandler = msg => InvokeAsync(() => OnMessageAdded(msg));
-        _messageUpdatedHandler = msg => InvokeAsync(() => OnMessageUpdated(msg));
+        _messageUpdatedHandler = (msg, force) => InvokeAsync(() => OnMessageUpdated(msg, force));
         _messageDeletedHandler = msg => InvokeAsync(() => OnMessageDeleted(msg));
         ChatViewModelService.MessageAdded += _messageAddedHandler;
         ChatViewModelService.MessageUpdated += _messageUpdatedHandler;
@@ -263,9 +268,15 @@
         StateHasChanged();
         await ScrollToBottom();
     }    
-    private void OnMessageUpdated(ChatMessageViewModel message)
+    private Task OnMessageUpdated(ChatMessageViewModel message, bool forceRender)
     {
-        StateHasChanged();
+        if (forceRender)
+        {
+            return _renderDebouncer.FlushAsync();
+        }
+
+        _renderDebouncer.TriggerUpdate();
+        return Task.CompletedTask;
     }
 
     private void OnMessageDeleted(ChatMessageViewModel message)
@@ -368,6 +379,7 @@
             ChatViewModelService.MessageUpdated -= _messageUpdatedHandler;
         if (_messageDeletedHandler != null)
             ChatViewModelService.MessageDeleted -= _messageDeletedHandler;
+        _renderDebouncer.Dispose();
         return ValueTask.CompletedTask;
     }
 

--- a/ChatClient.Api/Client/Pages/MultiAgentChat.razor
+++ b/ChatClient.Api/Client/Pages/MultiAgentChat.razor
@@ -227,6 +227,8 @@
 
 @code {
     private bool isLLMAnswering { get; set; } = false;
+    private const int UpdateIntervalMs = 500;
+
     private bool isLoadingInitialData = true;
     private bool chatStarted = false;
     private ElementReference messagesElement;
@@ -248,8 +250,10 @@
     private UserSettings userSettings = new();
     private Dictionary<string, AgentStatistics> agentStatistics = new();
 
+    private StreamingDebouncer _renderDebouncer = null!;
+
     private Func<ChatMessageViewModel, Task>? _messageAddedHandler;
-    private Func<ChatMessageViewModel, Task>? _messageUpdatedHandler;
+    private Func<ChatMessageViewModel, bool, Task>? _messageUpdatedHandler;
     private Func<ChatMessageViewModel, Task>? _messageDeletedHandler;
 
     protected override async Task OnInitializedAsync()
@@ -262,8 +266,9 @@
 
         ChatService.LoadingStateChanged += OnLoadingStateChanged;
         ChatViewModelService.ChatInitialized += OnChatInitialized;
+        _renderDebouncer = new StreamingDebouncer(UpdateIntervalMs, () => InvokeAsync(StateHasChanged));
         _messageAddedHandler = msg => InvokeAsync(() => OnMessageAdded(msg));
-        _messageUpdatedHandler = msg => InvokeAsync(() => OnMessageUpdated(msg));
+        _messageUpdatedHandler = (msg, force) => InvokeAsync(() => OnMessageUpdated(msg, force));
         _messageDeletedHandler = msg => InvokeAsync(() => OnMessageDeleted(msg));
         ChatViewModelService.MessageAdded += _messageAddedHandler;
         ChatViewModelService.MessageUpdated += _messageUpdatedHandler;
@@ -284,13 +289,20 @@
         StateHasChanged();
         await ScrollToBottom();
     }    
-    private void OnMessageUpdated(ChatMessageViewModel message)
+    private Task OnMessageUpdated(ChatMessageViewModel message, bool forceRender)
     {
         if (!message.IsStreaming && !message.IsCanceled && !string.IsNullOrEmpty(message.AgentName) && !string.IsNullOrEmpty(message.Statistics))
         {
             UpdateAgentStatistics(message.AgentName!, message.Statistics!);
         }
-        StateHasChanged();
+
+        if (forceRender)
+        {
+            return _renderDebouncer.FlushAsync();
+        }
+
+        _renderDebouncer.TriggerUpdate();
+        return Task.CompletedTask;
     }
 
     private void OnMessageDeleted(ChatMessageViewModel message)
@@ -402,6 +414,7 @@
             ChatViewModelService.MessageUpdated -= _messageUpdatedHandler;
         if (_messageDeletedHandler != null)
             ChatViewModelService.MessageDeleted -= _messageDeletedHandler;
+        _renderDebouncer.Dispose();
         return ValueTask.CompletedTask;
     }
 

--- a/ChatClient.Api/Client/Services/IChatService.cs
+++ b/ChatClient.Api/Client/Services/IChatService.cs
@@ -11,7 +11,7 @@ public interface IChatService
     event Action<bool>? LoadingStateChanged;
     event Action? ChatInitialized;
     event Func<IAppChatMessage, Task>? MessageAdded;
-    event Func<IAppChatMessage, Task>? MessageUpdated;
+    event Func<IAppChatMessage, bool, Task>? MessageUpdated;
     event Func<Guid, Task>? MessageDeleted;
     void InitializeChat(IEnumerable<AgentDescription> initialAgents);
     void ClearChat();

--- a/ChatClient.Api/Client/Services/IChatViewModelService.cs
+++ b/ChatClient.Api/Client/Services/IChatViewModelService.cs
@@ -8,6 +8,6 @@ public interface IChatViewModelService
     event Action<bool>? LoadingStateChanged;
     event Action? ChatInitialized;
     event Func<ChatMessageViewModel, Task>? MessageAdded;
-    event Func<ChatMessageViewModel, Task>? MessageUpdated;
+    event Func<ChatMessageViewModel, bool, Task>? MessageUpdated;
     event Func<ChatMessageViewModel, Task>? MessageDeleted;
 }

--- a/ChatClient.Api/Client/Services/StreamingMessageManager.cs
+++ b/ChatClient.Api/Client/Services/StreamingMessageManager.cs
@@ -12,10 +12,10 @@ namespace ChatClient.Api.Client.Services;
 /// </summary>
 public class StreamingMessageManager
 {
-    private readonly Func<IAppChatMessage, Task>? _messageUpdatedCallback;
+    private readonly Func<IAppChatMessage, bool, Task>? _messageUpdatedCallback;
     private readonly Dictionary<Guid, StreamingAppChatMessage> _activeMessages = new();
 
-    public StreamingMessageManager(Func<IAppChatMessage, Task>? messageUpdatedCallback)
+    public StreamingMessageManager(Func<IAppChatMessage, bool, Task>? messageUpdatedCallback)
     {
         _messageUpdatedCallback = messageUpdatedCallback;
     }
@@ -45,7 +45,7 @@ public class StreamingMessageManager
             message.Append(content);
             if (_messageUpdatedCallback != null)
             {
-                await _messageUpdatedCallback(message);
+                await _messageUpdatedCallback(message, false);
             }
         }
     }

--- a/ChatClient.Tests/StreamingMessageManagerTests.cs
+++ b/ChatClient.Tests/StreamingMessageManagerTests.cs
@@ -52,7 +52,7 @@ public class StreamingMessageManagerTests
     public async Task AppendToMessageAsync_MultipleStreams_UpdatesCorrectly()
     {
         List<IAppChatMessage> updated = [];
-        var manager = new StreamingMessageManager(msg =>
+        var manager = new StreamingMessageManager((msg, _) =>
         {
             updated.Add(msg);
             return Task.CompletedTask;


### PR DESCRIPTION
## Summary
- push message update throttling into UI components with a shared `StreamingDebouncer`
- add `forceRender` flag to message update events to request immediate redraws
- propagate render flag through chat and streaming services

## Testing
- `dotnet test` *(fails: ChatClient.Tests.MultiAgentTests.CopyWriterReviewer_CreateSlogan)*

------
https://chatgpt.com/codex/tasks/task_e_689ad6b55c4c832ab99d512e52f94063