### PR TITLE
feat: add round robin summary orchestrator

### DIFF
--- a/ChatClient.Api/Client/Components/IStopAgentParameters.cs
+++ b/ChatClient.Api/Client/Components/IStopAgentParameters.cs
@@ -1,0 +1,9 @@
+using ChatClient.Shared.Models.StopAgents;
+
+namespace ChatClient.Api.Client.Components;
+
+public interface IStopAgentParameters<out TRealParameterType>
+    where TRealParameterType : IStopAgentOptions
+{
+    TRealParameterType GetOptions();
+}

--- a/ChatClient.Api/Client/Components/RoundRobinStopAgentParameters.razor
+++ b/ChatClient.Api/Client/Components/RoundRobinStopAgentParameters.razor
@@ -1,8 +1,9 @@
 @using MudBlazor
 @using ChatClient.Shared.Models.StopAgents
+@implements IStopAgentParameters<RoundRobinStopAgentOptions>
 
 <MudNumericField T="int"
-                 Value="Options.Rounds"
+                 Value="TypedOptions.Rounds"
                  ValueChanged="OnRoundsChanged"
                  Min="1"
                  Label="Rounds"
@@ -12,14 +13,14 @@
 
 @code {
     [Parameter]
-    public RoundRobinStopAgentOptions Options { get; set; } = new();
+    public IStopAgentOptions Options { get; set; } = new RoundRobinStopAgentOptions();
 
-    [Parameter]
-    public EventCallback<RoundRobinStopAgentOptions> OptionsChanged { get; set; }
+    private RoundRobinStopAgentOptions TypedOptions => (RoundRobinStopAgentOptions)Options;
 
-    private async Task OnRoundsChanged(int value)
+    public RoundRobinStopAgentOptions GetOptions() => TypedOptions;
+
+    private void OnRoundsChanged(int value)
     {
-        Options.Rounds = value;
-        await OptionsChanged.InvokeAsync(Options);
+        TypedOptions.Rounds = value;
     }
 }

--- a/ChatClient.Api/Client/Components/RoundRobinSummaryStopAgentParameters.razor
+++ b/ChatClient.Api/Client/Components/RoundRobinSummaryStopAgentParameters.razor
@@ -1,0 +1,49 @@
+@using MudBlazor
+@using ChatClient.Shared.Models.StopAgents
+@using ChatClient.Shared.Models
+@implements IStopAgentParameters<RoundRobinSummaryStopAgentOptions>
+
+<MudNumericField T="int"
+                 Value="TypedOptions.Rounds"
+                 ValueChanged="OnRoundsChanged"
+                 Min="1"
+                 Label="Rounds"
+                 Variant="Variant.Outlined"
+                 FullWidth="true"
+                 Class="mt-4" />
+
+<MudSelect T="string"
+           Label="Summary Agent"
+           Value="TypedOptions.SummaryAgent"
+           ValueChanged="OnSummaryAgentChanged"
+           Variant="Variant.Outlined"
+           FullWidth="true"
+           Dense="true"
+           Class="mt-4">
+    @foreach (var agent in Agents)
+    {
+        <MudSelectItem Value="@agent.AgentName">@agent.AgentName</MudSelectItem>
+    }
+</MudSelect>
+
+@code {
+    [Parameter]
+    public IStopAgentOptions Options { get; set; } = new RoundRobinSummaryStopAgentOptions();
+
+    [Parameter]
+    public IReadOnlyList<AgentDescription> Agents { get; set; } = Array.Empty<AgentDescription>();
+
+    private RoundRobinSummaryStopAgentOptions TypedOptions => (RoundRobinSummaryStopAgentOptions)Options;
+
+    public RoundRobinSummaryStopAgentOptions GetOptions() => TypedOptions;
+
+    private void OnRoundsChanged(int value)
+    {
+        TypedOptions.Rounds = value;
+    }
+
+    private void OnSummaryAgentChanged(string value)
+    {
+        TypedOptions.SummaryAgent = value;
+    }
+}

--- a/ChatClient.Api/Client/Pages/MultiAgentChat.razor
+++ b/ChatClient.Api/Client/Pages/MultiAgentChat.razor
@@ -56,15 +56,27 @@
                         }
                     </MudSelect>
 
-                    <MudSelect T="string" Label="Stop Agent" @bind-Value="stopAgentName" Variant="Variant.Outlined" FullWidth="true" Class="mt-4" Dense="true">
+                    <MudSelect T="string"
+                               Label="Stop Agent"
+                               Value="stopAgentName"
+                               ValueChanged="OnStopAgentChanged"
+                               Variant="Variant.Outlined"
+                               FullWidth="true"
+                               Class="mt-4"
+                               Dense="true">
                         @foreach (var agent in stopAgents)
                         {
                             <MudSelectItem Value="@agent">@agent</MudSelectItem>
                         }
                     </MudSelect>
