### PR TITLE
feat: remember multi-agent selections

### DIFF
--- a/ChatClient.Api/Client/Components/ChatInput.razor
+++ b/ChatClient.Api/Client/Components/ChatInput.razor
@@ -64,6 +64,7 @@
     [Parameter] public EventCallback<(string text, IReadOnlyList<ChatMessageFile> files)> OnSend { get; set; }
     [Parameter] public bool ShowStopButton { get; set; } = false;
     [Parameter] public EventCallback OnStopClick { get; set; }
+    [Parameter] public bool IsMultiAgent { get; set; } = false;
     
     private string CurrentText { get; set; } = string.Empty;
     private List<ChatMessageFile> attachedFiles = [];
@@ -72,9 +73,10 @@
     {
         await base.OnInitializedAsync();
         var settings = await UserSettingsService.GetSettingsAsync();
-        if (!string.IsNullOrEmpty(settings.DefaultChatMessage))
+        var defaultMessage = IsMultiAgent ? settings.DefaultMultiAgentChatMessage : settings.DefaultChatMessage;
+        if (!string.IsNullOrEmpty(defaultMessage))
         {
-            CurrentText = settings.DefaultChatMessage;
+            CurrentText = defaultMessage;
         }
     }
 

--- a/ChatClient.Api/Client/Pages/AppSettings.razor
+++ b/ChatClient.Api/Client/Pages/AppSettings.razor
@@ -91,6 +91,16 @@
 
                     <MudCard Class="mb-4" Elevation="1">
                         <MudCardHeader Class="pb-2">
+                            <MudText Class="section-header">Default Multiagent Chat Message</MudText>
+                        </MudCardHeader>
+                        <MudCardContent Class="pt-0">
+                            <MudTextField T="string" Label="Default Multiagent Chat Message" @bind-Value="_settings.DefaultMultiAgentChatMessage"
+                                          Lines="3" Variant="Variant.Outlined" HelperText="Pre-filled message in the multiagent chat input" />
+                        </MudCardContent>
+                    </MudCard>
+
+                    <MudCard Class="mb-4" Elevation="1">
+                        <MudCardHeader Class="pb-2">
                             <MudText Class="section-header">Chat Participants</MudText>
                         </MudCardHeader>
                         <MudCardContent Class="pt-0">

--- a/ChatClient.Api/Client/Pages/Chat.razor
+++ b/ChatClient.Api/Client/Pages/Chat.razor
@@ -56,16 +56,6 @@
                         }
                     </MudSelect>
 
-                    <MudSwitch T="bool" @bind-value="showAgentDescription" Color="Color.Primary" Class="mt-4" Style="margin-bottom: 10px;">View Agent Description</MudSwitch>
-                    @if (showAgentDescription && selectedAgent != null)
-                    {
-                        <div class="agent-description-preview mt-3 pa-3 mb-2">
-                            <div class="mb-2">
-                                <strong>@selectedAgent.AgentName</strong>
-                                <div>@(selectedAgent.Content ?? string.Empty)</div>
-                            </div>
-                        </div>
-                    }
                     <MudButton Variant="Variant.Filled"
                                Color="Color.Primary"
                                FullWidth="true"
@@ -231,8 +221,6 @@
 
     [CascadingParameter(Name = "SelectedModel")]
     public OllamaModel? SelectedModel { get; set; }
-
-    private bool showAgentDescription { get; set; } = false;
 
 
     private UserSettings userSettings = new();

--- a/ChatClient.Api/Client/Pages/MultiAgentChat.razor
+++ b/ChatClient.Api/Client/Pages/MultiAgentChat.razor
@@ -55,20 +55,6 @@
                         }
                     </MudSelect>
 
