### PR TITLE
docs: clarify multi-agent chat

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,20 +1,7 @@
 # OllamaChat
 
-OllamaChat is a sample chat client for local LLMs powered by
-[Semantic Kernel](https://github.com/microsoft/semantic-kernel). It now
-supports multi‑agent conversations through the `GroupChatOrchestration` API.
-
-```csharp
-var orchestrator = new GroupChatOrchestration(
-    new BridgingRoundRobinManager { MaximumInvocationCount = 2 },
-    agent1, agent2);
-
-await using var runtime = new InProcessRuntime();
-await runtime.StartAsync();
-var result = await orchestrator.InvokeAsync("Hello", runtime);
-string final = await result.GetValueAsync();
-```
-
-Each agent is a `ChatCompletionAgent` with its own agent description. The round‑robin
-manager automatically rotates agents and stops after the specified number of
-rounds.
+OllamaChat is a sample chat client for local LLMs built on
+[Semantic Kernel](https://github.com/microsoft/semantic-kernel). It supports
+multi‑agent conversations via `GroupChatOrchestration` and uses a
+`ForceLastUserReducer` so the chat history always ends with a user message
+(`AuthorName="user"`).

--- a/docs/multi-agent-chat.md
+++ b/docs/multi-agent-chat.md
@@ -1,44 +1,19 @@
 # Multi-Agent Chat
 
-OllamaChat now relies on Semantic Kernel's built-in **GroupChatOrchestration** for
-all conversations. Every selected agent description becomes a `ChatCompletionAgent`,
-and a `RoundRobinGroupChatManager` rotates agents in turn. When only one agent is
-chosen, the orchestrator streams tokens through its `ResponseCallback`, so the
-client never talks to `IChatCompletionService` directly.
+OllamaChat uses Semantic Kernel's `GroupChatOrchestration` to coordinate
+selected `ChatCompletionAgent` instances. A `RoundRobinGroupChatManager`
+cycles through agents; increase `MaximumInvocationCount` to let them
+auto‑continue without extra user messages.
+
+The orchestrator's `ResponseCallback` writes messages directly to the chat
+history and the UI displays agent names from `ChatCompletionAgent.Name`.
+
+To keep the last speaker consistent, a `ForceLastUserReducer` rewrites the
+final agent reply as a user message (`AuthorName="user"`).
 
 ```csharp
-var ruToEn = new ChatCompletionAgent
-{
-    Name = "ru_to_en",
-    Description = "Russian to English translator",
-    Kernel = kernel,
-    Instructions = "If last message is Russian, translate it to English."
-};
-
-var enToEs = new ChatCompletionAgent
-{
-    Name = "en_to_es",
-    Description = "English to Spanish translator",
-    Kernel = kernel,
-    Instructions = "If last message is English, translate it to Spanish."
-};
-
 var orchestrator = new GroupChatOrchestration(
     new RoundRobinGroupChatManager { MaximumInvocationCount = 2 },
-    ruToEn, enToEs);
-
-await using var runtime = new InProcessRuntime();
-await runtime.StartAsync();
-var result = await orchestrator.InvokeAsync("Привет", runtime);
-string final = await result.GetValueAsync();
+    agents);
 ```
-
-`MaximumInvocationCount` controls how many times agents are invoked. Set it to a
-value greater than `1` to let agents auto‑continue without additional user
-messages.
-
-The chat UI records agent names from `ChatCompletionAgent.Name` so each message
-shows the speaker. No custom coordinator or manual history management is
-required—the orchestrator's `ResponseCallback` adds messages to the chat
-history directly.
 


### PR DESCRIPTION
## Summary
- simplify README and multi-agent chat documentation
- note that ForceLastUserReducer marks final agent reply as user

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68a6ec8315bc832a9c64510f73f1081a