### PR TITLE
Refactor chat service interface names

### DIFF
--- a/ChatClient.Api/Client/Layout/MainLayout.razor
+++ b/ChatClient.Api/Client/Layout/MainLayout.razor
@@ -126,8 +126,8 @@
     {
         await base.OnInitializedAsync();
 
-        ChatService.LoadingStateChanged += OnLoadingStateChanged;
-        isLLMAnswering = ChatService.IsLoading;
+        ChatService.AnsweringStateChanged += OnAnsweringStateChanged;
+        isLLMAnswering = ChatService.IsAnswering;
 
         var settings = await UserSettingsService.GetSettingsAsync();
         useAgentResponses = settings.DefaultUseAgentResponses;
@@ -171,9 +171,9 @@
         _isDarkMode = !_isDarkMode;
     }
 
-    private void OnLoadingStateChanged(bool loading)
+    private void OnAnsweringStateChanged(bool answering)
     {
-        isLLMAnswering = loading;
+        isLLMAnswering = answering;
         InvokeAsync(StateHasChanged);
     }
 
@@ -252,7 +252,7 @@
 
     public ValueTask DisposeAsync()
     {
-        ChatService.LoadingStateChanged -= OnLoadingStateChanged;
+        ChatService.AnsweringStateChanged -= OnAnsweringStateChanged;
         return ValueTask.CompletedTask;
     }
 }

--- a/ChatClient.Api/Client/Pages/Chat.razor
+++ b/ChatClient.Api/Client/Pages/Chat.razor
@@ -243,8 +243,8 @@
         await LoadAgents();
         await LoadUserSettings();
 
-        ChatService.LoadingStateChanged += OnLoadingStateChanged;
-        ChatViewModelService.ChatInitialized += OnChatInitialized;
+        ChatService.AnsweringStateChanged += OnAnsweringStateChanged;
+        ChatViewModelService.ChatReset += OnChatReset;
         _renderDebouncer = new StreamingDebouncer(UpdateIntervalMs, () => InvokeAsync(StateHasChanged));
         _messageAddedHandler = msg => InvokeAsync(() => OnMessageAdded(msg));
         _messageUpdatedHandler = (msg, force) => InvokeAsync(() => OnMessageUpdated(msg, force));
@@ -257,9 +257,9 @@
         StateHasChanged();
     }
 
-    private void OnLoadingStateChanged(bool loading)
+    private void OnAnsweringStateChanged(bool answering)
     {
-        isLLMAnswering = loading;
+        isLLMAnswering = answering;
         StateHasChanged();
     }
 
@@ -278,7 +278,7 @@
         StateHasChanged();
     }
 
-    private void OnChatInitialized()
+    private void OnChatReset()
     {
         chatStarted = true;
         StateHasChanged();
@@ -322,7 +322,7 @@
             string.Empty, // No stop agent for single agent
             string.Empty); // No stop phrase for single agent
 
-        await ChatService.AddUserMessageAndAnswerAsync(messageData.text.Trim(), chatConfiguration, messageData.files);
+        await ChatService.GenerateAnswerAsync(messageData.text.Trim(), chatConfiguration, messageData.files);
         await ScrollToBottom();
     }
 
@@ -365,8 +365,8 @@
 
     public ValueTask DisposeAsync()
     {
-        ChatService.LoadingStateChanged -= OnLoadingStateChanged;
-        ChatViewModelService.ChatInitialized -= OnChatInitialized;
+        ChatService.AnsweringStateChanged -= OnAnsweringStateChanged;
+        ChatViewModelService.ChatReset -= OnChatReset;
         if (_messageAddedHandler != null)
             ChatViewModelService.MessageAdded -= _messageAddedHandler;
         if (_messageUpdatedHandler != null)

--- a/ChatClient.Api/Client/Pages/MultiAgentChat.razor
+++ b/ChatClient.Api/Client/Pages/MultiAgentChat.razor
@@ -264,8 +264,8 @@
         await LoadAgents();
         await LoadUserSettings();
 
-        ChatService.LoadingStateChanged += OnLoadingStateChanged;
-        ChatViewModelService.ChatInitialized += OnChatInitialized;
+        ChatService.AnsweringStateChanged += OnAnsweringStateChanged;
+        ChatViewModelService.ChatReset += OnChatReset;
         _renderDebouncer = new StreamingDebouncer(UpdateIntervalMs, () => InvokeAsync(StateHasChanged));
         _messageAddedHandler = msg => InvokeAsync(() => OnMessageAdded(msg));
         _messageUpdatedHandler = (msg, force) => InvokeAsync(() => OnMessageUpdated(msg, force));
@@ -278,9 +278,9 @@
         StateHasChanged();
     }
 
-    private void OnLoadingStateChanged(bool loading)
+    private void OnAnsweringStateChanged(bool answering)
     {
-        isLLMAnswering = loading;
+        isLLMAnswering = answering;
         StateHasChanged();
     }
 
@@ -304,7 +304,7 @@
         StateHasChanged();
     }
 
