### PR TITLE
Ensure last chat message is user and log reducer activity

### DIFF
--- a/ChatClient.Api/Client/Services/ChatService.cs
+++ b/ChatClient.Api/Client/Services/ChatService.cs
@@ -19,13 +19,15 @@ namespace ChatClient.Api.Client.Services;
 public class ChatService(
     KernelService kernelService,
     ILogger<ChatService> logger,
-    IChatHistoryBuilder chatHistoryBuilder) : IChatService
+    IChatHistoryBuilder chatHistoryBuilder,
+    ForceLastUserReducer reducer) : IChatService
 {
     private CancellationTokenSource? _cancellationTokenSource;
     private StreamingMessageManager _streamingManager = null!;
     private readonly Dictionary<string, StreamingAppChatMessage> _activeStreams = new();
     private const string PlaceholderAgent = "__placeholder__";
     private Dictionary<string, AgentDescription> _agentsByName = new();
+    private readonly ForceLastUserReducer _reducer = reducer;
 
     public event Action<bool>? AnsweringStateChanged;
     public event Action? ChatReset;
@@ -229,7 +231,7 @@ public class ChatService(
                 Instructions = desc.Content,
                 Kernel = agentKernel,
                 Arguments = new KernelArguments(settings),
-                HistoryReducer = new ForceLastUserReducer()
+                HistoryReducer = _reducer
             });
         }
 

--- a/ChatClient.Api/Client/Services/ForceLastUserChatCompletionService.cs
+++ b/ChatClient.Api/Client/Services/ForceLastUserChatCompletionService.cs
@@ -1,21 +1,34 @@
+using System.Runtime.CompilerServices;
 using Microsoft.SemanticKernel;
 using Microsoft.SemanticKernel.ChatCompletion;
 
 namespace ChatClient.Api.Client.Services;
 
-//public sealed class ForceLastUserChatCompletionService(IChatCompletionService inner, ForceLastUserReducer reducer) : IChatCompletionService
-//{
-//    public IReadOnlyDictionary<string, object?> Attributes => inner.Attributes;
-//
-//    public async Task<IReadOnlyList<ChatMessageContent>> GetChatMessageContentsAsync(
-//        ChatHistory chatHistory,
-//        PromptExecutionSettings? executionSettings = null,
-//        Kernel? kernel = null,
-//        CancellationToken cancellationToken = default)
-//    {
-//        var reduced = await reducer.ReduceAsync(chatHistory, cancellationToken) ?? chatHistory;
-//        var history = reduced is ChatHistory h ? h : new ChatHistory(reduced);
-//        return await inner.GetChatMessageContentsAsync(history, executionSettings, kernel, cancellationToken);
-//    }
-//}
+public sealed class ForceLastUserChatCompletionService(IChatCompletionService inner, ForceLastUserReducer reducer) : IChatCompletionService
+{
+    public IReadOnlyDictionary<string, object?> Attributes => inner.Attributes;
+
+    public async Task<IReadOnlyList<ChatMessageContent>> GetChatMessageContentsAsync(
+        ChatHistory chatHistory,
+        PromptExecutionSettings? executionSettings = null,
+        Kernel? kernel = null,
+        CancellationToken cancellationToken = default)
+    {
+        var reduced = await reducer.ReduceAsync(chatHistory, cancellationToken) ?? chatHistory;
+        var history = reduced is ChatHistory h ? h : new ChatHistory(reduced);
+        return await inner.GetChatMessageContentsAsync(history, executionSettings, kernel, cancellationToken);
+    }
+
+    public async IAsyncEnumerable<StreamingChatMessageContent> GetStreamingChatMessageContentsAsync(
+        ChatHistory chatHistory,
+        PromptExecutionSettings? executionSettings = null,
+        Kernel? kernel = null,
+        [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        var reduced = await reducer.ReduceAsync(chatHistory, cancellationToken) ?? chatHistory;
+        var history = reduced is ChatHistory h ? h : new ChatHistory(reduced);
+        await foreach (var item in inner.GetStreamingChatMessageContentsAsync(history, executionSettings, kernel, cancellationToken))
+            yield return item;
+    }
+}
 

--- a/ChatClient.Api/Client/Services/ForceLastUserReducer.cs
+++ b/ChatClient.Api/Client/Services/ForceLastUserReducer.cs
@@ -1,27 +1,28 @@
+using Microsoft.Extensions.Logging;
 using Microsoft.SemanticKernel;
 using Microsoft.SemanticKernel.ChatCompletion;
 
 namespace ChatClient.Api.Client.Services;
 
-public sealed class ForceLastUserReducer : IChatHistoryReducer
+public sealed class ForceLastUserReducer(ILogger<ForceLastUserReducer>? logger = null) : IChatHistoryReducer
 {
     public Task<IEnumerable<ChatMessageContent>?> ReduceAsync(
         IReadOnlyList<ChatMessageContent> source,
         CancellationToken cancellationToken = default)
     {
         if (source.Count == 0)
-        {
             return Task.FromResult<IEnumerable<ChatMessageContent>?>(source);
-        }
 
         List<ChatMessageContent> list = new(source);
         ChatMessageContent last = list[^1];
-
-        if (last.Role != AuthorRole.User)
+        if (last.Role == AuthorRole.User)
         {
-            list[^1] = new ChatMessageContent(AuthorRole.User, last.Content, "user");
+            logger?.LogDebug("ForceLastUserReducer found last role already User");
+            return Task.FromResult<IEnumerable<ChatMessageContent>?>(list);
         }
 
+        logger?.LogInformation("ForceLastUserReducer changed last role from {OriginalRole} to User", last.Role);
+        list[^1] = new ChatMessageContent(AuthorRole.User, last.Content, "user");
         return Task.FromResult<IEnumerable<ChatMessageContent>?>(list);
     }
 }

--- a/ChatClient.Api/Program.cs
+++ b/ChatClient.Api/Program.cs
@@ -38,6 +38,7 @@ builder.Services.AddSingleton<ChatClient.Api.Services.McpSamplingService>();
 builder.Services.AddSingleton<ChatClient.Api.Services.KernelService>();
 builder.Services.AddSingleton<ChatClient.Api.Services.IOllamaClientService, ChatClient.Api.Services.OllamaService>();
 builder.Services.AddSingleton<ChatClient.Api.Services.McpFunctionIndexService>();
+builder.Services.AddSingleton<ForceLastUserReducer>();
 builder.Services.AddSingleton<ChatClient.Api.Services.IChatHistoryBuilder, ChatClient.Api.Services.ChatHistoryBuilder>();
 builder.Services.AddScoped<ChatClient.Api.Services.StartupOllamaChecker>();
 builder.Services.AddSingleton<ChatClient.Shared.Services.IAgentDescriptionService, ChatClient.Api.Services.AgentDescriptionService>();

--- a/ChatClient.Api/Services/ChatHistoryBuilder.cs
+++ b/ChatClient.Api/Services/ChatHistoryBuilder.cs
@@ -16,7 +16,10 @@ public interface IChatHistoryBuilder
     Task<ChatHistory> BuildChatHistoryAsync(IEnumerable<IAppChatMessage> messages, Kernel kernel, CancellationToken cancellationToken);
 }
 
