### PR TITLE
Simplify streaming debouncer logic

### DIFF
--- a/ChatClient.Api/Client/Pages/Chat.razor
+++ b/ChatClient.Api/Client/Pages/Chat.razor
@@ -270,13 +270,7 @@
     }    
     private Task OnMessageUpdated(ChatMessageViewModel message, bool forceRender)
     {
-        if (forceRender)
-        {
-            return _renderDebouncer.FlushAsync();
-        }
-
-        _renderDebouncer.TriggerUpdate();
-        return Task.CompletedTask;
+        return _renderDebouncer.TriggerAsync(forceRender);
     }
 
     private void OnMessageDeleted(ChatMessageViewModel message)
@@ -379,7 +373,6 @@
             ChatViewModelService.MessageUpdated -= _messageUpdatedHandler;
         if (_messageDeletedHandler != null)
             ChatViewModelService.MessageDeleted -= _messageDeletedHandler;
-        _renderDebouncer.Dispose();
         return ValueTask.CompletedTask;
     }
 

--- a/ChatClient.Api/Client/Pages/MultiAgentChat.razor
+++ b/ChatClient.Api/Client/Pages/MultiAgentChat.razor
@@ -296,13 +296,7 @@
             UpdateAgentStatistics(message.AgentName!, message.Statistics!);
         }
 
-        if (forceRender)
-        {
-            return _renderDebouncer.FlushAsync();
-        }
-
-        _renderDebouncer.TriggerUpdate();
-        return Task.CompletedTask;
+        return _renderDebouncer.TriggerAsync(forceRender);
     }
 
     private void OnMessageDeleted(ChatMessageViewModel message)
@@ -414,7 +408,6 @@
             ChatViewModelService.MessageUpdated -= _messageUpdatedHandler;
         if (_messageDeletedHandler != null)
             ChatViewModelService.MessageDeleted -= _messageDeletedHandler;
-        _renderDebouncer.Dispose();
         return ValueTask.CompletedTask;
     }
 

--- a/ChatClient.Api/Client/Services/StreamingDebouncer.cs
+++ b/ChatClient.Api/Client/Services/StreamingDebouncer.cs
@@ -1,104 +1,34 @@
 namespace ChatClient.Api.Client.Services;
 
 /// <summary>
-/// Handles debouncing of streaming updates with immediate first update and delayed subsequent updates
+/// Simple debouncer that triggers an update only if enough time has passed
+/// since the last call or when explicitly forced.
 /// </summary>
-public sealed class StreamingDebouncer : IDisposable
+public sealed class StreamingDebouncer
 {
     private readonly int _debounceDelayMs;
-    private readonly Timer _timer;
     private readonly Func<Task> _onUpdate;
-    private readonly object _lockObject = new();
-    private bool _hasFirstUpdate;
-    private bool _disposed;
+    private DateTime _lastUpdate = DateTime.MinValue;
 
     public StreamingDebouncer(int debounceDelayMs, Func<Task> onUpdate)
     {
         _debounceDelayMs = debounceDelayMs;
         _onUpdate = onUpdate;
-        _timer = new Timer(OnTimerCallback, null, Timeout.Infinite, Timeout.Infinite);
     }
 
     /// <summary>
-    /// Triggers an update - first update happens immediately, subsequent updates are debounced
+    /// Triggers the update callback if the debounce interval has elapsed or when forced.
     /// </summary>
-    public void TriggerUpdate()
+    public Task TriggerAsync(bool forceRender = false)
     {
-        if (_disposed)
-            return;
+        var now = DateTime.UtcNow;
 
-        lock (_lockObject)
+        if (forceRender || (now - _lastUpdate).TotalMilliseconds >= _debounceDelayMs)
         {
-            if (!_hasFirstUpdate)
-            {
-                _hasFirstUpdate = true;
-                // First update - execute immediately without waiting
-                _ = Task.Run(async () =>
-                {
-                    try
-                    {
-                        await _onUpdate();
-                    }
-                    catch (Exception)
-                    {
-                        // Swallow exceptions to prevent crashing the background task
-                    }
-                });
-                return;
-            }
-
-            // Subsequent updates - restart the debounce timer
-            _timer.Change(_debounceDelayMs, Timeout.Infinite);
-        }
-    }
-
-    /// <summary>
-    /// Force immediate execution of pending update
-    /// </summary>
-    public async Task FlushAsync()
-    {
-        if (_disposed)
-            return;
-
-        lock (_lockObject)
-        {
-            _timer.Change(Timeout.Infinite, Timeout.Infinite);
+            _lastUpdate = now;
+            return _onUpdate();
         }
 
-        try
-        {
-            await _onUpdate();
-        }
-        catch (Exception)
-        {
-            // Swallow exceptions as this is called in cleanup scenarios
-        }
-    }
-
-    private async void OnTimerCallback(object? state)
-    {
-        if (_disposed)
-            return;
-
-        try
-        {
-            await _onUpdate();
-        }
-        catch (Exception)
-        {
-            // Swallow exceptions to prevent crashing the timer callback
-        }
-    }
-
-    public void Dispose()
-    {
-        if (_disposed)
-            return;
-
-        lock (_lockObject)
-        {
-            _disposed = true;
-            _timer?.Dispose();
-        }
+        return Task.CompletedTask;
     }
 }

--- a/docs/chat-unification-improvements.md
+++ b/docs/chat-unification-improvements.md
@@ -58,12 +58,11 @@ internal sealed class SingleAgentGroupChatManager : RoundRobinGroupChatManager
 ```
 
 ### `StreamingDebouncer`
-Умный дебаунсер для стриминга:
+Простой дебаунсер для стриминга:
 ```csharp
-public sealed class StreamingDebouncer : IDisposable
+public sealed class StreamingDebouncer
 {
-    public void TriggerUpdate()        // Первое обновление - немедленно
-    public async Task FlushAsync()     // Принудительное финальное обновление
+    public Task TriggerAsync(bool forceRender = false);
 }
 ```
 


### PR DESCRIPTION
## Summary
- simplify streaming debouncer to time-based logic without timers
- streamline message update handling to use new debouncer interface
- remove unnecessary disposals

## Testing
- `dotnet test` *(fails: ChatClient.Tests.MultiAgentTests.CopyWriterReviewer_CreateSlogan - Connection refused (localhost:11434))*

------
https://chatgpt.com/codex/tasks/task_e_689af3b74b08832aa3edc45c0316ecc1