### PR TITLE
Refactor kernel creation workflow

### DIFF
--- a/ChatClient.Api/Client/Services/ChatService.cs
+++ b/ChatClient.Api/Client/Services/ChatService.cs
@@ -173,16 +173,17 @@ public class ChatService(
 
         foreach (var desc in _agentDescriptions)
         {
+            var functionsToRegister = await kernelService.GetFunctionsToRegisterAsync(desc.FunctionSettings, userMessage);
+
             var agentKernel = await kernelService.CreateKernelAsync(
                 chatConfiguration with
                 {
-                    Functions = desc.FunctionSettings.SelectedFunctions,
+                    Functions = functionsToRegister,
                     ModelName = string.IsNullOrWhiteSpace(desc.ModelName)
                         ? chatConfiguration.ModelName
                         : desc.ModelName
                 },
-                desc.FunctionSettings.AutoSelectCount > 0 ? userMessage : null,
-                desc.FunctionSettings.AutoSelectCount > 0 ? desc.FunctionSettings.AutoSelectCount : null);
+                functionsToRegister);
 
             var agentName = !string.IsNullOrWhiteSpace(desc.ShortName) ? desc.ShortName : desc.AgentName;
 


### PR DESCRIPTION
## Summary
- split function selection and kernel creation into dedicated methods
- simplify CreateKernelAsync signature and register MCP tools separately
- update chat service to resolve functions before constructing kernels

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_689c6ac2c570832ab1980ae9c81f2e92