### PR TITLE
Remove duplicate streaming message tracking

### DIFF
--- a/ChatClient.Api/Client/Services/ChatService.cs
+++ b/ChatClient.Api/Client/Services/ChatService.cs
@@ -61,7 +61,7 @@ public class ChatService(
 
         Messages.Clear();
         _activeStreams.Clear();
-        _streamingManager = new StreamingMessageManager(MessageUpdated);
+        _streamingManager = new StreamingMessageManager();
         _agentDescriptions = agentsList;
 
         AddSystemMessages();

--- a/ChatClient.Tests/StreamingMessageManagerTests.cs
+++ b/ChatClient.Tests/StreamingMessageManagerTests.cs
@@ -1,5 +1,3 @@
-using System.Collections.Generic;
-
 using ChatClient.Api.Client.Services;
 using ChatClient.Shared.Models;
 
@@ -13,7 +11,7 @@ public class StreamingMessageManagerTests
     [Fact]
     public void CancelStreaming_WithContent_AppendsCancelMessage()
     {
-        var manager = new StreamingMessageManager(null);
+        var manager = new StreamingMessageManager();
         var streamingMessage = new StreamingAppChatMessage("Hello", DateTime.Now, ChatRole.Assistant);
         streamingMessage.Append(" world");
 
@@ -26,7 +24,7 @@ public class StreamingMessageManagerTests
     [Fact]
     public void CompleteStreaming_PreservesCanceledStatus()
     {
-        var manager = new StreamingMessageManager(null);
+        var manager = new StreamingMessageManager();
         var streamingMessage = new StreamingAppChatMessage("Hello", DateTime.Now, ChatRole.Assistant);
         streamingMessage.SetCanceled();
 
@@ -40,7 +38,7 @@ public class StreamingMessageManagerTests
     [Fact]
     public void CompleteStreaming_PreservesAgentName()
     {
-        var manager = new StreamingMessageManager(null);
+        var manager = new StreamingMessageManager();
         var streamingMessage = new StreamingAppChatMessage("Hello", DateTime.Now, ChatRole.Assistant, agentName: "Agent1");
 
         var finalMessage = manager.CompleteStreaming(streamingMessage);
@@ -48,24 +46,4 @@ public class StreamingMessageManagerTests
         Assert.Equal("Agent1", finalMessage.AgentName);
     }
 
-    [Fact]
-    public async Task AppendToMessageAsync_MultipleStreams_UpdatesCorrectly()
-    {
-        List<IAppChatMessage> updated = [];
-        var manager = new StreamingMessageManager((msg, _) =>
-        {
-            updated.Add(msg);
-            return Task.CompletedTask;
-        });
-
-        var msg1 = manager.CreateStreamingMessage(agentName: "Agent1");
-        var msg2 = manager.CreateStreamingMessage(agentName: "Agent2");
-
-        await manager.AppendToMessageAsync(msg1.Id, "hi");
-        await manager.AppendToMessageAsync(msg2.Id, "bye");
-
-        Assert.Equal("hi", msg1.Content);
-        Assert.Equal("bye", msg2.Content);
-        Assert.Equal(2, updated.Count);
-    }
 }


### PR DESCRIPTION
## Summary
- Simplify streaming message handling by eliminating internal active message tracking
- Instantiate `StreamingMessageManager` without callbacks and rely on `ChatService`'s active stream map
- Clean up tests to match revised manager API

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_689b631f4570832a80904072a417c2c2