### PR TITLE
Auto-grow chat input

### DIFF
--- a/ChatClient.Api/Client/Components/ChatInput.razor
+++ b/ChatClient.Api/Client/Components/ChatInput.razor
@@ -24,6 +24,8 @@
                       @bind-Value="CurrentText"
                       DebounceInterval="200"
                       Lines="3"
+                      MaxLines="15"
+                      AutoGrow="true"
                       Label="Type your message"
                       Variant="Variant.Outlined"
                       Style="flex-grow:1"


### PR DESCRIPTION
## Summary
- auto-expand chat input box up to 15 lines for long messages

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_689cd644df04832aba5c028aa6abc141