### PR TITLE
fix: remove redundant system messages in multi-agent chat

### DIFF
--- a/ChatClient.Api/Client/Services/ChatService.cs
+++ b/ChatClient.Api/Client/Services/ChatService.cs
@@ -56,17 +56,7 @@ public class ChatService(
         _streamingManager = new StreamingMessageManager();
         _agentDescriptions = agents;
 
-        AddSystemMessages();
         ChatReset?.Invoke();
-    }
-
-    private void AddSystemMessages()
-    {
-        foreach (var agent in _agentDescriptions)
-        {
-            var systemMessage = new AppChatMessage(agent.Content, DateTime.Now, ChatRole.System, string.Empty);
-            Messages.Add(systemMessage);
-        }
     }
 
     public void ResetChat()

--- a/ChatClient.Tests/ChatServiceTests.cs
+++ b/ChatClient.Tests/ChatServiceTests.cs
@@ -29,7 +29,7 @@ public class ChatServiceTests
     }
 
     [Fact]
-    public void InitializeChat_SingleAgent_AddsSystemMessage()
+    public void InitializeChat_SingleAgent_NoSystemMessage()
     {
         var chatService = new ChatService(
             kernelService: null!,
@@ -39,8 +39,6 @@ public class ChatServiceTests
         var prompt = new AgentDescription { AgentName = "Agent", Content = "Hello" };
         chatService.InitializeChat([prompt]);
 
-        Assert.Single(chatService.Messages);
-        Assert.Equal(ChatRole.System, chatService.Messages[0].Role);
-        Assert.Equal("Hello", chatService.Messages[0].Content);
+        Assert.Empty(chatService.Messages);
     }
 }


### PR DESCRIPTION
## Summary
- avoid injecting system messages during chat initialization
- adjust unit test to reflect absence of system messages

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_689e0b13ddd4832a83078dcac8328b02