### PR TITLE
Refactor tracking filter handling

### DIFF
--- a/ChatClient.Api/Client/Services/TrackingFiltersScope.cs
+++ b/ChatClient.Api/Client/Services/TrackingFiltersScope.cs
@@ -1,19 +1,36 @@
-﻿#pragma warning disable SKEXP0110
+#pragma warning disable SKEXP0110
+
+using System;
+using System.Collections.Generic;
+
+using Microsoft.SemanticKernel.Agents.Runtime.InProcess;
 
 namespace ChatClient.Api.Client.Services;
 
 internal sealed class TrackingFiltersScope : IDisposable
 {
-    private readonly Action _onDispose;
+    public Dictionary<string, FunctionCallRecordingFilter> Filters { get; } = new();
+    private readonly List<Action> _onDispose = new();
 
-    public TrackingFiltersScope(Action onDispose)
+    public void Register(string agentName, FunctionCallRecordingFilter filter, Action unregister)
     {
-        _onDispose = onDispose;
+        Filters[agentName] = filter;
+        _onDispose.Add(unregister);
     }
 
     public void Dispose()
     {
-        _onDispose();
+        foreach (var action in _onDispose)
+        {
+            action();
+        }
+
+        foreach (var filter in Filters.Values)
+        {
+            filter.Clear();
+        }
+
+        Filters.Clear();
     }
 }
 

--- a/ChatClient.Shared/Models/StreamingAppChatMessage.cs
+++ b/ChatClient.Shared/Models/StreamingAppChatMessage.cs
@@ -19,7 +19,6 @@ public class StreamingAppChatMessage(string initialContent, DateTime msgDateTime
     public string? AgentName { get; private set; } = agentName;
 
     public int ApproximateTokenCount { get; set; }
-    public int FunctionCallStartIndex { get; set; }
 
     public Guid Id { get; private set; } = Guid.NewGuid();
 

--- a/ChatClient.Tests/StreamingAppChatMessageTests.cs
+++ b/ChatClient.Tests/StreamingAppChatMessageTests.cs
@@ -14,7 +14,6 @@ public class StreamingAppChatMessageTests
         var msg = new StreamingAppChatMessage("hello", DateTime.Now, ChatRole.Assistant);
 
         Assert.Equal(0, msg.ApproximateTokenCount);
-        Assert.Equal(0, msg.FunctionCallStartIndex);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- use TrackingFiltersScope to hold per-agent function recording filters
- drop FunctionCallStartIndex from streaming chat messages and handle all recorded calls

## Testing
- `dotnet test` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_689c722af41c832ab1f1efa013bf9171