### PR TITLE
Remove unused rounds field from top menu

### DIFF
--- a/ChatClient.Api/Client/Layout/MainLayout.razor
+++ b/ChatClient.Api/Client/Layout/MainLayout.razor
@@ -13,7 +13,6 @@
 <MudDialogProvider />
 <MudSnackbarProvider />
 <MudPopoverProvider />
-<CascadingValue Value="@maximumInvocationCount" Name="MaximumInvocationCount">
 <CascadingValue Value="@selectedModel" Name="SelectedModel">
 <CascadingValue Value="@stopAgentName" Name="StopAgentName">
 <CascadingValue Value="@stopPhrase" Name="StopPhrase">
@@ -29,14 +28,6 @@
                        StartIcon="@Icons.Material.Filled.AddCircle"
                        Size="Size.Small"
                        Class="ml-4">New Chat</MudButton>
-           <MudNumericField T="int"
-                           @bind-Value="maximumInvocationCount"
-                           Min="1"
-                           Label="Rounds"
-                           Variant="Variant.Filled"
-                           Margin="Margin.Dense"
-                           Class="ml-2"
-                           Style="width: 100px;" />
             <MudSelect T="OllamaModel"
                        Value="selectedModel"
                        ValueChanged="OnModelChanged"
@@ -94,7 +85,6 @@
 </CascadingValue>
 </CascadingValue>
 </CascadingValue>
-</CascadingValue>
 
 <div id="blazor-error-ui" data-nosnippet>
     An unhandled error has occurred.
@@ -106,7 +96,6 @@
     private bool _drawerOpen = true;
     private bool _isDarkMode = true;
     private bool isLLMAnswering;
-    private int maximumInvocationCount = 1;
     private List<OllamaModel> availableModels = new();
     private OllamaModel? selectedModel;
     private string stopAgentName = string.Empty;


### PR DESCRIPTION
## Summary
- remove unused "Rounds" numeric field from app bar
- drop unused MaximumInvocationCount cascade and backing field

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_689b43c402c4832aa01c77f93c6554de