-                    @if (stopAgentName == RoundRobinStopAgent)
+                    @switch (stopAgentName)
                     {
-                        <RoundRobinStopAgentParameters @bind-Options="roundRobinOptions" />
+                        case RoundRobinStopAgent:
+                            <RoundRobinStopAgentParameters @ref="stopAgentParametersComponent" Options="stopAgentOptions" />
+                            break;
+                        case RoundRobinSummaryStopAgent:
+                            <RoundRobinSummaryStopAgentParameters @ref="stopAgentParametersComponent" Options="stopAgentOptions" Agents="selectedAgents" />
+                            break;
                     }
 
                     <MudButton Variant="Variant.Filled"
@@ -235,8 +247,10 @@
     public OllamaModel? SelectedModel { get; set; }
 
     private const string RoundRobinStopAgent = "RoundRobin";
-    private List<string> stopAgents = new() { RoundRobinStopAgent };
-    private RoundRobinStopAgentOptions roundRobinOptions = new();
+    private const string RoundRobinSummaryStopAgent = "RoundRobinWithSummary";
+    private List<string> stopAgents = new();
+    private IStopAgentParameters<IStopAgentOptions>? stopAgentParametersComponent;
+    private IStopAgentOptions stopAgentOptions = new RoundRobinStopAgentOptions();
     private string stopAgentName = RoundRobinStopAgent;
 
     private UserSettings userSettings = new();
@@ -249,6 +263,8 @@
 
     protected override async Task OnInitializedAsync()
     {
+        stopAgents = new() { RoundRobinStopAgent, RoundRobinSummaryStopAgent };
+
         isLoadingInitialData = true;
         StateHasChanged();
 
@@ -296,6 +312,17 @@
         StateHasChanged();
     }
 
