### PR TITLE
Add agent-specific temperature and repetition penalty

### DIFF
--- a/ChatClient.Api/Client/Services/ChatService.cs
+++ b/ChatClient.Api/Client/Services/ChatService.cs
@@ -182,16 +182,30 @@ public class ChatService(
             agentKernel.FunctionInvocationFilters.Add(trackingFilter);
             trackingScope.Register(agentName, trackingFilter, () => agentKernel.FunctionInvocationFilters.Remove(trackingFilter));
 
+            var settings = new PromptExecutionSettings
+            {
+                FunctionChoiceBehavior = FunctionChoiceBehavior.Auto(autoInvoke: true)
+            };
+
+            if (desc.Temperature.HasValue)
+            {
+                settings.ExtensionData ??= new Dictionary<string, object>();
+                settings.ExtensionData["temperature"] = desc.Temperature.Value;
+            }
+
+            if (desc.RepeatPenalty.HasValue)
+            {
+                settings.ExtensionData ??= new Dictionary<string, object>();
+                settings.ExtensionData["repeat_penalty"] = desc.RepeatPenalty.Value;
+            }
+
             agents.Add(new ChatCompletionAgent
             {
                 Name = agentName,
                 Description = desc.AgentName,
                 Instructions = desc.Content,
                 Kernel = agentKernel,
-                Arguments = new KernelArguments(new PromptExecutionSettings
-                {
-                    FunctionChoiceBehavior = FunctionChoiceBehavior.Auto(autoInvoke: true)
-                })
+                Arguments = new KernelArguments(settings)
             });
         }
 

--- a/ChatClient.Shared/Models/AgentDescription.cs
+++ b/ChatClient.Shared/Models/AgentDescription.cs
@@ -7,6 +7,8 @@ public class AgentDescription
     public string Content { get; set; } = string.Empty;
     public string? ShortName { get; set; }
     public string? ModelName { get; set; }
+    public double? Temperature { get; set; }
+    public double? RepeatPenalty { get; set; }
 
     public FunctionSettings FunctionSettings { get; set; } = new();
 


### PR DESCRIPTION
## Summary
- allow agents to specify generation temperature and repetition penalty
- forward these parameters to Ollama chat completion settings

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_689ed47c798c832ab211d5e0c9a434de