### PR TITLE
Add bridging round robin manager

### DIFF
--- a/ChatClient.Api/Client/Services/BridgingRoundRobinManager.cs
+++ b/ChatClient.Api/Client/Services/BridgingRoundRobinManager.cs
@@ -1,0 +1,38 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.SemanticKernel;
+using Microsoft.SemanticKernel.Agents;
+using Microsoft.SemanticKernel.Agents.Orchestration.GroupChat;
+using Microsoft.SemanticKernel.ChatCompletion;
+
+namespace ChatClient.Api.Client.Services;
+
+#pragma warning disable SKEXP0110
+public sealed class BridgingRoundRobinManager : RoundRobinGroupChatManager
+{
+    private readonly HashSet<ChatMessageContent> _bridgedMessages = new();
+
+    public override ValueTask<GroupChatManagerResult<string>> SelectNextAgent(
+        ChatHistory history,
+        GroupChatTeam team,
+        CancellationToken cancellationToken = default)
+    {
+        var last = history.LastOrDefault();
+        if (last is not null
+            && last.Role == AuthorRole.Assistant
+            && !_bridgedMessages.Contains(last))
+        {
+            var text = string.Join("", last.Items.OfType<TextContent>().Select(t => t.Text));
+            if (!string.IsNullOrWhiteSpace(text))
+            {
+                history.AddUserMessage(text);
+                _bridgedMessages.Add(last);
+            }
+        }
+
+        return base.SelectNextAgent(history, team, cancellationToken);
+    }
+}
+#pragma warning restore SKEXP0110

--- a/ChatClient.Api/Client/Services/StopAgentFactory.cs
+++ b/ChatClient.Api/Client/Services/StopAgentFactory.cs
@@ -15,7 +15,7 @@ internal class StopAgentFactory : IStopAgentFactory
     private static GroupChatManager CreateRoundRobin(RoundRobinStopAgentOptions? opts)
     {
         var rounds = opts?.Rounds ?? 1;
-        return new RoundRobinGroupChatManager { MaximumInvocationCount = rounds };
+        return new BridgingRoundRobinManager { MaximumInvocationCount = rounds };
     }
 }
 #pragma warning restore SKEXP0110

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ supports multi‑agent conversations through the `GroupChatOrchestration` API.
 
 ```csharp
 var orchestrator = new GroupChatOrchestration(
-    new RoundRobinGroupChatManager { MaximumInvocationCount = 2 },
+    new BridgingRoundRobinManager { MaximumInvocationCount = 2 },
     agent1, agent2);
 
 await using var runtime = new InProcessRuntime();


### PR DESCRIPTION
## Summary
- add BridgingRoundRobinManager to bridge last assistant message as user input
- use BridgingRoundRobinManager when creating round-robin stop agent
- update documentation to show new manager usage

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_689f1e10fed0832aa5e6f2eb068fb804