### PR TITLE
Render stop agent parameters via dynamic components

### DIFF
--- a/ChatClient.Api/Client/Components/IStopAgentParameters.cs
+++ b/ChatClient.Api/Client/Components/IStopAgentParameters.cs
@@ -1,9 +1,0 @@
-using ChatClient.Shared.Models.StopAgents;
-
-namespace ChatClient.Api.Client.Components;
-
-public interface IStopAgentParameters<out TRealParameterType>
-    where TRealParameterType : IStopAgentOptions
-{
-    TRealParameterType GetOptions();
-}

--- a/ChatClient.Api/Client/Components/RoundRobinStopAgentParameters.razor
+++ b/ChatClient.Api/Client/Components/RoundRobinStopAgentParameters.razor
@@ -1,6 +1,6 @@
 @using MudBlazor
 @using ChatClient.Shared.Models.StopAgents
-@implements IStopAgentParameters<RoundRobinStopAgentOptions>
+@inherits StopAgentParametersBase
 
 <MudNumericField T="int"
                  Value="TypedOptions.Rounds"
@@ -12,12 +12,7 @@
                  Class="mt-4" />
 
 @code {
-    [Parameter]
-    public IStopAgentOptions Options { get; set; } = new RoundRobinStopAgentOptions();
-
-    private RoundRobinStopAgentOptions TypedOptions => (RoundRobinStopAgentOptions)Options;
-
-    public RoundRobinStopAgentOptions GetOptions() => TypedOptions;
+    private RoundRobinStopAgentOptions TypedOptions => (RoundRobinStopAgentOptions)Context.Options;
 
     private void OnRoundsChanged(int value)
     {

--- a/ChatClient.Api/Client/Components/RoundRobinSummaryStopAgentParameters.razor
+++ b/ChatClient.Api/Client/Components/RoundRobinSummaryStopAgentParameters.razor
@@ -1,7 +1,7 @@
 @using MudBlazor
 @using ChatClient.Shared.Models.StopAgents
 @using ChatClient.Shared.Models
-@implements IStopAgentParameters<RoundRobinSummaryStopAgentOptions>
+@inherits StopAgentParametersBase
 
 <MudNumericField T="int"
                  Value="TypedOptions.Rounds"
@@ -20,22 +20,14 @@
            FullWidth="true"
            Dense="true"
            Class="mt-4">
-    @foreach (var agent in Agents)
+    @foreach (var agent in Context.Agents)
     {
         <MudSelectItem Value="@agent.AgentName">@agent.AgentName</MudSelectItem>
     }
 </MudSelect>
 
 @code {
-    [Parameter]
-    public IStopAgentOptions Options { get; set; } = new RoundRobinSummaryStopAgentOptions();
-
-    [Parameter]
-    public IReadOnlyList<AgentDescription> Agents { get; set; } = Array.Empty<AgentDescription>();
-
-    private RoundRobinSummaryStopAgentOptions TypedOptions => (RoundRobinSummaryStopAgentOptions)Options;
-
-    public RoundRobinSummaryStopAgentOptions GetOptions() => TypedOptions;
+    private RoundRobinSummaryStopAgentOptions TypedOptions => (RoundRobinSummaryStopAgentOptions)Context.Options;
 
     private void OnRoundsChanged(int value)
     {

--- a/ChatClient.Api/Client/Components/StopAgentParametersBase.cs
+++ b/ChatClient.Api/Client/Components/StopAgentParametersBase.cs
@@ -1,0 +1,14 @@
+using ChatClient.Shared.Models;
+using ChatClient.Shared.Models.StopAgents;
+using Microsoft.AspNetCore.Components;
+
+namespace ChatClient.Api.Client.Components;
+
+public sealed record StopAgentEditorContext(IStopAgentOptions Options, IReadOnlyList<AgentDescription> Agents);
+
+public abstract class StopAgentParametersBase : ComponentBase
+{
+    [Parameter]
+    public StopAgentEditorContext Context { get; set; } = default!;
+}
+

--- a/ChatClient.Api/Client/Pages/MultiAgentChat.razor
+++ b/ChatClient.Api/Client/Pages/MultiAgentChat.razor
@@ -3,6 +3,7 @@
 @using Microsoft.AspNetCore.Components.Web
 @using System.Collections.ObjectModel
 @using System.Collections.Generic
+@using System.Collections.Immutable
 @using System.Text.Json
 @using ChatClient.Shared.Models
 @using ChatClient.Shared.Models.StopAgents
@@ -69,14 +70,13 @@
                             <MudSelectItem Value="@agent">@agent</MudSelectItem>
                         }
                     </MudSelect>
-                    @switch (stopAgentName)
+                    @if (editorType is not null)
                     {
-                        case RoundRobinStopAgent:
-                            <RoundRobinStopAgentParameters @ref="stopAgentParametersComponent" Options="stopAgentOptions" />
-                            break;
-                        case RoundRobinSummaryStopAgent:
-                            <RoundRobinSummaryStopAgentParameters @ref="stopAgentParametersComponent" Options="stopAgentOptions" Agents="agents" />
-                            break;
+                        <DynamicComponent Type="editorType" Parameters="editorParams" />
+                    }
+                    else
+                    {
+                        <em>Editor for '@stopAgentOptions.GetType().Name' not found</em>
                     }
 
                     <MudButton Variant="Variant.Filled"
@@ -249,9 +249,19 @@
     private const string RoundRobinStopAgent = "RoundRobin";
     private const string RoundRobinSummaryStopAgent = "RoundRobinWithSummary";
     private List<string> stopAgents = new();
-    private IStopAgentParameters<IStopAgentOptions>? stopAgentParametersComponent;
     private IStopAgentOptions stopAgentOptions = new RoundRobinStopAgentOptions();
     private string stopAgentName = RoundRobinStopAgent;
+
+    private static readonly IReadOnlyDictionary<Type, Type> Editors = new Dictionary<Type, Type>
+    {
+        { typeof(RoundRobinStopAgentOptions), typeof(RoundRobinStopAgentParameters) },
+        { typeof(RoundRobinSummaryStopAgentOptions), typeof(RoundRobinSummaryStopAgentParameters) },
+    }.ToImmutableDictionary();
+
+    private Type? editorType => Editors.TryGetValue(stopAgentOptions.GetType(), out var t) ? t : null;
+
+    private Dictionary<string, object?> editorParams =>
+        new() { ["Context"] = new StopAgentEditorContext(stopAgentOptions, agents) };
 
     private UserSettings userSettings = new();
 
@@ -377,10 +387,7 @@
 
         userSettings.StopAgentName = stopAgentName;
         userSettings.MultiAgentSelectedAgents = selectedAgents.Select(a => a.AgentName).ToList();
-        var opts = stopAgentParametersComponent?.GetOptions();
-        userSettings.StopAgentOptions = opts is null
-            ? null
-            : JsonSerializer.SerializeToElement(opts, opts.GetType());
+        userSettings.StopAgentOptions = JsonSerializer.SerializeToElement(stopAgentOptions, stopAgentOptions.GetType());
         await UserSettingsService.SaveSettingsAsync(userSettings);
 
         ChatService.InitializeChat(selectedAgents);
@@ -397,7 +404,7 @@
             .Distinct()
             .ToList();
 
-        var options = stopAgentParametersComponent?.GetOptions();
+        var options = stopAgentOptions;
         if (selectedAgents.Count == 1)
         {
             switch (options)


### PR DESCRIPTION
## Summary
- Replace switch-based parameter editors with dynamic component resolution
- Introduce shared StopAgentEditorContext and base class for stop agent parameter components
- Persist stop agent options directly without component interface

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68a7269cf2e4832a9d3e32568139b0a1