### PR TITLE
Fix summary agent handling in round robin chats

### DIFF
--- a/ChatClient.Api/Client/Pages/MultiAgentChat.razor
+++ b/ChatClient.Api/Client/Pages/MultiAgentChat.razor
@@ -390,7 +390,18 @@
         userSettings.StopAgentOptions = JsonSerializer.SerializeToElement(stopAgentOptions, stopAgentOptions.GetType());
         await UserSettingsService.SaveSettingsAsync(userSettings);
 
-        ChatService.InitializeChat(selectedAgents);
+        var agentsForChat = selectedAgents.ToList();
+        var manager = StopAgentFactory.Create(stopAgentName, stopAgentOptions);
+        if (manager is IGroupChatAgentProvider provider)
+        {
+            foreach (var agentId in provider.GetRequiredAgents())
+            {
+                var agent = agents.FirstOrDefault(a => a.AgentId == agentId);
+                if (agent is not null && agentsForChat.All(a => a.AgentId != agent.AgentId))
+                    agentsForChat.Add(agent);
+            }
+        }
+        ChatService.InitializeChat(agentsForChat);
         chatStarted = true;
         StateHasChanged();
     }

--- a/ChatClient.Api/Client/Services/IGroupChatAgentProvider.cs
+++ b/ChatClient.Api/Client/Services/IGroupChatAgentProvider.cs
@@ -1,0 +1,8 @@
+using System.Collections.Generic;
+
+namespace ChatClient.Api.Client.Services;
+
+public interface IGroupChatAgentProvider
+{
+    IEnumerable<string> GetRequiredAgents();
+}


### PR DESCRIPTION
## Summary
- expose chat manager required agents via IGroupChatAgentProvider
- register manager-provided agents during chat initialization
- implement agent provider in RoundRobinSummaryGroupChatManager

## Testing
- `dotnet test --no-build`


------
https://chatgpt.com/codex/tasks/task_e_68a7433d590c832aa8f3852ded937898