### PR TITLE
Log agent start before LLM call

### DIFF
--- a/ChatClient.Api/Client/Services/ChatService.cs
+++ b/ChatClient.Api/Client/Services/ChatService.cs
@@ -190,7 +190,7 @@ public class ChatService(
         {
             var functionsToRegister = await kernelService.GetFunctionsToRegisterAsync(desc.FunctionSettings, userMessage);
             var modelName = desc.ModelName ?? throw new InvalidOperationException("Agent model name is not set.");
-            var agentKernel = await kernelService.CreateKernelAsync(modelName, functionsToRegister);
+            var agentKernel = await kernelService.CreateKernelAsync(modelName, functionsToRegister, desc.AgentName);
 
             // TODO Add function into AgentDescription to get Agent name for UI
             var agentName = !string.IsNullOrWhiteSpace(desc.ShortName) ? desc.ShortName : desc.AgentName;
@@ -249,7 +249,6 @@ public class ChatService(
 
                 if (!_activeStreams.TryGetValue(agentName, out var message))
                 {
-                    logger.LogInformation("Agent {AgentName} started responding", agentName);
                     if (_activeStreams.TryGetValue(PlaceholderAgent, out var placeholder))
                     {
                         logger.LogDebug("Replacing placeholder with agent {AgentName}, placeholder content length: {ContentLength}", 

--- a/ChatClient.Api/Services/HttpLoggingHandler.cs
+++ b/ChatClient.Api/Services/HttpLoggingHandler.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Text;
+using System.Linq;
 using Microsoft.Extensions.Logging;
 
 namespace ChatClient.Api.Services;
@@ -23,6 +24,9 @@ public class HttpLoggingHandler(ILogger<HttpLoggingHandler> logger) : Delegating
     {
         if (!logger.IsEnabled(LogLevel.Information))
             return;
+
+        if (request.Headers.TryGetValues("X-Agent-Name", out var agentValues))
+            logger.LogInformation("Agent {AgentName} started responding", agentValues.First());
 
         var sb = new StringBuilder();
         sb.AppendLine($"HTTP Request: {request.Method} {request.RequestUri}");


### PR DESCRIPTION
## Summary
- pass agent description to kernel and attach agent header to outgoing requests
- log agent start in HttpLoggingHandler before sending payload to LLM
- drop streaming callback info log to avoid duplicate entries

## Testing
- `dotnet build`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68a4a87a7c44832abda2b22d94c1f202