### PR TITLE
Propagate cancellation tokens through agent setup

### DIFF
--- a/ChatClient.Api/Services/IMcpClientService.cs
+++ b/ChatClient.Api/Services/IMcpClientService.cs
@@ -6,6 +6,6 @@ namespace ChatClient.Api.Services;
 
 public interface IMcpClientService : IAsyncDisposable
 {
-    Task<IReadOnlyCollection<IMcpClient>> GetMcpClientsAsync();
-    Task<IReadOnlyList<McpClientTool>> GetMcpTools(IMcpClient mcpClient);
+    Task<IReadOnlyCollection<IMcpClient>> GetMcpClientsAsync(CancellationToken cancellationToken = default);
+    Task<IReadOnlyList<McpClientTool>> GetMcpTools(IMcpClient mcpClient, CancellationToken cancellationToken = default);
 }

--- a/ChatClient.Api/Services/McpFunctionIndexService.cs
+++ b/ChatClient.Api/Services/McpFunctionIndexService.cs
@@ -61,10 +61,11 @@ public class McpFunctionIndexService
                 return;
             }
 
-            var clients = await _clientService.GetMcpClientsAsync();
+            var clients = await _clientService.GetMcpClientsAsync(cancellationToken);
             foreach (var client in clients)
             {
-                var tools = await _clientService.GetMcpTools(client);
+                cancellationToken.ThrowIfCancellationRequested();
+                var tools = await _clientService.GetMcpTools(client, cancellationToken);
                 foreach (var tool in tools)
                 {
                     string text = $"{tool.Name}. {tool.Description}";


### PR DESCRIPTION
## Summary
- ensure cancel requests reach agent creation and MCP tooling
- add cancellation support to MCP client and function index services

## Testing
- `dotnet test --no-build`

------
https://chatgpt.com/codex/tasks/task_e_68a77b6f5994832ab52e493e086961f6