### PR TITLE
Ensure last message treated as user in chat history

### DIFF
--- a/ChatClient.Api/Services/ChatHistoryBuilder.cs
+++ b/ChatClient.Api/Services/ChatHistoryBuilder.cs
@@ -7,6 +7,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.SemanticKernel;
 using Microsoft.SemanticKernel.ChatCompletion;
 using System.Linq;
+using ChatClient.Api.Client.Services;
 
 namespace ChatClient.Api.Services;
 
@@ -64,7 +65,9 @@ public class ChatHistoryBuilder(IUserSettingsService settingsService, ILogger<Ch
     public async Task<ChatHistory> BuildChatHistoryAsync(IEnumerable<IAppChatMessage> messages, Kernel kernel, CancellationToken cancellationToken)
     {
         var history = BuildBaseHistory(messages);
-        // Temporarily disabled!!! 
+        var reduced = await new ForceLastUserReducer().ReduceAsync(history, cancellationToken) ?? history;
+        history = reduced is ChatHistory h ? h : new ChatHistory(reduced);
+        // Temporarily disabled!!!
         // history = await ApplyHistoryModeAsync(history, kernel, cancellationToken);
         // logger.LogInformation("Chat history:\n{History}", FormatHistory(history));
         return history;


### PR DESCRIPTION
## Summary
- Apply ForceLastUserReducer when building chat history so the final message is always marked as `user`

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68a3547f6ac4832ab9bad93d8fb3497e