### PR TITLE
Ensure last message is user in multi-agent chat

### DIFF
--- a/ChatClient.Api/Client/Services/ChatService.cs
+++ b/ChatClient.Api/Client/Services/ChatService.cs
@@ -174,6 +174,7 @@ public class ChatService(
     private async Task<List<ChatCompletionAgent>> CreateAgents(string userMessage, TrackingFiltersScope trackingScope)
     {
         var agents = new List<ChatCompletionAgent>();
+        var reducer = new ForceLastUserReducer();
 
         foreach (var desc in _agentsByName.Values)
         {
@@ -211,7 +212,8 @@ public class ChatService(
                 Description = desc.AgentName,
                 Instructions = desc.Content,
                 Kernel = agentKernel,
-                Arguments = new KernelArguments(settings)
+                Arguments = new KernelArguments(settings),
+                HistoryReducer = reducer
             });
         }
 

--- a/ChatClient.Api/Client/Services/ForceLastUserReducer.cs
+++ b/ChatClient.Api/Client/Services/ForceLastUserReducer.cs
@@ -1,0 +1,35 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.SemanticKernel.Agents;
+using Microsoft.SemanticKernel.ChatCompletion;
+using Microsoft.SemanticKernel;
+
+namespace ChatClient.Api.Client.Services;
+
+public sealed class ForceLastUserReducer : IChatHistoryReducer
+{
+    public Task<IEnumerable<ChatMessageContent>?> ReduceAsync(
+        IReadOnlyList<ChatMessageContent> source,
+        CancellationToken cancellationToken = default)
+    {
+        if (source.Count == 0)
+            return Task.FromResult<IEnumerable<ChatMessageContent>?>(source);
+
+        var list = new List<ChatMessageContent>(source);
+        var last = list[^1];
+
+        if (last.Role != AuthorRole.User)
+        {
+            var items = new ChatMessageContentItemCollection();
+            foreach (var item in last.Items)
+                items.Add(item);
+
+            var replaced = new ChatMessageContent(AuthorRole.User, items, "user");
+
+            list[^1] = replaced;
+        }
+
+        return Task.FromResult<IEnumerable<ChatMessageContent>?>(list);
+    }
+}

--- a/ChatClient.Tests/ChatHistoryBuilderTests.cs
+++ b/ChatClient.Tests/ChatHistoryBuilderTests.cs
@@ -2,6 +2,7 @@ using ChatClient.Api.Services;
 using ChatClient.Shared.Models;
 using ChatClient.Shared.Services;
 
+using System.Linq;
 using Microsoft.Extensions.Logging;
 using Microsoft.SemanticKernel;
 using Microsoft.SemanticKernel.ChatCompletion;
@@ -27,5 +28,22 @@ public class ChatHistoryBuilderTests
         var kernel = Kernel.CreateBuilder().Build();
         var history = await builder.BuildChatHistoryAsync(messages, kernel, CancellationToken.None);
         Assert.Equal(AuthorRole.User, history[^1].Role);
+    }
+
+    [Fact]
+    public void BuildBaseHistory_PreservesOrder()
+    {
+        var builder = new ChatHistoryBuilder(new DummySettingsService(), new LoggerFactory().CreateLogger<ChatHistoryBuilder>());
+        var messages = new List<IAppChatMessage>
+        {
+            new AppChatMessage("first", DateTime.UtcNow.AddMinutes(2), ChatRole.User),
+            new AppChatMessage("second", DateTime.UtcNow.AddMinutes(1), ChatRole.Assistant),
+            new AppChatMessage("third", DateTime.UtcNow.AddMinutes(3), ChatRole.User)
+        };
+        var history = builder.BuildBaseHistory(messages);
+        var texts = history
+            .Select(m => string.Join(string.Empty, m.Items.OfType<Microsoft.SemanticKernel.TextContent>().Select(t => t.Text)))
+            .ToList();
+        Assert.Equal(new[] { "first", "second", "third" }, texts);
     }
 }


### PR DESCRIPTION
## Summary
- add `ForceLastUserReducer` to convert the most recent chat entry into a user message
- hook reducer into agent creation so each agent responds to a user turn
- verify chat history keeps original message order

## Testing
- `dotnet test --filter BuildBaseHistory_PreservesOrder`
- `dotnet test --filter KantAndBentham_DebateLyingToSaveLife` *(fails: Connection refused (localhost:11434))*

------
https://chatgpt.com/codex/tasks/task_e_68a21b6b378c832a8025eb5e4d36263d