### PR TITLE
Add chat export formats

### DIFF
--- a/ChatClient.Api/Client/Pages/Chat.razor
+++ b/ChatClient.Api/Client/Pages/Chat.razor
@@ -25,6 +25,7 @@
 @inject IAgentDescriptionService AgentService
 @inject IUserSettingsService UserSettingsService
 @inject IStopAgentFactory StopAgentFactory
+@inject IEnumerable<IChatFormatter> ChatFormatters
 
 <PageTitle>Chat with AI Assistant</PageTitle>
 
@@ -87,9 +88,16 @@
     }
     else
     {
+        <div class="chat-actions">
+            <MudMenu Icon="@Icons.Material.Filled.ContentCopy" AnchorOrigin="Origin.TopRight" TransformOrigin="Origin.TopRight">
+                <MudMenuItem OnClick="@(() => CopyChatAsync(ChatFormat.Text))">Copy as Text</MudMenuItem>
+                <MudMenuItem OnClick="@(() => CopyChatAsync(ChatFormat.Markdown))">Copy as Markdown</MudMenuItem>
+                <MudMenuItem OnClick="@(() => CopyChatAsync(ChatFormat.Html))">Copy as HTML</MudMenuItem>
+            </MudMenu>
+        </div>
         <div class="chat-messages-container" @ref="messagesElement">
             @foreach (var message in ChatViewModelService.Messages)
-            {                
+            {
                 @if (message.Role != Microsoft.Extensions.AI.ChatRole.System)
                 {
                     <MudChat Dense="true" ChatPosition="@(message.Role == Microsoft.Extensions.AI.ChatRole.Assistant ? ChatBubblePosition.Start : ChatBubblePosition.End)" @key="message.Id">
@@ -359,6 +367,14 @@
         {
             await JSRuntime.InvokeVoidAsync("copyText", message.RawContent);
         }
+    }
+
+    private async Task CopyChatAsync(ChatFormat format)
+    {
+        var formatter = ChatFormatters.FirstOrDefault(f => f.FormatType == format);
+        if (formatter is null) return;
+        var text = formatter.Format(ChatViewModelService.Messages);
+        await JSRuntime.InvokeVoidAsync("copyText", text);
     }
 
     public ValueTask DisposeAsync()

--- a/ChatClient.Api/Client/Services/ChatFormat.cs
+++ b/ChatClient.Api/Client/Services/ChatFormat.cs
@@ -1,0 +1,8 @@
+namespace ChatClient.Api.Client.Services;
+
+public enum ChatFormat
+{
+    Text,
+    Markdown,
+    Html
+}

--- a/ChatClient.Api/Client/Services/HtmlChatFormatter.cs
+++ b/ChatClient.Api/Client/Services/HtmlChatFormatter.cs
@@ -1,0 +1,25 @@
+using System.Collections.Generic;
+using System.Text;
+using ChatClient.Api.Client.ViewModels;
+using Microsoft.Extensions.AI;
+
+namespace ChatClient.Api.Client.Services;
+
+public class HtmlChatFormatter : IChatFormatter
+{
+    public ChatFormat FormatType => ChatFormat.Html;
+
+    public string Format(IEnumerable<ChatMessageViewModel> messages)
+    {
+        var sb = new StringBuilder();
+        sb.AppendLine("<div class=\"chat-transcript\">");
+        foreach (var msg in messages)
+        {
+            if (msg.Role == ChatRole.System) continue;
+            var name = msg.Role == ChatRole.Assistant ? msg.AgentName ?? "Assistant" : "User";
+            sb.Append("<p><strong>").Append(name).Append(":</strong> ").Append(msg.HtmlContent).AppendLine("</p>");
+        }
+        sb.AppendLine("</div>");
+        return sb.ToString();
+    }
+}

--- a/ChatClient.Api/Client/Services/IChatFormatter.cs
+++ b/ChatClient.Api/Client/Services/IChatFormatter.cs
@@ -1,0 +1,10 @@
+using System.Collections.Generic;
+using ChatClient.Api.Client.ViewModels;
+
+namespace ChatClient.Api.Client.Services;
+
+public interface IChatFormatter
+{
+    ChatFormat FormatType { get; }
+    string Format(IEnumerable<ChatMessageViewModel> messages);
+}

--- a/ChatClient.Api/Client/Services/MarkdownChatFormatter.cs
+++ b/ChatClient.Api/Client/Services/MarkdownChatFormatter.cs
@@ -1,0 +1,23 @@
+using System.Collections.Generic;
+using System.Text;
+using ChatClient.Api.Client.ViewModels;
+using Microsoft.Extensions.AI;
+
+namespace ChatClient.Api.Client.Services;
+
+public class MarkdownChatFormatter : IChatFormatter
+{
+    public ChatFormat FormatType => ChatFormat.Markdown;
+
+    public string Format(IEnumerable<ChatMessageViewModel> messages)
+    {
+        var sb = new StringBuilder();
+        foreach (var msg in messages)
+        {
+            if (msg.Role == ChatRole.System) continue;
+            var name = msg.Role == ChatRole.Assistant ? msg.AgentName ?? "Assistant" : "User";
+            sb.AppendLine($"**{name}:** {msg.Content}\n");
+        }
+        return sb.ToString();
+    }
+}

--- a/ChatClient.Api/Client/Services/TextChatFormatter.cs
+++ b/ChatClient.Api/Client/Services/TextChatFormatter.cs
@@ -1,0 +1,23 @@
+using System.Collections.Generic;
+using System.Text;
+using ChatClient.Api.Client.ViewModels;
+using Microsoft.Extensions.AI;
+
+namespace ChatClient.Api.Client.Services;
+
+public class TextChatFormatter : IChatFormatter
+{
+    public ChatFormat FormatType => ChatFormat.Text;
+
+    public string Format(IEnumerable<ChatMessageViewModel> messages)
+    {
+        var sb = new StringBuilder();
+        foreach (var msg in messages)
+        {
+            if (msg.Role == ChatRole.System) continue;
+            var name = msg.Role == ChatRole.Assistant ? msg.AgentName ?? "Assistant" : "User";
+            sb.AppendLine($"{name}: {msg.Content}");
+        }
+        return sb.ToString();
+    }
+}

--- a/ChatClient.Api/Program.cs
+++ b/ChatClient.Api/Program.cs
@@ -1,5 +1,6 @@
 using ChatClient.Api;
 using ChatClient.Api.Services;
+using ChatClient.Api.Client.Services;
 
 using Microsoft.AspNetCore.Hosting.Server;
 using Microsoft.AspNetCore.Hosting.Server.Features;
@@ -42,6 +43,9 @@ builder.Services.AddSingleton<ChatClient.Shared.Services.IUserSettingsService, C
 builder.Services.AddScoped<ChatClient.Api.Client.Services.IChatService, ChatClient.Api.Client.Services.ChatService>();
 builder.Services.AddScoped<ChatClient.Api.Client.Services.IChatViewModelService, ChatClient.Api.Client.Services.ChatViewModelService>();
 builder.Services.AddSingleton<ChatClient.Api.Client.Services.IStopAgentFactory, ChatClient.Api.Client.Services.StopAgentFactory>();
+builder.Services.AddSingleton<IChatFormatter, TextChatFormatter>();
+builder.Services.AddSingleton<IChatFormatter, MarkdownChatFormatter>();
+builder.Services.AddSingleton<IChatFormatter, HtmlChatFormatter>();
 
 builder.Services.AddRazorPages();
 builder.Services.AddServerSideBlazor();

--- a/ChatClient.Api/wwwroot/css/chat.css
+++ b/ChatClient.Api/wwwroot/css/chat.css
@@ -5,6 +5,12 @@
     position: relative;
 }
 
+.chat-actions {
+    display: flex;
+    justify-content: flex-end;
+    padding: 0.5rem;
+}
+
 .chat-messages-container {
     padding: 1rem;
     display: flex;


### PR DESCRIPTION
## Summary
- add copy menu above messages with text, markdown, and HTML export
- introduce modular IChatFormatter and implementations for each export format
- style chat action bar for copy menu

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_689f28e40ba8832aa46718d692354d68