### PR TITLE
refactor: unify function settings for agents

### DIFF
--- a/ChatClient.Api/Client/Pages/AgentDescriptions.razor
+++ b/ChatClient.Api/Client/Pages/AgentDescriptions.razor
@@ -199,13 +199,11 @@
             <MudText Typo="Typo.caption">Leave blank to use chat's default model.</MudText>
 
             <div class="mt-4">
-                <FunctionSelector AvailableFunctions="@availableFunctions"
-                                   SelectedFunctions="@editingAgent.Functions"
-                                   SelectedFunctionsChanged="@OnFunctionsChanged"
-                                   Expanded="true"
-                                   ExpandedChanged="@(v => functionsExpanded = v)"
-                                   AutoSelectCount="@editingAgent.AutoSelectCount"
-                                   AutoSelectCountChanged="@OnAutoSelectCountChanged" />
+                <FunctionSettingsSelector AvailableFunctions="@availableFunctions"
+                                          FunctionSettings="@editingAgent.FunctionSettings"
+                                          FunctionSettingsChanged="@OnFunctionSettingsChanged"
+                                          Expanded="true"
+                                          ExpandedChanged="@(v => functionsExpanded = v)" />
             </div>
 
             <MudTextField @bind-Value="editingAgent.Content"
@@ -316,8 +314,6 @@
             Name = "",
             Content = "",
             ModelName = null,
-            Functions = [],
-            AutoSelectCount = 0,
             FunctionSettings = new FunctionSettings
             {
                 AutoSelectCount = 0,
@@ -359,12 +355,10 @@
             ModelName = agent.ModelName,
             CreatedAt = agent.CreatedAt,
             UpdatedAt = agent.UpdatedAt,
-            Functions = new List<string>(agent.Functions),
-            AutoSelectCount = agent.AutoSelectCount,
             FunctionSettings = new FunctionSettings
             {
-                AutoSelectCount = agent.AutoSelectCount,
-                SelectedFunctions = new List<string>(agent.Functions)
+                AutoSelectCount = agent.FunctionSettings.AutoSelectCount,
+                SelectedFunctions = new List<string>(agent.FunctionSettings.SelectedFunctions)
             }
         };
 
@@ -428,29 +422,11 @@
     }
 
     private FunctionSettings GetFunctionSettings(AgentDescription agent)
-    {
-        // For backward compatibility, use the new FunctionSettings if available,
-        // otherwise create from legacy properties
-        if (agent.FunctionSettings?.HasFunctions == true)
-            return agent.FunctionSettings;
+        => agent.FunctionSettings;
 
-        return new FunctionSettings
-        {
-            AutoSelectCount = agent.AutoSelectCount,
-            SelectedFunctions = agent.Functions ?? []
-        };
-    }
-
-    private void OnFunctionsChanged(List<string> functions)
+    private void OnFunctionSettingsChanged(FunctionSettings settings)
     {
-        editingAgent.Functions = functions;
-        editingAgent.FunctionSettings.SelectedFunctions = new List<string>(functions);
-    }
-
-    private void OnAutoSelectCountChanged(int count)
-    {
-        editingAgent.AutoSelectCount = count;
-        editingAgent.FunctionSettings.AutoSelectCount = count;
+        editingAgent.FunctionSettings = settings;
     }
 
     private void CancelEdit()
