### PR TITLE
feat: send images in unified agent chat

### DIFF
--- a/ChatClient.Tests/ChatServiceTests.cs
+++ b/ChatClient.Tests/ChatServiceTests.cs
@@ -22,7 +22,8 @@ public class ChatServiceTests
     {
         var chatService = new ChatService(
             kernelService: null!,
-            logger: new LoggerFactory().CreateLogger<ChatService>());
+            logger: new LoggerFactory().CreateLogger<ChatService>(),
+            chatHistoryBuilder: new DummyHistoryBuilder());
 
         Assert.Throws<ArgumentException>(() => chatService.InitializeChat([]));
     }
@@ -32,7 +33,8 @@ public class ChatServiceTests
     {
         var chatService = new ChatService(
             kernelService: null!,
-            logger: new LoggerFactory().CreateLogger<ChatService>());
+            logger: new LoggerFactory().CreateLogger<ChatService>(),
+            chatHistoryBuilder: new DummyHistoryBuilder());
 
         var prompt = new AgentDescription { AgentName = "Agent", Content = "Hello" };
         chatService.InitializeChat([prompt]);


### PR DESCRIPTION
## Summary
- route all chats through `GroupChatOrchestration` and supply full history via `InputTransform`
- drop single-agent special case and simplify group chat manager setup

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_689cb651291c832aaa2ce6ded7ad9ed3