+    private void OnStopAgentChanged(string name)
+    {
+        stopAgentName = name;
+        stopAgentOptions = name switch
+        {
+            RoundRobinStopAgent => new RoundRobinStopAgentOptions(),
+            RoundRobinSummaryStopAgent => new RoundRobinSummaryStopAgentOptions(),
+            _ => new RoundRobinStopAgentOptions()
+        };
+    }
+
     private async Task LoadAgents()
     {
         agents = await AgentService.GetAllAsync();
@@ -311,8 +338,23 @@
             ? RoundRobinStopAgent
             : userSettings.StopAgentName;
 
-        if (userSettings.MultiAgentRounds > 0)
-            roundRobinOptions.Rounds = userSettings.MultiAgentRounds;
+        stopAgentOptions = stopAgentName switch
+        {
+            RoundRobinStopAgent => new RoundRobinStopAgentOptions(),
+            RoundRobinSummaryStopAgent => new RoundRobinSummaryStopAgentOptions(),
+            _ => new RoundRobinStopAgentOptions()
+        };
+
+        if (userSettings.StopAgentOptions.HasValue)
+        {
+            var element = userSettings.StopAgentOptions.Value;
+            stopAgentOptions = stopAgentName switch
+            {
+                RoundRobinStopAgent => element.Deserialize<RoundRobinStopAgentOptions>() ?? new RoundRobinStopAgentOptions(),
+                RoundRobinSummaryStopAgent => element.Deserialize<RoundRobinSummaryStopAgentOptions>() ?? new RoundRobinSummaryStopAgentOptions(),
+                _ => new RoundRobinStopAgentOptions()
+            };
+        }
 
         if (userSettings.MultiAgentSelectedAgents?.Count > 0)
         {
@@ -335,7 +377,10 @@
 
         userSettings.StopAgentName = stopAgentName;
         userSettings.MultiAgentSelectedAgents = selectedAgents.Select(a => a.AgentName).ToList();
-        userSettings.MultiAgentRounds = roundRobinOptions.Rounds;
+        var opts = stopAgentParametersComponent?.GetOptions();
+        userSettings.StopAgentOptions = opts is null
+            ? null
+            : JsonSerializer.SerializeToElement(opts, opts.GetType());
         await UserSettingsService.SaveSettingsAsync(userSettings);
 
         ChatService.InitializeChat(selectedAgents);
@@ -352,11 +397,21 @@
             .Distinct()
             .ToList();
 
-        var rounds = selectedAgents.Count == 1 ? 1 : roundRobinOptions.Rounds;
-
-        var chatConfiguration = new ChatConfiguration(SelectedModel?.Name, allFunctions);
-        var options = new RoundRobinStopAgentOptions { Rounds = rounds };
+        var options = stopAgentParametersComponent?.GetOptions();
+        if (selectedAgents.Count == 1)
+        {
+            switch (options)
+            {
+                case RoundRobinStopAgentOptions rr:
+                    rr.Rounds = 1;
+                    break;
+                case RoundRobinSummaryStopAgentOptions rs:
+                    rs.Rounds = 1;
+                    break;
+            }
+        }
         var groupChatManager = StopAgentFactory.Create(stopAgentName, options);
+        var chatConfiguration = new ChatConfiguration(SelectedModel?.Name, allFunctions);
 
         await ChatService.GenerateAnswerAsync(messageData.text.Trim(), chatConfiguration, groupChatManager, messageData.files);
         await ScrollToBottom();

--- a/ChatClient.Api/Client/Services/RoundRobinSummaryGroupChatManager.cs
+++ b/ChatClient.Api/Client/Services/RoundRobinSummaryGroupChatManager.cs
@@ -1,0 +1,42 @@
+using Microsoft.SemanticKernel.Agents.Orchestration.GroupChat;
+using Microsoft.SemanticKernel.ChatCompletion;
+
+namespace ChatClient.Api.Client.Services;
+
+#pragma warning disable SKEXP0110
+public sealed class RoundRobinSummaryGroupChatManager(string summaryAgentName) : RoundRobinGroupChatManager
+{
+    private readonly string _summaryAgentName = summaryAgentName;
+    private bool _summaryPending;
+    private bool _summaryDone;
+
+    public override async ValueTask<GroupChatManagerResult<bool>> ShouldTerminate(
+        ChatHistory history,
+        CancellationToken cancellationToken = default)
+    {
+        var baseResult = await base.ShouldTerminate(history, cancellationToken);
+        if (_summaryDone) return baseResult;
+        if (!baseResult.Value) return baseResult;
+        if (!_summaryPending)
+        {
+            _summaryPending = true;
+            return new(false);
+        }
+        return new(false);
+    }
+
+    public override ValueTask<GroupChatManagerResult<string>> SelectNextAgent(
+        ChatHistory history,
+        GroupChatTeam team,
+        CancellationToken cancellationToken = default)
+    {
+        if (_summaryPending && !_summaryDone)
+        {
+            _summaryDone = true;
+            _summaryPending = false;
+            return ValueTask.FromResult(new GroupChatManagerResult<string>(_summaryAgentName));
+        }
+        return base.SelectNextAgent(history, team, cancellationToken);
+    }
+}
+#pragma warning restore SKEXP0110

--- a/ChatClient.Api/Client/Services/StopAgentFactory.cs
+++ b/ChatClient.Api/Client/Services/StopAgentFactory.cs
@@ -6,16 +6,29 @@ namespace ChatClient.Api.Client.Services;
 #pragma warning disable SKEXP0110
 internal class StopAgentFactory : IStopAgentFactory
 {
-    public GroupChatManager Create(string name, IStopAgentOptions? options = null) => name switch
+    private readonly Dictionary<string, Func<IStopAgentOptions?, GroupChatManager>> _factories = new()
     {
-        "RoundRobin" => CreateRoundRobin(options as RoundRobinStopAgentOptions),
-        _ => CreateRoundRobin(options as RoundRobinStopAgentOptions)
+        ["RoundRobin"] = o => CreateRoundRobin(o as RoundRobinStopAgentOptions),
+        ["RoundRobinWithSummary"] = o => CreateRoundRobinWithSummary(o as RoundRobinSummaryStopAgentOptions)
     };
+
+    public GroupChatManager Create(string name, IStopAgentOptions? options = null)
+    {
+        if (_factories.TryGetValue(name, out var factory)) return factory(options);
+        return CreateRoundRobin(options as RoundRobinStopAgentOptions);
+    }
 
     private static GroupChatManager CreateRoundRobin(RoundRobinStopAgentOptions? opts)
     {
         var rounds = opts?.Rounds ?? 1;
         return new BridgingRoundRobinManager { MaximumInvocationCount = rounds };
+    }
+
+    private static GroupChatManager CreateRoundRobinWithSummary(RoundRobinSummaryStopAgentOptions? opts)
+    {
+        var rounds = opts?.Rounds ?? 1;
+        var agent = opts?.SummaryAgent ?? string.Empty;
+        return new RoundRobinSummaryGroupChatManager(agent) { MaximumInvocationCount = rounds };
     }
 }
 #pragma warning restore SKEXP0110

--- a/ChatClient.Shared/Models/StopAgents/RoundRobinSummaryStopAgentOptions.cs
+++ b/ChatClient.Shared/Models/StopAgents/RoundRobinSummaryStopAgentOptions.cs
@@ -1,0 +1,7 @@
+namespace ChatClient.Shared.Models.StopAgents;
+
+public class RoundRobinSummaryStopAgentOptions : IStopAgentOptions
+{
+    public int Rounds { get; set; } = 1;
+    public string SummaryAgent { get; set; } = string.Empty;
+}

--- a/ChatClient.Shared/Models/UserSettings.cs
+++ b/ChatClient.Shared/Models/UserSettings.cs
@@ -1,5 +1,6 @@
 using System.Text.Json.Serialization;
 using System.Collections.Generic;
+using System.Text.Json;
 
 using ChatClient.Shared.Constants;
 
@@ -74,6 +75,6 @@ public class UserSettings
     [JsonPropertyName("multiAgentSelectedAgents")]
     public List<string> MultiAgentSelectedAgents { get; set; } = [];
 
-    [JsonPropertyName("multiAgentRounds")]
-    public int MultiAgentRounds { get; set; } = 1;
+    [JsonPropertyName("stopAgentOptions")]
+    public JsonElement? StopAgentOptions { get; set; }
 }


### PR DESCRIPTION
## Summary
- add stop agent parameter interface so UI components return typed options
- persist strategy options as serialized JSON in user settings
- build group chat manager using options without round-specific helpers
- consolidate stop agent options into a single instance and swap components based on selection

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68a70e5042e8832a87badda09ec5b58d