### PR TITLE
Ensure agents carry model names and use them for statistics

### DIFF
--- a/ChatClient.Api/Client/Pages/Chat.razor
+++ b/ChatClient.Api/Client/Pages/Chat.razor
@@ -310,9 +310,10 @@
     {
         var agents = selectedAgent != null ? new[] { selectedAgent } : Array.Empty<AgentDescription>();
         if (agents.Length != 1)
-        {
             throw new InvalidOperationException("Single-agent chat requires exactly one agent.");
-        }
+
+        if (string.IsNullOrWhiteSpace(agents[0].ModelName))
+            agents[0].ModelName = SelectedModel?.Name;
 
         ChatService.InitializeChat(agents);
         chatStarted = true;

--- a/ChatClient.Api/Client/Pages/MultiAgentChat.razor
+++ b/ChatClient.Api/Client/Pages/MultiAgentChat.razor
@@ -341,6 +341,10 @@
         if (selectedAgents.Count == 0)
             return;
 
+        foreach (var agent in selectedAgents)
+            if (string.IsNullOrWhiteSpace(agent.ModelName))
+                agent.ModelName = SelectedModel?.Name;
+
         ChatService.InitializeChat(selectedAgents);
         chatStarted = true;
         StateHasChanged();

--- a/ChatClient.Api/Client/Services/StreamingMessageManager.cs
+++ b/ChatClient.Api/Client/Services/StreamingMessageManager.cs
@@ -55,7 +55,7 @@ public class StreamingMessageManager
     /// <summary>
     /// Creates statistics for message with additional metrics.
     /// </summary>
-    public string BuildStatistics(TimeSpan processingTime, ChatConfiguration chatConfiguration, int tokenCount, IEnumerable<string>? invokedServers = null)
+    public string BuildStatistics(TimeSpan processingTime, string modelName, int tokenCount, int functionCount, IEnumerable<string>? invokedServers = null)
     {
         var tokensPerSecond = processingTime.TotalSeconds > 0
             ? (tokenCount / processingTime.TotalSeconds).ToString("F1")
@@ -63,10 +63,10 @@ public class StreamingMessageManager
 
         var statisticsBuilder = new System.Text.StringBuilder();
         statisticsBuilder.Append($"⏱️ {processingTime.TotalSeconds:F1}s");
-        statisticsBuilder.Append($" • 🤖 {chatConfiguration.ModelName}");
-        if (chatConfiguration.Functions.Any())
+        statisticsBuilder.Append($" • 🤖 {modelName}");
+        if (functionCount > 0)
         {
-            statisticsBuilder.Append($" • 🔧 {chatConfiguration.Functions.Count} funcs");
+            statisticsBuilder.Append($" • 🔧 {functionCount} funcs");
         }
         if (invokedServers != null && invokedServers.Any())
         {


### PR DESCRIPTION
## Summary
- fill agent model names at chat start
- base streaming statistics on agent model and function count
- drop unused ChatConfiguration plumbing

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_689f52ecb95c832aa20e79f2af5cbad9