### PR TITLE
feat: add round robin stop agent UI

### DIFF
--- a/ChatClient.Api/Client/Components/RoundRobinStopAgentParameters.razor
+++ b/ChatClient.Api/Client/Components/RoundRobinStopAgentParameters.razor
@@ -1,0 +1,25 @@
+@using MudBlazor
+@using ChatClient.Shared.Models.StopAgents
+
+<MudNumericField T="int"
+                 Value="Options.Rounds"
+                 ValueChanged="OnRoundsChanged"
+                 Min="1"
+                 Label="Rounds"
+                 Variant="Variant.Outlined"
+                 FullWidth="true"
+                 Class="mt-4" />
+
+@code {
+    [Parameter]
+    public RoundRobinStopAgentOptions Options { get; set; } = new();
+
+    [Parameter]
+    public EventCallback<RoundRobinStopAgentOptions> OptionsChanged { get; set; }
+
+    private async Task OnRoundsChanged(int value)
+    {
+        Options.Rounds = value;
+        await OptionsChanged.InvokeAsync(Options);
+    }
+}

--- a/ChatClient.Api/Client/Layout/MainLayout.razor
+++ b/ChatClient.Api/Client/Layout/MainLayout.razor
@@ -14,8 +14,6 @@
 <MudSnackbarProvider />
 <MudPopoverProvider />
 <CascadingValue Value="@selectedModel" Name="SelectedModel">
-<CascadingValue Value="@stopAgentName" Name="StopAgentName">
-<CascadingValue Value="@stopPhrase" Name="StopPhrase">
 <MudLayout>
     <MudAppBar Elevation="1" Dense="true">
         <MudIconButton Icon="@Icons.Material.Filled.Menu" Color="Color.Inherit" Edge="Edge.Start" OnClick="@((e) => DrawerToggle())" Size="Size.Medium" />
@@ -83,8 +81,6 @@
     }
 </MudLayout>
 </CascadingValue>
-</CascadingValue>
-</CascadingValue>
 
 <div id="blazor-error-ui" data-nosnippet>
     An unhandled error has occurred.
@@ -98,8 +94,6 @@
     private bool isLLMAnswering;
     private List<OllamaModel> availableModels = new();
     private OllamaModel? selectedModel;
-    private string stopAgentName = string.Empty;
-    private string stopPhrase = string.Empty;
     private MudTheme? _theme = null;
 
     protected override async Task OnInitializedAsync()
@@ -110,8 +104,6 @@
         isLLMAnswering = ChatService.IsAnswering;
 
         var settings = await UserSettingsService.GetSettingsAsync();
-        stopAgentName = settings.StopAgentName;
-        stopPhrase = settings.StopPhrase;
 
         try
         {

--- a/ChatClient.Api/Client/Pages/AppSettings.razor
+++ b/ChatClient.Api/Client/Pages/AppSettings.razor
@@ -123,8 +123,6 @@
                     <MudCardContent Class="pt-0">
                         <MudTextField T="string" Label="Stop Agent Name" @bind-Value="_settings.StopAgentName"
                                       Variant="Variant.Outlined" HelperText="Agent name that triggers chat termination" />
-                        <MudTextField T="string" Label="Stop Phrase" @bind-Value="_settings.StopPhrase"
-                                      Variant="Variant.Outlined" Class="mt-2" HelperText="Phrase that ends the group chat" />
                     </MudCardContent>
                 </MudCard>
 

--- a/ChatClient.Api/Client/Pages/Chat.razor
+++ b/ChatClient.Api/Client/Pages/Chat.razor
@@ -6,6 +6,7 @@
 @using System.Collections.Generic
 @using System.Text.Json
 @using ChatClient.Shared.Models
+@using ChatClient.Shared.Models.StopAgents
 @using System.Threading
 @using System.Text
 @using System.Linq
@@ -23,6 +24,7 @@
 @inject IChatService ChatService
 @inject IAgentDescriptionService AgentService
 @inject IUserSettingsService UserSettingsService
+@inject IStopAgentFactory StopAgentFactory
 
 <PageTitle>Chat with AI Assistant</PageTitle>
 
@@ -316,8 +318,9 @@
 
         var functions = selectedAgent.FunctionSettings.SelectedFunctions ?? [];
         var chatConfiguration = new ChatConfiguration(SelectedModel?.Name, functions);
-
-        await ChatService.GenerateAnswerAsync(messageData.text.Trim(), chatConfiguration, messageData.files);
+        var options = new RoundRobinStopAgentOptions { Rounds = 1 };
+        var groupChatManager = StopAgentFactory.Create("RoundRobin", options);
+        await ChatService.GenerateAnswerAsync(messageData.text.Trim(), chatConfiguration, groupChatManager, messageData.files);
         await ScrollToBottom();
     }
 

