### PR TITLE
Skip MCP indexing when Ollama unavailable

### DIFF
--- a/ChatClient.Api/Client/Components/OllamaCheck.razor
+++ b/ChatClient.Api/Client/Components/OllamaCheck.razor
@@ -1,4 +1,3 @@
-@using ChatClient.Shared.Models
 @using ChatClient.Api.Services
 @using MudBlazor
 @inject IOllamaClientService OllamaService
@@ -14,37 +13,6 @@
         </div>
     </MudStack>
 }
-else if (!ollamaAvailable)
-{
-    <MudStack Justify="Justify.Center" AlignItems="AlignItems.Center" Style="height: 50vh;">
-        <div class="text-center">
-            <MudIcon Icon="@Icons.Material.Filled.Warning" Size="Size.Large" Color="Color.Warning" />
-            <MudText Typo="Typo.h6" Class="mt-2 mb-3">Ollama Server Required</MudText>
-            <MudText Class="mb-2">This page requires Ollama to be running.</MudText>
-
-            @if (!string.IsNullOrEmpty(errorMessage))
-            {
-                <MudText Typo="Typo.body2" Color="Color.Secondary" Class="mb-4">
-                    @errorMessage
-                </MudText>
-            }
-            <MudButtonGroup>
-                <MudButton Href="https://ollama.com"
-                           Target="_blank"
-                           Variant="Variant.Filled" Color="Color.Primary"
-                           StartIcon="@Icons.Material.Filled.OpenInNew">
-                    https://ollama.com
-                </MudButton>
-                <MudButton OnClick="CheckAgain"
-                           Variant="Variant.Outlined" Color="Color.Secondary"
-                           StartIcon="@Icons.Material.Filled.Refresh"
-                           Disabled="@isChecking">
-                    Try Again
-                </MudButton>
-            </MudButtonGroup>
-        </div>
-    </MudStack>
-}
 else
 {
     @ChildContent
@@ -54,15 +22,8 @@ else
     [Parameter] public RenderFragment? ChildContent { get; set; }
 
     private bool isChecking = true;
-    private bool ollamaAvailable = false;
-    private string? errorMessage;
 
     protected override async Task OnInitializedAsync()
-    {
-        await CheckOllamaStatus();
-    }
-
-    private async Task CheckAgain()
     {
         await CheckOllamaStatus();
     }
@@ -70,21 +31,15 @@ else
     private async Task CheckOllamaStatus()
     {
         isChecking = true;
-        StateHasChanged();
-
         try
         {
             await OllamaService.GetModelsAsync();
-            ollamaAvailable = true;
-            errorMessage = null;
-            Logger.LogInformation("Ollama is available for page access");
         }
         catch (Exception ex)
         {
-            ollamaAvailable = false;
-            var status = OllamaStatusHelper.CreateStatusFromException(ex);
-            errorMessage = status.ErrorMessage;
-            Logger.LogWarning(ex, "Ollama not available for page access: {ErrorMessage}", errorMessage);
+            Logger.LogWarning(ex, "Ollama not available for page access");
+            NavigationManager.NavigateTo("/ollama-connection-settings", true);
+            return;
         }
         finally
         {

--- a/ChatClient.Api/Program.cs
+++ b/ChatClient.Api/Program.cs
@@ -59,22 +59,21 @@ using (var scope = app.Services.CreateScope())
     var kernelService = scope.ServiceProvider.GetRequiredService<KernelService>();
     var mcpClientService = scope.ServiceProvider.GetRequiredService<IMcpClientService>();
     kernelService.SetMcpClientService(mcpClientService);
-    var indexService = scope.ServiceProvider.GetRequiredService<McpFunctionIndexService>();
-    await indexService.BuildIndexAsync();
 
-    // Check Ollama status at startup
     var startupChecker = scope.ServiceProvider.GetRequiredService<StartupOllamaChecker>();
     var ollamaStatus = await startupChecker.CheckOllamaStatusAsync();
 
-    if (!ollamaStatus.IsAvailable)
+    if (ollamaStatus.IsAvailable)
+    {
+        var indexService = scope.ServiceProvider.GetRequiredService<McpFunctionIndexService>();
+        await indexService.BuildIndexAsync();
+        Console.WriteLine("Ollama is available and ready.");
+    }
+    else
     {
         Console.WriteLine($"Warning: Ollama is not available - {ollamaStatus.ErrorMessage}");
         Console.WriteLine("The application will start but Ollama functionality will be limited.");
         Console.WriteLine("Users will be redirected to the setup page when trying to use Ollama features.");
-    }
-    else
-    {
-        Console.WriteLine("Ollama is available and ready.");
     }
 }
 

--- a/ChatClient.Api/Services/McpFunctionIndexService.cs
+++ b/ChatClient.Api/Services/McpFunctionIndexService.cs
@@ -51,6 +51,16 @@ public class McpFunctionIndexService
 
             _modelId = await DetermineModelIdAsync();
 
+            try
+            {
+                await _ollamaService.GetModelsAsync();
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Ollama is not available. Skipping MCP function indexing.");
+                return;
+            }
+
             var clients = await _clientService.GetMcpClientsAsync();
             foreach (var client in clients)
             {


### PR DESCRIPTION
## Summary
- Check Ollama availability before building MCP function index
- Redirect users to connection settings when Ollama is offline
- Short-circuit MCP index build if Ollama is down

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_689da84209d0832aabe898d1dbfcad83