-                    <MudSwitch T="bool" @bind-value="showAgentDescription" Color="Color.Primary" Class="mt-4" Style="margin-bottom: 10px;">View Agent Description</MudSwitch>
-                    @if (showAgentDescription && selectedAgents.Any())
-                    {
-                        <div class="agent-description-preview mt-3 pa-3 mb-2">
-                            @foreach (var agent in selectedAgents)
-                            {
-                                <div class="mb-2">
-                                    <strong>@agent.AgentName</strong>
-                                    <div>@(agent.Content ?? string.Empty)</div>
-                                </div>
-                            }
-                        </div>
-                    }
-
                     <MudSelect T="string" Label="Stop Agent" @bind-Value="stopAgentName" Variant="Variant.Outlined" FullWidth="true" Class="mt-4" Dense="true">
                         @foreach (var agent in stopAgents)
                         {
@@ -227,7 +213,8 @@
             <MudStack Direction="Direction.Column">
                 <ChatInput OnSend="SendChatMessageAsync"
                           ShowStopButton="isLLMAnswering"
-                          OnStopClick="Cancel" />
+                          OnStopClick="Cancel"
+                          IsMultiAgent="true" />
             </MudStack>
         </div>
     }
@@ -247,8 +234,6 @@
 
     [CascadingParameter(Name = "SelectedModel")]
     public OllamaModel? SelectedModel { get; set; }
-
-    private bool showAgentDescription { get; set; } = false;
 
     private const string RoundRobinStopAgent = "RoundRobin";
     private List<string> stopAgents = new() { RoundRobinStopAgent };
@@ -334,9 +319,21 @@
         stopAgentName = string.IsNullOrWhiteSpace(userSettings.StopAgentName)
             ? RoundRobinStopAgent
             : userSettings.StopAgentName;
-    }
 
-    private void StartChat()
+        if (userSettings.MultiAgentRounds > 0)
+            roundRobinOptions.Rounds = userSettings.MultiAgentRounds;
+
+        if (userSettings.MultiAgentSelectedAgents?.Count > 0)
+        {
+            selectedAgents = userSettings.MultiAgentSelectedAgents
+                .Select(name => agents.FirstOrDefault(a => a.AgentName == name))
+                .Where(a => a is not null)
+                .Select(a => a!)
+                .ToList();
+        }
+    }
+    
+    private async Task StartChat()
     {
         if (selectedAgents.Count == 0)
             return;
@@ -344,6 +341,11 @@
         foreach (var agent in selectedAgents)
             if (string.IsNullOrWhiteSpace(agent.ModelName))
                 agent.ModelName = SelectedModel?.Name;
+
+        userSettings.StopAgentName = stopAgentName;
+        userSettings.MultiAgentSelectedAgents = selectedAgents.Select(a => a.AgentName).ToList();
+        userSettings.MultiAgentRounds = roundRobinOptions.Rounds;
+        await UserSettingsService.SaveSettingsAsync(userSettings);
 
         ChatService.InitializeChat(selectedAgents);
         chatStarted = true;

--- a/ChatClient.Shared/Models/UserSettings.cs
+++ b/ChatClient.Shared/Models/UserSettings.cs
@@ -1,4 +1,5 @@
 using System.Text.Json.Serialization;
+using System.Collections.Generic;
 
 using ChatClient.Shared.Constants;
 
@@ -11,6 +12,9 @@ public class UserSettings
 
     [JsonPropertyName("defaultChatMessage")]
     public string DefaultChatMessage { get; set; } = string.Empty;
+
+    [JsonPropertyName("defaultMultiAgentChatMessage")]
+    public string DefaultMultiAgentChatMessage { get; set; } = string.Empty;
 
     [JsonPropertyName("userName")]
     public string UserName { get; set; } = string.Empty;
@@ -66,4 +70,10 @@ public class UserSettings
 
     [JsonPropertyName("stopAgentName")]
     public string StopAgentName { get; set; } = string.Empty;
+
+    [JsonPropertyName("multiAgentSelectedAgents")]
+    public List<string> MultiAgentSelectedAgents { get; set; } = [];
+
+    [JsonPropertyName("multiAgentRounds")]
+    public int MultiAgentRounds { get; set; } = 1;
 }


### PR DESCRIPTION
## Summary
- remove agent description preview toggle
- remember selected agents and round count in multi-agent chat
- add default message for multi-agent conversations

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68a490d76128832ab25245ef2d0c3a62