### PR TITLE
Display agent name in placeholder message

### DIFF
--- a/ChatClient.Api/Client/Services/ChatService.cs
+++ b/ChatClient.Api/Client/Services/ChatService.cs
@@ -116,7 +116,10 @@ public class ChatService(
         await AddMessageAsync(new AppChatMessage(trimmedText, DateTime.Now, ChatRole.User, string.Empty, files));
 
         // Display a temporary placeholder while waiting for the first agent token
-        var placeholder = _streamingManager.CreateStreamingMessage();
+        var defaultAgentName = _agentDescriptions.FirstOrDefault()?.AgentName
+            ?? _agentDescriptions.FirstOrDefault()?.Name
+            ?? string.Empty;
+        var placeholder = _streamingManager.CreateStreamingMessage(agentName: defaultAgentName);
         placeholder.Append("...");
         _activeStreams[PlaceholderAgent] = placeholder;
         await AddMessageAsync(placeholder);


### PR DESCRIPTION
## Summary
- Show the first agent's name for temporary placeholder messages so the avatar isn't blank

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_689b5e224e4c832ab33637fb9bffd9d1