-    private void OnChatInitialized()
+    private void OnChatReset()
     {
         chatStarted = true;
         agentStatistics.Clear();
@@ -357,7 +357,7 @@
             stopAgentName,
             stopPhrase);
 
-        await ChatService.AddUserMessageAndAnswerAsync(messageData.text.Trim(), chatConfiguration, messageData.files);
+        await ChatService.GenerateAnswerAsync(messageData.text.Trim(), chatConfiguration, messageData.files);
         await ScrollToBottom();
     }
 
@@ -400,8 +400,8 @@
 
     public ValueTask DisposeAsync()
     {
-        ChatService.LoadingStateChanged -= OnLoadingStateChanged;
-        ChatViewModelService.ChatInitialized -= OnChatInitialized;
+        ChatService.AnsweringStateChanged -= OnAnsweringStateChanged;
+        ChatViewModelService.ChatReset -= OnChatReset;
         if (_messageAddedHandler != null)
             ChatViewModelService.MessageAdded -= _messageAddedHandler;
         if (_messageUpdatedHandler != null)

--- a/ChatClient.Api/Client/Services/IChatService.cs
+++ b/ChatClient.Api/Client/Services/IChatService.cs
@@ -6,16 +6,16 @@ namespace ChatClient.Api.Client.Services;
 
 public interface IChatService
 {
-    bool IsLoading { get; }
+    bool IsAnswering { get; }
     IReadOnlyList<AgentDescription> AgentDescriptions { get; }
-    event Action<bool>? LoadingStateChanged;
-    event Action? ChatInitialized;
+    event Action<bool>? AnsweringStateChanged;
+    event Action? ChatReset;
     event Func<IAppChatMessage, Task>? MessageAdded;
     event Func<IAppChatMessage, bool, Task>? MessageUpdated;
     event Func<Guid, Task>? MessageDeleted;
     void InitializeChat(IEnumerable<AgentDescription> initialAgents);
-    void ClearChat();
+    void ResetChat();
     Task CancelAsync();
-    Task AddUserMessageAndAnswerAsync(string text, ChatConfiguration chatConfiguration, IReadOnlyList<ChatMessageFile> files);
+    Task GenerateAnswerAsync(string text, ChatConfiguration chatConfiguration, IReadOnlyList<ChatMessageFile> files);
     Task DeleteMessageAsync(Guid id);
 }

--- a/ChatClient.Api/Client/Services/IChatViewModelService.cs
+++ b/ChatClient.Api/Client/Services/IChatViewModelService.cs
@@ -4,9 +4,9 @@ namespace ChatClient.Api.Client.Services;
 public interface IChatViewModelService
 {
     IReadOnlyList<ChatMessageViewModel> Messages { get; }
-    bool IsLoading { get; }
-    event Action<bool>? LoadingStateChanged;
-    event Action? ChatInitialized;
+    bool IsAnswering { get; }
+    event Action<bool>? AnsweringStateChanged;
+    event Action? ChatReset;
     event Func<ChatMessageViewModel, Task>? MessageAdded;
     event Func<ChatMessageViewModel, bool, Task>? MessageUpdated;
     event Func<ChatMessageViewModel, Task>? MessageDeleted;

--- a/ChatClient.Tests/ChatViewModelServiceTests.cs
+++ b/ChatClient.Tests/ChatViewModelServiceTests.cs
@@ -13,18 +13,18 @@ public class ChatViewModelServiceTests
 {
     private class StubChatService : IChatService
     {
-        public bool IsLoading => false;
+        public bool IsAnswering => false;
         public IReadOnlyList<AgentDescription> AgentDescriptions { get; } = [];
-        public event Action<bool>? LoadingStateChanged;
-        public event Action? ChatInitialized;
+        public event Action<bool>? AnsweringStateChanged;
+        public event Action? ChatReset;
         public event Func<IAppChatMessage, Task>? MessageAdded;
         public event Func<IAppChatMessage, bool, Task>? MessageUpdated;
         public event Func<Guid, Task>? MessageDeleted;
 
         public void InitializeChat(IEnumerable<AgentDescription> initialAgents) { }
-        public void ClearChat() { }
+        public void ResetChat() { }
         public Task CancelAsync() => Task.CompletedTask;
-        public Task AddUserMessageAndAnswerAsync(string text, ChatConfiguration chatConfiguration, IReadOnlyList<ChatMessageFile> files) => Task.CompletedTask;
+        public Task GenerateAnswerAsync(string text, ChatConfiguration chatConfiguration, IReadOnlyList<ChatMessageFile> files) => Task.CompletedTask;
         public Task DeleteMessageAsync(Guid id) => Task.CompletedTask;
 
         public Task RaiseMessageAdded(IAppChatMessage message) => MessageAdded?.Invoke(message) ?? Task.CompletedTask;


### PR DESCRIPTION
## Summary
- Rename IChatService's loading flag to `IsAnswering` with matching `AnsweringStateChanged` event
- Rename chat lifecycle members to `ChatReset` and `ResetChat`
- Introduce `GenerateAnswerAsync` for main response cycle and update usages

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_689b0bd6ee34832a8d5b3e157bc5066f