### PR TITLE
Skip logging of streaming response bodies

### DIFF
--- a/ChatClient.Api/Services/HttpLoggingHandler.cs
+++ b/ChatClient.Api/Services/HttpLoggingHandler.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Text;
 using Microsoft.Extensions.Logging;
 
@@ -81,11 +82,19 @@ public class HttpLoggingHandler(ILogger<HttpLoggingHandler> logger) : Delegating
                     sb.AppendLine($"  {header.Key}: {string.Join(", ", header.Value)}");
             }
 
-            var content = await SafeReadAsStringAsync(response.Content, ct);
-            if (!string.IsNullOrEmpty(content))
+            var mediaType = response.Content.Headers.ContentType?.MediaType;
+            if (string.Equals(mediaType, "application/x-ndjson", StringComparison.OrdinalIgnoreCase))
             {
-                sb.AppendLine("Body:");
-                sb.AppendLine(Truncate(content, MaxBodyChars));
+                sb.AppendLine("Body: <streaming content>");
+            }
+            else
+            {
+                var content = await SafeReadAsStringAsync(response.Content, ct);
+                if (!string.IsNullOrEmpty(content))
+                {
+                    sb.AppendLine("Body:");
+                    sb.AppendLine(Truncate(content, MaxBodyChars));
+                }
             }
         }
 


### PR DESCRIPTION
## Summary
- avoid reading NDJSON bodies in `HttpLoggingHandler` to stop buffering streaming responses

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68a4991ec170832a871b6a371f42163c