--- a/ChatClient.Api/Client/Pages/MultiAgentChat.razor
+++ b/ChatClient.Api/Client/Pages/MultiAgentChat.razor
@@ -5,6 +5,7 @@
 @using System.Collections.Generic
 @using System.Text.Json
 @using ChatClient.Shared.Models
+@using ChatClient.Shared.Models.StopAgents
 @using System.Threading
 @using System.Text
 @using System.Linq
@@ -23,6 +24,7 @@
 @inject IChatService ChatService
 @inject IAgentDescriptionService AgentService
 @inject IUserSettingsService UserSettingsService
+@inject IStopAgentFactory StopAgentFactory
 
 <PageTitle>Chat with AI Assistant</PageTitle>
 
@@ -67,9 +69,16 @@
                         </div>
                     }
 
-                    <MudNumericField T="int" @bind-Value="maximumInvocationCount" Min="1" Label="Rounds" Variant="Variant.Outlined" FullWidth="true" Class="mt-4" />
-                    <MudTextField T="string" @bind-Value="stopAgentName" Label="Stop Agent" Variant="Variant.Outlined" FullWidth="true" Class="mt-4" />
-                    <MudTextField T="string" @bind-Value="stopPhrase" Label="Stop Phrase" Variant="Variant.Outlined" FullWidth="true" Class="mt-4" />
+                    <MudSelect T="string" Label="Stop Agent" @bind-Value="stopAgentName" Variant="Variant.Outlined" FullWidth="true" Class="mt-4" Dense="true">
+                        @foreach (var agent in stopAgents)
+                        {
+                            <MudSelectItem Value="@agent">@agent</MudSelectItem>
+                        }
+                    </MudSelect>
+                    @if (stopAgentName == RoundRobinStopAgent)
+                    {
+                        <RoundRobinStopAgentParameters @bind-Options="roundRobinOptions" />
+                    }
 
                     <MudButton Variant="Variant.Filled"
                                Color="Color.Primary"
@@ -241,9 +250,10 @@
 
     private bool showAgentDescription { get; set; } = false;
 
-    private int maximumInvocationCount = 1;
-    private string stopAgentName = string.Empty;
-    private string stopPhrase = string.Empty;
+    private const string RoundRobinStopAgent = "RoundRobin";
+    private List<string> stopAgents = new() { RoundRobinStopAgent };
+    private RoundRobinStopAgentOptions roundRobinOptions = new();
+    private string stopAgentName = RoundRobinStopAgent;
 
     private UserSettings userSettings = new();
     private Dictionary<string, AgentStatistics> agentStatistics = new();
@@ -321,8 +331,9 @@
     private async Task LoadUserSettings()
     {
         userSettings = await UserSettingsService.GetSettingsAsync();
-        stopAgentName = userSettings.StopAgentName;
-        stopPhrase = userSettings.StopPhrase;
+        stopAgentName = string.IsNullOrWhiteSpace(userSettings.StopAgentName)
+            ? RoundRobinStopAgent
+            : userSettings.StopAgentName;
     }
 
     private void StartChat()
@@ -344,12 +355,13 @@
             .Distinct()
             .ToList();
 
-        // Automatically set invocation count: 1 for single agent, user-defined for multiple agents
-        var invocationCount = selectedAgents.Count == 1 ? 1 : maximumInvocationCount;
+        var rounds = selectedAgents.Count == 1 ? 1 : roundRobinOptions.Rounds;
 
         var chatConfiguration = new ChatConfiguration(SelectedModel?.Name, allFunctions);
+        var options = new RoundRobinStopAgentOptions { Rounds = rounds };
+        var groupChatManager = StopAgentFactory.Create(stopAgentName, options);
 
-        await ChatService.GenerateAnswerAsync(messageData.text.Trim(), chatConfiguration, messageData.files);
+        await ChatService.GenerateAnswerAsync(messageData.text.Trim(), chatConfiguration, groupChatManager, messageData.files);
         await ScrollToBottom();
     }
 

