### PR TITLE
Add copy menu to multi-agent chat

### DIFF
--- a/ChatClient.Api/Client/Pages/MultiAgentChat.razor
+++ b/ChatClient.Api/Client/Pages/MultiAgentChat.razor
@@ -25,6 +25,7 @@
 @inject IAgentDescriptionService AgentService
 @inject IUserSettingsService UserSettingsService
 @inject IStopAgentFactory StopAgentFactory
+@inject IEnumerable<IChatFormatter> ChatFormatters
 
 <PageTitle>Chat with AI Assistant</PageTitle>
 
@@ -88,6 +89,13 @@
     }
     else
     {
+        <div class="chat-actions">
+            <MudMenu Icon="@Icons.Material.Filled.ContentCopy" AnchorOrigin="Origin.TopRight" TransformOrigin="Origin.TopRight">
+                <MudMenuItem OnClick="@(() => CopyChatAsync(ChatFormat.Text))">Copy as Text</MudMenuItem>
+                <MudMenuItem OnClick="@(() => CopyChatAsync(ChatFormat.Markdown))">Copy as Markdown</MudMenuItem>
+                <MudMenuItem OnClick="@(() => CopyChatAsync(ChatFormat.Html))">Copy as HTML</MudMenuItem>
+            </MudMenu>
+        </div>
         <div class="chat-messages-container" @ref="messagesElement">
             @if (agentStatistics.Any())
             {
@@ -406,6 +414,14 @@
         {
             await JSRuntime.InvokeVoidAsync("copyText", message.RawContent);
         }
+    }
+
+    private async Task CopyChatAsync(ChatFormat format)
+    {
+        var formatter = ChatFormatters.FirstOrDefault(f => f.FormatType == format);
+        if (formatter is null) return;
+        var text = formatter.Format(ChatViewModelService.Messages);
+        await JSRuntime.InvokeVoidAsync("copyText", text);
     }
 
     public ValueTask DisposeAsync()


### PR DESCRIPTION
## Summary
- add chat-wide copy menu to multi-agent chat
- inject chat formatters and implement copy handler

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68a49c1c7ddc832aac0b40110306cc30