### PR TITLE
Include streaming messages in history builder

### DIFF
--- a/ChatClient.Api/Services/ChatHistoryBuilder.cs
+++ b/ChatClient.Api/Services/ChatHistoryBuilder.cs
@@ -21,7 +21,7 @@ public class ChatHistoryBuilder(IUserSettingsService settingsService, ILogger<Ch
     public ChatHistory BuildBaseHistory(IEnumerable<IAppChatMessage> messages)
     {
         var history = new ChatHistory();
-        foreach (var msg in messages.Where(m => !m.IsStreaming))
+        foreach (var msg in messages)
         {
             var items = new ChatMessageContentItemCollection();
             if (!string.IsNullOrEmpty(msg.Content))

--- a/ChatClient.Tests/ChatHistoryBuilderTests.cs
+++ b/ChatClient.Tests/ChatHistoryBuilderTests.cs
@@ -46,4 +46,20 @@ public class ChatHistoryBuilderTests
             .ToList();
         Assert.Equal(new[] { "first", "second", "third" }, texts);
     }
+
+    [Fact]
+    public void BuildBaseHistory_IncludesStreamingMessage()
+    {
+        var builder = new ChatHistoryBuilder(new DummySettingsService(), new LoggerFactory().CreateLogger<ChatHistoryBuilder>());
+        var messages = new List<IAppChatMessage>
+        {
+            new AppChatMessage("hi", DateTime.UtcNow, ChatRole.User),
+            new StreamingAppChatMessage("partial", DateTime.UtcNow, ChatRole.Assistant)
+        };
+        var history = builder.BuildBaseHistory(messages);
+        var texts = history
+            .Select(m => string.Join(string.Empty, m.Items.OfType<Microsoft.SemanticKernel.TextContent>().Select(t => t.Text)))
+            .ToList();
+        Assert.Equal(new[] { "hi", "partial" }, texts);
+    }
 }


### PR DESCRIPTION
## Summary
- include streaming messages when building chat history
- test ensures streaming messages are preserved

## Testing
- `dotnet test` *(fails: The current .NET SDK does not support targeting .NET 9.0)*
- `apt-get install -y dotnet-sdk-9.0` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_68a4cec388e8832a8609817c8841b219