--- a/ChatClient.Api/Client/Services/ChatService.cs
+++ b/ChatClient.Api/Client/Services/ChatService.cs
@@ -100,7 +100,7 @@ public class ChatService(
         _activeStreams.Clear();
     }
 
-    public async Task GenerateAnswerAsync(string text, ChatConfiguration chatConfiguration, IReadOnlyList<ChatMessageFile>? files = null)
+    public async Task GenerateAnswerAsync(string text, ChatConfiguration chatConfiguration, GroupChatManager groupChatManager, IReadOnlyList<ChatMessageFile>? files = null)
     {
         if (string.IsNullOrWhiteSpace(text) || IsAnswering)
             return;
@@ -123,7 +123,6 @@ public class ChatService(
             await runtime.StartAsync(_cancellationTokenSource.Token);
 
             var agents = await CreateAgents(chatConfiguration, text, trackingScope);
-            var groupChatManager = CreateGroupChatManager(chatConfiguration);
 
             OrchestrationInputTransform<string> inputTransform = async (_, ct) =>
                 await chatHistoryBuilder.BuildChatHistoryAsync(Messages, agents[0].Kernel, ct);
@@ -207,13 +206,8 @@ public class ChatService(
         return agents;
     }
 
-    private RoundRobinGroupChatManager CreateGroupChatManager(ChatConfiguration chatConfiguration)
-    {
-        return new RoundRobinGroupChatManager { MaximumInvocationCount = 1 };
-    }
-
     private GroupChatOrchestration CreateChatOrchestration(
-        RoundRobinGroupChatManager groupChatManager,
+        GroupChatManager groupChatManager,
         List<ChatCompletionAgent> agents,
         ChatConfiguration chatConfiguration,
         TrackingFiltersScope trackingScope,

--- a/ChatClient.Api/Client/Services/IChatService.cs
+++ b/ChatClient.Api/Client/Services/IChatService.cs
@@ -1,4 +1,6 @@
 using ChatClient.Shared.Models;
+#pragma warning disable SKEXP0110
+using Microsoft.SemanticKernel.Agents.Orchestration.GroupChat;
 
 namespace ChatClient.Api.Client.Services;
 
@@ -16,6 +18,7 @@ public interface IChatService
     void InitializeChat(IEnumerable<AgentDescription> initialAgents);
     void ResetChat();
     Task CancelAsync();
-    Task GenerateAnswerAsync(string text, ChatConfiguration chatConfiguration, IReadOnlyList<ChatMessageFile> files);
+    Task GenerateAnswerAsync(string text, ChatConfiguration chatConfiguration, GroupChatManager groupChatManager, IReadOnlyList<ChatMessageFile> files);
     Task DeleteMessageAsync(Guid id);
 }
+#pragma warning restore SKEXP0110

--- a/ChatClient.Api/Client/Services/IStopAgentFactory.cs
+++ b/ChatClient.Api/Client/Services/IStopAgentFactory.cs
@@ -1,0 +1,11 @@
+using ChatClient.Shared.Models.StopAgents;
+using Microsoft.SemanticKernel.Agents.Orchestration.GroupChat;
+
+namespace ChatClient.Api.Client.Services;
+
+#pragma warning disable SKEXP0110
+public interface IStopAgentFactory
+{
+    GroupChatManager Create(string name, IStopAgentOptions? options = null);
+}
+#pragma warning restore SKEXP0110

--- a/ChatClient.Api/Client/Services/StopAgentFactory.cs
+++ b/ChatClient.Api/Client/Services/StopAgentFactory.cs
@@ -1,0 +1,21 @@
+using ChatClient.Shared.Models.StopAgents;
+using Microsoft.SemanticKernel.Agents.Orchestration.GroupChat;
+
+namespace ChatClient.Api.Client.Services;
+
+#pragma warning disable SKEXP0110
+internal class StopAgentFactory : IStopAgentFactory
+{
+    public GroupChatManager Create(string name, IStopAgentOptions? options = null) => name switch
+    {
+        "RoundRobin" => CreateRoundRobin(options as RoundRobinStopAgentOptions),
+        _ => CreateRoundRobin(options as RoundRobinStopAgentOptions)
+    };
+
+    private static GroupChatManager CreateRoundRobin(RoundRobinStopAgentOptions? opts)
+    {
+        var rounds = opts?.Rounds ?? 1;
+        return new RoundRobinGroupChatManager { MaximumInvocationCount = rounds };
+    }
+}
+#pragma warning restore SKEXP0110

--- a/ChatClient.Api/Program.cs
+++ b/ChatClient.Api/Program.cs
@@ -41,6 +41,7 @@ builder.Services.AddSingleton<ChatClient.Shared.Services.IAgentDescriptionServic
 builder.Services.AddSingleton<ChatClient.Shared.Services.IUserSettingsService, ChatClient.Api.Services.UserSettingsService>();
 builder.Services.AddScoped<ChatClient.Api.Client.Services.IChatService, ChatClient.Api.Client.Services.ChatService>();
 builder.Services.AddScoped<ChatClient.Api.Client.Services.IChatViewModelService, ChatClient.Api.Client.Services.ChatViewModelService>();
+builder.Services.AddSingleton<ChatClient.Api.Client.Services.IStopAgentFactory, ChatClient.Api.Client.Services.StopAgentFactory>();
 
 builder.Services.AddRazorPages();
 builder.Services.AddServerSideBlazor();

--- a/ChatClient.Shared/Models/ChatConfiguration.cs
+++ b/ChatClient.Shared/Models/ChatConfiguration.cs
@@ -1,3 +1,5 @@
 namespace ChatClient.Shared.Models;
 
-public record ChatConfiguration(string ModelName, IReadOnlyCollection<string> Functions);
+public record ChatConfiguration(
+    string ModelName,
+    IReadOnlyCollection<string> Functions);

--- a/ChatClient.Shared/Models/StopAgents/IStopAgentOptions.cs
+++ b/ChatClient.Shared/Models/StopAgents/IStopAgentOptions.cs
@@ -1,0 +1,5 @@
+namespace ChatClient.Shared.Models.StopAgents;
+
+public interface IStopAgentOptions
+{
+}

--- a/ChatClient.Shared/Models/StopAgents/RoundRobinStopAgentOptions.cs
+++ b/ChatClient.Shared/Models/StopAgents/RoundRobinStopAgentOptions.cs
@@ -1,0 +1,6 @@
+namespace ChatClient.Shared.Models.StopAgents;
+
+public class RoundRobinStopAgentOptions : IStopAgentOptions
+{
+    public int Rounds { get; set; } = 1;
+}

--- a/ChatClient.Shared/Models/UserSettings.cs
+++ b/ChatClient.Shared/Models/UserSettings.cs
@@ -66,7 +66,4 @@ public class UserSettings
 
     [JsonPropertyName("stopAgentName")]
     public string StopAgentName { get; set; } = string.Empty;
-
-    [JsonPropertyName("stopPhrase")]
-    public string StopPhrase { get; set; } = string.Empty;
 }

--- a/ChatClient.Tests/ChatViewModelServiceTests.cs
+++ b/ChatClient.Tests/ChatViewModelServiceTests.cs
@@ -6,6 +6,7 @@ using ChatClient.Api.Client.Services;
 using ChatClient.Shared.Models;
 
 using Microsoft.Extensions.AI;
+using Microsoft.SemanticKernel.Agents.Orchestration.GroupChat;
 
 namespace ChatClient.Tests;
 
@@ -24,7 +25,9 @@ public class ChatViewModelServiceTests
         public void InitializeChat(IEnumerable<AgentDescription> initialAgents) { }
         public void ResetChat() { }
         public Task CancelAsync() => Task.CompletedTask;
-        public Task GenerateAnswerAsync(string text, ChatConfiguration chatConfiguration, IReadOnlyList<ChatMessageFile> files) => Task.CompletedTask;
+#pragma warning disable SKEXP0110
+        public Task GenerateAnswerAsync(string text, ChatConfiguration chatConfiguration, GroupChatManager groupChatManager, IReadOnlyList<ChatMessageFile> files) => Task.CompletedTask;
+#pragma warning restore SKEXP0110
         public Task DeleteMessageAsync(Guid id) => Task.CompletedTask;
 
         public Task RaiseMessageAdded(IAppChatMessage message) => MessageAdded?.Invoke(message) ?? Task.CompletedTask;


### PR DESCRIPTION
## Summary
- remove stop-agent fields from chat configuration
- create stop-agent factory with round-robin options
- wire pages to factory and bind round-robin parameters

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_689dc589e55c832a87bd1dfca29490ba