### PR TITLE
Remove unused Agent checkbox and configuration

### DIFF
--- a/ChatClient.Api/Client/Layout/MainLayout.razor
+++ b/ChatClient.Api/Client/Layout/MainLayout.razor
@@ -13,7 +13,6 @@
 <MudDialogProvider />
 <MudSnackbarProvider />
 <MudPopoverProvider />
-<CascadingValue Value="@useAgentResponses" Name="UseAgentResponses">
 <CascadingValue Value="@maximumInvocationCount" Name="MaximumInvocationCount">
 <CascadingValue Value="@selectedModel" Name="SelectedModel">
 <CascadingValue Value="@stopAgentName" Name="StopAgentName">
@@ -30,12 +29,6 @@
                        StartIcon="@Icons.Material.Filled.AddCircle"
                        Size="Size.Small"
                        Class="ml-4">New Chat</MudButton>
-           <MudCheckBox @bind-Value="useAgentResponses"
-                         Label="Agent"
-                         Color="Color.Primary"
-                         Size="Size.Small"
-                         Dense="true"
-                         Class="ml-4" />
            <MudNumericField T="int"
                            @bind-Value="maximumInvocationCount"
                            Min="1"
@@ -102,7 +95,6 @@
 </CascadingValue>
 </CascadingValue>
 </CascadingValue>
-</CascadingValue>
 
 <div id="blazor-error-ui" data-nosnippet>
     An unhandled error has occurred.
@@ -114,7 +106,6 @@
     private bool _drawerOpen = true;
     private bool _isDarkMode = true;
     private bool isLLMAnswering;
-    private bool useAgentResponses = false;
     private int maximumInvocationCount = 1;
     private List<OllamaModel> availableModels = new();
     private OllamaModel? selectedModel;
@@ -130,7 +121,6 @@
         isLLMAnswering = ChatService.IsAnswering;
 
         var settings = await UserSettingsService.GetSettingsAsync();
-        useAgentResponses = settings.DefaultUseAgentResponses;
         stopAgentName = settings.StopAgentName;
         stopPhrase = settings.StopPhrase;
 

--- a/ChatClient.Api/Client/Pages/AppSettings.razor
+++ b/ChatClient.Api/Client/Pages/AppSettings.razor
@@ -103,20 +103,6 @@
                         </MudCardContent>
                     </MudCard>
 
-                    <MudCard Class="mb-4" Elevation="1">
-                        <MudCardHeader Class="pb-2">
-                            <MudText Class="section-header">Default Chat Mode</MudText>
-                        </MudCardHeader>
-                    <MudCardContent Class="pt-0">
-                        <MudCheckBox @bind-Value="_settings.DefaultUseAgentResponses"
-                                     Label="Agent Responses by Default"
-                                     Color="Color.Primary" />
-                        <MudText Typo="Typo.caption" Class="mt-2">
-                            When enabled, new chats will start with agent responses instead of standard responses.
-                        </MudText>
-                    </MudCardContent>
-                </MudCard>
-
                 <MudCard Class="mb-4" Elevation="1">
                     <MudCardHeader Class="pb-2">
                         <MudText Class="section-header">Function Auto-Selection</MudText>

--- a/ChatClient.Api/Client/Pages/Chat.razor
+++ b/ChatClient.Api/Client/Pages/Chat.razor
@@ -219,8 +219,6 @@
     private List<AgentDescription> agents = new();
     private AgentDescription? selectedAgent { get; set; }
 
-    [CascadingParameter(Name = "UseAgentResponses")]
-    public bool UseAgentResponses { get; set; }
     [CascadingParameter(Name = "SelectedModel")]
     public OllamaModel? SelectedModel { get; set; }
 
@@ -317,7 +315,6 @@
         var chatConfiguration = new ChatConfiguration(
             SelectedModel?.Name ?? string.Empty,
             functions,
-            UseAgentResponses,
             1, // Single agent - always 1 invocation
             string.Empty, // No stop agent for single agent
             string.Empty); // No stop phrase for single agent

--- a/ChatClient.Api/Client/Pages/MultiAgentChat.razor
+++ b/ChatClient.Api/Client/Pages/MultiAgentChat.razor
@@ -236,8 +236,6 @@
     private List<AgentDescription> agents = new();
     private List<AgentDescription> selectedAgents { get; set; } = new();
 
-    [CascadingParameter(Name = "UseAgentResponses")]
-    public bool UseAgentResponses { get; set; }
     [CascadingParameter(Name = "SelectedModel")]
     public OllamaModel? SelectedModel { get; set; }
 
@@ -352,7 +350,6 @@
         var chatConfiguration = new ChatConfiguration(
             SelectedModel?.Name ?? string.Empty,
             allFunctions,
-            UseAgentResponses,
             invocationCount,
             stopAgentName,
             stopPhrase);

--- a/ChatClient.Shared/Models/ChatConfiguration.cs
+++ b/ChatClient.Shared/Models/ChatConfiguration.cs
@@ -3,7 +3,6 @@ namespace ChatClient.Shared.Models;
 public record ChatConfiguration(
     string ModelName,
     IReadOnlyCollection<string> Functions,
-    bool UseAgentResponses,
     int MaximumInvocationCount = 1,
     string StopAgentName = "",
     string StopPhrase = "");

--- a/ChatClient.Shared/Models/UserSettings.cs
+++ b/ChatClient.Shared/Models/UserSettings.cs
@@ -46,12 +46,6 @@ public class UserSettings
     public int McpSamplingTimeoutSeconds { get; set; } = 30 * 60;
 
     /// <summary>
-    /// Default response mode for new chats: true for Agent responses, false for standard responses
-    /// </summary>
-    [JsonPropertyName("defaultUseAgentResponses")]
-    public bool DefaultUseAgentResponses { get; set; } = false;
-
-    /// <summary>
     /// Number of functions to auto-select for new chats. Set to 0 to disable
     /// auto-selection.
     /// </summary>


### PR DESCRIPTION
## Summary
- drop unused "Agent" toggle from main toolbar
- clean up UserSettings and AppSettings from agent response mode
- remove `UseAgentResponses` from chat configuration and pages

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_689b30a8418c832a8dcf894c7f5ee338