### PR TITLE
Allow copying messages during generation

### DIFF
--- a/ChatClient.Api/Client/Pages/Chat.razor
+++ b/ChatClient.Api/Client/Pages/Chat.razor
@@ -103,11 +103,11 @@
                     <MudChat Dense="true" ChatPosition="@(message.Role == Microsoft.Extensions.AI.ChatRole.Assistant ? ChatBubblePosition.Start : ChatBubblePosition.End)" @key="message.Id">
                          <MudChatHeader>
                              <time>@message.MsgDateTime.ToString("g")</time>
+                             <span class="copy-button" title="Copy answer" @onclick="(() => CopyVisibleMessage(message))">📋</span>
+                             <span class="copy-button" title="Copy raw" @onclick="(() => CopyRawMessage(message))">🚪</span>
                              @if (!isLLMAnswering)
                              {
-                                <span class="copy-button" title="Copy answer" @onclick="(() => CopyVisibleMessage(message))">📋</span>
-                                <span class="copy-button" title="Copy raw" @onclick="(() => CopyRawMessage(message))">🚪</span>
-                                <span class="delete-button" title="Delete" @onclick="(() => DeleteMessage(message))">🗑</span>
+                                 <span class="delete-button" title="Delete" @onclick="(() => DeleteMessage(message))">🗑</span>
                              }
                          </MudChatHeader>
 

--- a/ChatClient.Api/Client/Pages/MultiAgentChat.razor
+++ b/ChatClient.Api/Client/Pages/MultiAgentChat.razor
@@ -119,11 +119,11 @@
                     <MudChat Dense="true" ChatPosition="@(message.Role == Microsoft.Extensions.AI.ChatRole.Assistant ? ChatBubblePosition.Start : ChatBubblePosition.End)" @key="message.Id">
                          <MudChatHeader>
                              <time>@message.MsgDateTime.ToString("g")</time>
+                             <span class="copy-button" title="Copy answer" @onclick="(() => CopyVisibleMessage(message))">📋</span>
+                             <span class="copy-button" title="Copy raw" @onclick="(() => CopyRawMessage(message))">🚪</span>
                              @if (!isLLMAnswering)
                              {
-                                <span class="copy-button" title="Copy answer" @onclick="(() => CopyVisibleMessage(message))">📋</span>
-                                <span class="copy-button" title="Copy raw" @onclick="(() => CopyRawMessage(message))">🚪</span>
-                                <span class="delete-button" title="Delete" @onclick="(() => DeleteMessage(message))">🗑</span>
+                                 <span class="delete-button" title="Delete" @onclick="(() => DeleteMessage(message))">🗑</span>
                              }
                          </MudChatHeader>
 


### PR DESCRIPTION
## Summary
- keep copy buttons visible even while the model is responding
- hide delete option only during generation

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_689f314487b0832a9649925b6a09b365