@@ -465,10 +441,6 @@
         {
             try
             {
-                // Ensure legacy properties are synchronized with FunctionSettings
-                editingAgent.Functions = editingAgent.FunctionSettings.SelectedFunctions;
-                editingAgent.AutoSelectCount = editingAgent.FunctionSettings.AutoSelectCount;
-
                 if (editingAgent.Id == null)
                 {
                     var result = await AgentService.CreateAsync(editingAgent);

--- a/ChatClient.Api/Client/Pages/Chat.razor
+++ b/ChatClient.Api/Client/Pages/Chat.razor
@@ -298,10 +298,13 @@
 
     private void StartChat()
     {
-        if (selectedAgent == null)
-            return;
+        var agents = selectedAgent != null ? new[] { selectedAgent } : Array.Empty<AgentDescription>();
+        if (agents.Length != 1)
+        {
+            throw new InvalidOperationException("Single-agent chat requires exactly one agent.");
+        }
 
-        ChatService.InitializeChat(new[] { selectedAgent });
+        ChatService.InitializeChat(agents);
         chatStarted = true;
         StateHasChanged();
     }
@@ -311,7 +314,7 @@
         if (string.IsNullOrWhiteSpace(messageData.text) || isLLMAnswering) return;
         if (selectedAgent == null) return;
 
-        var functions = selectedAgent.Functions ?? [];
+        var functions = selectedAgent.FunctionSettings.SelectedFunctions ?? [];
         var chatConfiguration = new ChatConfiguration(SelectedModel?.Name, functions);
 
         await ChatService.GenerateAnswerAsync(messageData.text.Trim(), chatConfiguration, messageData.files);

--- a/ChatClient.Api/Client/Pages/MultiAgentChat.razor
+++ b/ChatClient.Api/Client/Pages/MultiAgentChat.razor
@@ -340,7 +340,7 @@
             return;
 
         var allFunctions = selectedAgents
-            .SelectMany(a => a.Functions)
+            .SelectMany(a => a.FunctionSettings.SelectedFunctions)
             .Distinct()
             .ToList();
 

--- a/ChatClient.Api/Client/Services/ChatService.cs
+++ b/ChatClient.Api/Client/Services/ChatService.cs
@@ -220,13 +220,13 @@ public class ChatService(
             var agentKernel = await kernelService.CreateKernelAsync(
                 chatConfiguration with
                 {
-                    Functions = desc.Functions,
+                    Functions = desc.FunctionSettings.SelectedFunctions,
                     ModelName = string.IsNullOrWhiteSpace(desc.ModelName)
                         ? chatConfiguration.ModelName
                         : desc.ModelName
                 },
-                desc.AutoSelectCount > 0 ? userMessage : null,
-                desc.AutoSelectCount > 0 ? desc.AutoSelectCount : null);
+                desc.FunctionSettings.AutoSelectCount > 0 ? userMessage : null,
+                desc.FunctionSettings.AutoSelectCount > 0 ? desc.FunctionSettings.AutoSelectCount : null);
 
             agentKernel.FunctionInvocationFilters.Add(trackingFilter);
 

--- a/ChatClient.Api/Services/AgentDescriptionService.cs
+++ b/ChatClient.Api/Services/AgentDescriptionService.cs
@@ -92,7 +92,6 @@ public class AgentDescriptionService : IAgentDescriptionService
 
             prompt.CreatedAt = DateTime.UtcNow;
             prompt.UpdatedAt = DateTime.UtcNow;
-            prompt.Functions ??= new();
 
             agents.Add(prompt);
             await WriteToFileAsync(agents);
@@ -125,7 +124,6 @@ public class AgentDescriptionService : IAgentDescriptionService
             }
 
             prompt.UpdatedAt = DateTime.UtcNow;
-            prompt.Functions ??= new();
             agents[existingIndex] = prompt;
 
             await WriteToFileAsync(agents);
@@ -180,11 +178,6 @@ public class AgentDescriptionService : IAgentDescriptionService
 
         var json = await File.ReadAllTextAsync(_filePath);
         var agents = JsonSerializer.Deserialize<List<AgentDescription>>(json) ?? [];
-
-        foreach (var agent in agents)
-        {
-            agent.Functions ??= new();
-        }
 
         return agents;
     }

--- a/ChatClient.Shared/Models/AgentDescription.cs
+++ b/ChatClient.Shared/Models/AgentDescription.cs
@@ -8,11 +8,6 @@ public class AgentDescription
     public string? AgentName { get; set; }
     public string? ModelName { get; set; }
 
-    // Legacy properties for backward compatibility
-    public List<string> Functions { get; set; } = [];
-    public int AutoSelectCount { get; set; }
-
-    // New unified function settings
     public FunctionSettings FunctionSettings { get; set; } = new();
 
     public DateTime CreatedAt { get; set; } = DateTime.UtcNow;

--- a/ChatClient.Tests/AgentDescriptionServiceTests.cs
+++ b/ChatClient.Tests/AgentDescriptionServiceTests.cs
@@ -30,8 +30,11 @@ public class AgentDescriptionServiceTests
                 Name = "Test",
                 Content = "Test content",
                 ModelName = "test-model",
-                Functions = ["srv:fn1", "srv:fn2"],
-                AutoSelectCount = 3
+                FunctionSettings = new FunctionSettings
+                {
+                    SelectedFunctions = ["srv:fn1", "srv:fn2"],
+                    AutoSelectCount = 3
+                }
             };
 
             var created = await service.CreateAsync(prompt);
@@ -41,8 +44,8 @@ public class AgentDescriptionServiceTests
 
             Assert.NotNull(retrieved);
             Assert.Equal("test-model", retrieved!.ModelName);
-            Assert.Equal(["srv:fn1", "srv:fn2"], retrieved.Functions);
-            Assert.Equal(3, retrieved.AutoSelectCount);
+            Assert.Equal(["srv:fn1", "srv:fn2"], retrieved.FunctionSettings.SelectedFunctions);
+            Assert.Equal(3, retrieved.FunctionSettings.AutoSelectCount);
         }
         finally
         {


### PR DESCRIPTION
## Summary
- drop legacy function list fields from `AgentDescription`
- update chat services and UI to use `FunctionSettings`
- ensure single-agent chat validates exactly one agent

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_689b98e0d984832a9ea46a55c35a25bb