### PR TITLE
Show streaming placeholder before first agent response

### DIFF
--- a/ChatClient.Shared/Models/StreamingAppChatMessage.cs
+++ b/ChatClient.Shared/Models/StreamingAppChatMessage.cs
@@ -50,6 +50,16 @@ public class StreamingAppChatMessage(string initialContent, DateTime msgDateTime
     {
         _contentBuilder.Append(text);
     }
+
+    public void ResetContent()
+    {
+        _contentBuilder.Clear();
+    }
+
+    public void SetAgentName(string? name)
+    {
+        AgentName = name;
+    }
     public void SetStatistics(string stats)
     {
         Statistics = stats;

--- a/ChatClient.Tests/StreamingAppChatMessageTests.cs
+++ b/ChatClient.Tests/StreamingAppChatMessageTests.cs
@@ -16,5 +16,24 @@ public class StreamingAppChatMessageTests
         Assert.Equal(0, msg.ApproximateTokenCount);
         Assert.Equal(0, msg.FunctionCallStartIndex);
     }
+
+    [Fact]
+    public void ResetContent_ClearsPlaceholder()
+    {
+        var msg = new StreamingAppChatMessage("...", DateTime.Now, ChatRole.Assistant);
+        msg.ResetContent();
+        msg.Append("hi");
+
+        Assert.Equal("hi", msg.Content);
+    }
+
+    [Fact]
+    public void SetAgentName_UpdatesName()
+    {
+        var msg = new StreamingAppChatMessage(string.Empty, DateTime.Now, ChatRole.Assistant);
+        msg.SetAgentName("Agent");
+
+        Assert.Equal("Agent", msg.AgentName);
+    }
 }
 


### PR DESCRIPTION
## Summary
- display a temporary "..." message while waiting for the first agent token
- reuse the placeholder as the agent's streaming message once the response starts
- add helper methods and unit tests for resetting content and updating agent name

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_689b47a09338832aac87b70279c140ab