### PR TITLE
Fix summary agent lookup

### DIFF
--- a/ChatClient.Api/Client/Components/RoundRobinSummaryStopAgentParameters.razor
+++ b/ChatClient.Api/Client/Components/RoundRobinSummaryStopAgentParameters.razor
@@ -22,7 +22,7 @@
            Class="mt-4">
     @foreach (var agent in Context.Agents)
     {
-        <MudSelectItem Value="@agent.AgentName">@agent.AgentName</MudSelectItem>
+        <MudSelectItem Value="@agent.AgentId">@agent.AgentName</MudSelectItem>
     }
 </MudSelect>
 

--- a/ChatClient.Api/Client/Services/ChatService.cs
+++ b/ChatClient.Api/Client/Services/ChatService.cs
@@ -61,7 +61,7 @@ public class ChatService(
 
         // Create lookup dictionary for agent names
         _agentsByName = agents.ToDictionary(
-            desc => !string.IsNullOrWhiteSpace(desc.ShortName) ? desc.ShortName : desc.AgentName,
+            desc => desc.AgentId,
             desc => desc,
             StringComparer.OrdinalIgnoreCase);
 
@@ -227,8 +227,7 @@ public class ChatService(
             var modelName = desc.ModelName ?? throw new InvalidOperationException("Agent model name is not set.");
             var agentKernel = await kernelService.CreateKernelAsync(modelName, functionsToRegister, desc.AgentName);
 
-            // TODO Add function into AgentDescription to get Agent name for UI
-            var agentName = !string.IsNullOrWhiteSpace(desc.ShortName) ? desc.ShortName : desc.AgentName;
+            var agentName = desc.AgentId;
 
             var trackingFilter = new FunctionCallRecordingFilter();
             agentKernel.FunctionInvocationFilters.Add(trackingFilter);

--- a/ChatClient.Shared/Models/AgentDescription.cs
+++ b/ChatClient.Shared/Models/AgentDescription.cs
@@ -1,3 +1,5 @@
+using System.Text.Json.Serialization;
+
 namespace ChatClient.Shared.Models;
 
 public class AgentDescription
@@ -9,6 +11,9 @@ public class AgentDescription
     public string? ModelName { get; set; }
     public double? Temperature { get; set; }
     public double? RepeatPenalty { get; set; }
+
+    [JsonIgnore]
+    public string AgentId => string.IsNullOrWhiteSpace(ShortName) ? AgentName : ShortName;
 
     public FunctionSettings FunctionSettings { get; set; } = new();
 


### PR DESCRIPTION
## Summary
- Introduce `AgentId` property on `AgentDescription` to centralize identifier logic
- Use `AgentId` for agent dictionary lookup and agent selection controls

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68a73579ba48832abe9c4d20c0f74ecf