-public class ChatHistoryBuilder(IUserSettingsService settingsService, ILogger<ChatHistoryBuilder> logger) : IChatHistoryBuilder
+public class ChatHistoryBuilder(
+    IUserSettingsService settingsService,
+    ILogger<ChatHistoryBuilder> logger,
+    ForceLastUserReducer reducer) : IChatHistoryBuilder
 {
     public ChatHistory BuildBaseHistory(IEnumerable<IAppChatMessage> messages)
     {
@@ -70,7 +73,7 @@ public class ChatHistoryBuilder(IUserSettingsService settingsService, ILogger<Ch
         var initialRole = history.LastOrDefault()?.Role;
         logger.LogDebug("Initial history last role: {Role}", initialRole);
 
-        var reduced = await new ForceLastUserReducer().ReduceAsync(history, cancellationToken) ?? history;
+        var reduced = await reducer.ReduceAsync(history, cancellationToken) ?? history;
         history = reduced is ChatHistory h ? h : new ChatHistory(reduced);
         var finalRole = history.LastOrDefault()?.Role;
         logger.LogDebug("Final history last role: {Role}", finalRole);

--- a/ChatClient.Api/Services/KernelService.cs
+++ b/ChatClient.Api/Services/KernelService.cs
@@ -62,12 +62,12 @@ public class KernelService(
         httpClient.BaseAddress = new Uri(baseUrl);
         if (!string.IsNullOrEmpty(agentName))
             httpClient.DefaultRequestHeaders.Add("X-Agent-Name", agentName);
-        builder.Services.AddSingleton<IChatCompletionService>(_ =>
-        {
-            return new OllamaChatCompletionService(modelId, httpClient: httpClient);
-        });
         builder.Services.AddSingleton(httpClient);
         builder.Services.AddLogging(c => c.AddConsole().SetMinimumLevel(LogLevel.Information));
+        builder.Services.AddSingleton<IChatCompletionService>(_ =>
+            new ForceLastUserChatCompletionService(
+                new OllamaChatCompletionService(modelId, httpClient: httpClient),
+                serviceProvider.GetRequiredService<ForceLastUserReducer>()));
 
         return builder.Build();
     }

--- a/ChatClient.Tests/ChatHistoryBuilderTests.cs
+++ b/ChatClient.Tests/ChatHistoryBuilderTests.cs
@@ -1,4 +1,5 @@
 using ChatClient.Api.Services;
+using ChatClient.Api.Client.Services;
 using ChatClient.Shared.Models;
 using ChatClient.Shared.Services;
 
@@ -19,7 +20,7 @@ public class ChatHistoryBuilderTests
     [Fact]
     public async Task BuildChatHistoryAsync_LastAssistantBecomesUser()
     {
-        var builder = new ChatHistoryBuilder(new DummySettingsService(), new LoggerFactory().CreateLogger<ChatHistoryBuilder>());
+        var builder = new ChatHistoryBuilder(new DummySettingsService(), new LoggerFactory().CreateLogger<ChatHistoryBuilder>(), new ForceLastUserReducer());
         var messages = new List<IAppChatMessage>
         {
             new AppChatMessage("hi", DateTime.UtcNow, ChatRole.User),
@@ -33,7 +34,7 @@ public class ChatHistoryBuilderTests
     [Fact]
     public void BuildBaseHistory_PreservesOrder()
     {
-        var builder = new ChatHistoryBuilder(new DummySettingsService(), new LoggerFactory().CreateLogger<ChatHistoryBuilder>());
+        var builder = new ChatHistoryBuilder(new DummySettingsService(), new LoggerFactory().CreateLogger<ChatHistoryBuilder>(), new ForceLastUserReducer());
         var messages = new List<IAppChatMessage>
         {
             new AppChatMessage("first", DateTime.UtcNow.AddMinutes(2), ChatRole.User),
@@ -50,7 +51,7 @@ public class ChatHistoryBuilderTests
     [Fact]
     public void BuildBaseHistory_IncludesStreamingMessage()
     {
-        var builder = new ChatHistoryBuilder(new DummySettingsService(), new LoggerFactory().CreateLogger<ChatHistoryBuilder>());
+        var builder = new ChatHistoryBuilder(new DummySettingsService(), new LoggerFactory().CreateLogger<ChatHistoryBuilder>(), new ForceLastUserReducer());
         var messages = new List<IAppChatMessage>
         {
             new AppChatMessage("hi", DateTime.UtcNow, ChatRole.User),

--- a/ChatClient.Tests/ChatServiceTests.cs
+++ b/ChatClient.Tests/ChatServiceTests.cs
@@ -23,7 +23,8 @@ public class ChatServiceTests
         var chatService = new ChatService(
             kernelService: null!,
             logger: new LoggerFactory().CreateLogger<ChatService>(),
-            chatHistoryBuilder: new DummyHistoryBuilder());
+            chatHistoryBuilder: new DummyHistoryBuilder(),
+            reducer: new ForceLastUserReducer());
 
         Assert.Throws<ArgumentException>(() => chatService.InitializeChat([]));
     }
@@ -34,7 +35,8 @@ public class ChatServiceTests
         var chatService = new ChatService(
             kernelService: null!,
             logger: new LoggerFactory().CreateLogger<ChatService>(),
-            chatHistoryBuilder: new DummyHistoryBuilder());
+            chatHistoryBuilder: new DummyHistoryBuilder(),
+            reducer: new ForceLastUserReducer());
 
         var prompt = new AgentDescription { AgentName = "Agent", Content = "Hello" };
         chatService.InitializeChat([prompt]);

--- a/ChatClient.Tests/ForceLastUserReducerTests.cs
+++ b/ChatClient.Tests/ForceLastUserReducerTests.cs
@@ -1,0 +1,26 @@
+using ChatClient.Api.Client.Services;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.SemanticKernel;
+using Microsoft.SemanticKernel.ChatCompletion;
+using System.Linq;
+using Xunit;
+
+namespace ChatClient.Tests;
+
+public class ForceLastUserReducerTests
+{
+    [Fact]
+    public async Task ReplaceAssistantWithUser()
+    {
+        ChatHistory history =
+        [
+            new ChatMessageContent(AuthorRole.System, "sys", "system"),
+            new ChatMessageContent(AuthorRole.Assistant, "answer", "assistant")
+        ];
+
+        var reducer = new ForceLastUserReducer(new NullLogger<ForceLastUserReducer>());
+        var reduced = await reducer.ReduceAsync(history);
+        var last = reduced!.Last();
+        Assert.Equal(AuthorRole.User, last.Role);
+    }
+}


### PR DESCRIPTION
## Summary
- add logging to `ForceLastUserReducer` and wrap chat completion with `ForceLastUserChatCompletionService`
- register `ForceLastUserReducer` via DI and use it in `ChatService` and `ChatHistoryBuilder`
- add tests verifying reducer behavior and align philosopher debate test with main flow

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68a619a78aa8832a95ee52612fef3896