### PR TITLE
Rename AgentFile to RagFile, extend file converter, and add internal agent GUID

### DIFF
--- a/ChatClient.Api/Client/Pages/AgentDescriptions.razor
+++ b/ChatClient.Api/Client/Pages/AgentDescriptions.razor
@@ -1,4 +1,5 @@
 ﻿@page "/agent-descriptions"
+@using System
 @using ChatClient.Shared.Models
 @using ChatClient.Shared.Services
 @using ChatClient.Api.Services
@@ -173,7 +174,7 @@
 
 <MudDialog @bind-Visible="@showEditAgentDialog" Options="editDialogOptions">
     <TitleContent>
-        <MudText Typo="Typo.h6">@(editingAgent?.Id == null ? "Create New Agent Description" : "Edit Agent Description")</MudText>
+        <MudText Typo="Typo.h6">@(editingAgent?.Id == Guid.Empty ? "Create New Agent Description" : "Edit Agent Description")</MudText>
     </TitleContent>
     <DialogContent>
         <MudForm @ref="editAgentForm" Model="@editingAgent">
@@ -313,7 +314,7 @@
     {
         editingAgent = new AgentDescription
         {
-            Id = null,
+            Id = Guid.Empty,
             CreatedAt = DateTime.UtcNow,
             UpdatedAt = DateTime.UtcNow,
             AgentName = "",
@@ -391,10 +392,10 @@
 
     private async Task DeleteAgent()
     {
-        if (agentToDelete?.Id == null) return;
+        if (agentToDelete is null || agentToDelete.Id == Guid.Empty) return;
         try
         {
-            await AgentService.DeleteAsync(agentToDelete.Id.Value);
+            await AgentService.DeleteAsync(agentToDelete.Id);
             Snackbar.Add("Agent deleted successfully", Severity.Success);
 
             agents.Remove(agentToDelete);
@@ -451,7 +452,7 @@
         {
             try
             {
-                if (editingAgent.Id == null)
+                if (editingAgent.Id == Guid.Empty)
                 {
                     var result = await AgentService.CreateAsync(editingAgent);
                     agents.Add(result);

--- a/ChatClient.Api/Controllers/RagFilesController.cs
+++ b/ChatClient.Api/Controllers/RagFilesController.cs
@@ -1,0 +1,68 @@
+using System.IO;
+using System.Linq;
+
+using Microsoft.AspNetCore.Mvc;
+using ChatClient.Api.Services;
+using ChatClient.Shared.Models;
+using ChatClient.Shared.Services;
+
+namespace ChatClient.Api.Controllers;
+
+[ApiController]
+[Route("api/agents/{id:guid}/files")]
+public class RagFilesController : ControllerBase
+{
+    private readonly IRagFileService _fileService;
+    private readonly IFileConverter _converter;
+
+    public RagFilesController(IRagFileService fileService, IFileConverter converter)
+    {
+        _fileService = fileService;
+        _converter = converter;
+    }
+
+    [HttpGet]
+    public async Task<ActionResult<IEnumerable<RagFile>>> GetFiles(Guid id)
+        => Ok(await _fileService.GetFilesAsync(id));
+
+    [HttpGet("{fileName}")]
+    public async Task<ActionResult<RagFile>> GetFile(Guid id, string fileName)
+    {
+        var file = await _fileService.GetFileAsync(id, fileName);
+        if (file is null)
+            return NotFound();
+        return Ok(file);
+    }
+
+    [HttpPost]
+    public async Task<ActionResult> Upload(Guid id, [FromForm] IFormFile file)
+    {
+        var ext = Path.GetExtension(file.FileName);
+        if (!_converter.GetSupportedExtensions().Contains(ext, StringComparer.OrdinalIgnoreCase))
+            return BadRequest($"Unsupported file type {ext}");
+
+        var content = await _converter.ConvertToTextAsync(file);
+        await _fileService.AddOrUpdateFileAsync(id, new RagFile { FileName = file.FileName, Content = content });
+        return Ok();
+    }
+
+    [HttpPut("{fileName}")]
+    public async Task<ActionResult> Update(Guid id, string fileName, [FromForm] IFormFile file)
+    {
+        var ext = Path.GetExtension(file.FileName);
+        if (!_converter.GetSupportedExtensions().Contains(ext, StringComparer.OrdinalIgnoreCase))
+            return BadRequest($"Unsupported file type {ext}");
+
+        var content = await _converter.ConvertToTextAsync(file);
+        await _fileService.AddOrUpdateFileAsync(id, new RagFile { FileName = fileName, Content = content });
+        return Ok();
+    }
+
+    [HttpDelete("{fileName}")]
+    public async Task<ActionResult> Delete(Guid id, string fileName)
+    {
+        await _fileService.DeleteFileAsync(id, fileName);
+        return NoContent();
+    }
+}
+

--- a/ChatClient.Api/Program.cs
+++ b/ChatClient.Api/Program.cs
@@ -43,6 +43,8 @@ builder.Services.AddSingleton<ChatClient.Api.Services.IAppChatHistoryBuilder, Ch
 builder.Services.AddScoped<ChatClient.Api.Services.StartupOllamaChecker>();
 builder.Services.AddSingleton<ChatClient.Shared.Services.IAgentDescriptionService, ChatClient.Api.Services.AgentDescriptionService>();
 builder.Services.AddSingleton<ChatClient.Shared.Services.IUserSettingsService, ChatClient.Api.Services.UserSettingsService>();
+builder.Services.AddSingleton<ChatClient.Shared.Services.IRagFileService, ChatClient.Api.Services.RagFileService>();
+builder.Services.AddSingleton<ChatClient.Api.Services.IFileConverter, ChatClient.Api.Services.NoOpFileConverter>();
 builder.Services.AddScoped<ChatClient.Api.Client.Services.IAppChatService, ChatClient.Api.Client.Services.AppChatService>();
 builder.Services.AddScoped<ChatClient.Api.Client.Services.IChatViewModelService, ChatClient.Api.Client.Services.ChatViewModelService>();
 builder.Services.AddSingleton<ChatClient.Api.Client.Services.IStopAgentFactory, ChatClient.Api.Client.Services.StopAgentFactory>();

--- a/ChatClient.Api/Services/AgentDescriptionService.cs
+++ b/ChatClient.Api/Services/AgentDescriptionService.cs
@@ -87,7 +87,7 @@ public class AgentDescriptionService : IAgentDescriptionService
 
             var agents = await ReadFromFileAsync();
 
-            if (prompt.Id == null)
+            if (prompt.Id == Guid.Empty)
                 prompt.Id = Guid.NewGuid();
 
             prompt.CreatedAt = DateTime.UtcNow;
@@ -178,6 +178,16 @@ public class AgentDescriptionService : IAgentDescriptionService
 
         var json = await File.ReadAllTextAsync(_filePath);
         var agents = JsonSerializer.Deserialize<List<AgentDescription>>(json) ?? [];
+
+        var updated = false;
+        foreach (var agent in agents.Where(a => a.Id == Guid.Empty))
+        {
+            agent.Id = Guid.NewGuid();
+            updated = true;
+        }
+
+        if (updated)
+            await WriteToFileAsync(agents);
 
         return agents;
     }

--- a/ChatClient.Api/Services/IFileConverter.cs
+++ b/ChatClient.Api/Services/IFileConverter.cs
@@ -1,0 +1,12 @@
+using System.Collections.Generic;
+
+using Microsoft.AspNetCore.Http;
+
+namespace ChatClient.Api.Services;
+
+public interface IFileConverter
+{
+    Task<string> ConvertToTextAsync(IFormFile file);
+    IEnumerable<string> GetSupportedExtensions();
+}
+

--- a/ChatClient.Api/Services/NoOpFileConverter.cs
+++ b/ChatClient.Api/Services/NoOpFileConverter.cs
@@ -1,0 +1,25 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+using Microsoft.AspNetCore.Http;
+
+namespace ChatClient.Api.Services;
+
+public class NoOpFileConverter : IFileConverter
+{
+    private static readonly string[] _extensions = [".txt", ".md"];
+
+    public IEnumerable<string> GetSupportedExtensions() => _extensions;
+
+    public async Task<string> ConvertToTextAsync(IFormFile file)
+    {
+        var ext = Path.GetExtension(file.FileName);
+        if (!_extensions.Contains(ext, StringComparer.OrdinalIgnoreCase))
+            throw new NotSupportedException($"Unsupported file type {ext}");
+
+        using var reader = new StreamReader(file.OpenReadStream());
+        return await reader.ReadToEndAsync();
+    }
+}
+

--- a/ChatClient.Api/Services/RagFileService.cs
+++ b/ChatClient.Api/Services/RagFileService.cs
@@ -1,0 +1,75 @@
+using System.IO;
+
+using ChatClient.Shared.Models;
+using ChatClient.Shared.Services;
+
+namespace ChatClient.Api.Services;
+
+public class RagFileService : IRagFileService
+{
+    private readonly string _basePath;
+
+    public RagFileService(IConfiguration configuration)
+    {
+        _basePath = configuration["RagFiles:BasePath"] ?? Path.Combine("Data", "agents");
+    }
+
+    public async Task<List<RagFile>> GetFilesAsync(Guid id)
+    {
+        var filesDir = Path.Combine(GetAgentFolder(id), "files");
+        if (!Directory.Exists(filesDir))
+            return [];
+
+        var result = new List<RagFile>();
+        foreach (var file in Directory.GetFiles(filesDir))
+        {
+            var content = await File.ReadAllTextAsync(file);
+            result.Add(new RagFile { FileName = Path.GetFileName(file), Content = content });
+        }
+        return result;
+    }
+
+    public async Task<RagFile?> GetFileAsync(Guid id, string fileName)
+    {
+        var filePath = Path.Combine(GetAgentFolder(id), "files", fileName);
+        if (!File.Exists(filePath))
+            return null;
+
+        var content = await File.ReadAllTextAsync(filePath);
+        return new RagFile { FileName = fileName, Content = content };
+    }
+
+    public async Task AddOrUpdateFileAsync(Guid id, RagFile file)
+    {
+        var agentFolder = GetAgentFolder(id);
+        Directory.CreateDirectory(Path.Combine(agentFolder, "files"));
+        Directory.CreateDirectory(Path.Combine(agentFolder, "index"));
+
+        var filePath = Path.Combine(agentFolder, "files", file.FileName);
+        await File.WriteAllTextAsync(filePath, file.Content);
+
+        var indexPath = Path.Combine(agentFolder, "index", Path.ChangeExtension(file.FileName, ".idx"));
+        if (File.Exists(indexPath))
+            File.Delete(indexPath);
+
+        // TODO: trigger index rebuild
+    }
+
+    public Task DeleteFileAsync(Guid id, string fileName)
+    {
+        var agentFolder = GetAgentFolder(id);
+        var filePath = Path.Combine(agentFolder, "files", fileName);
+        if (File.Exists(filePath))
+            File.Delete(filePath);
+
+        var indexPath = Path.Combine(agentFolder, "index", Path.ChangeExtension(fileName, ".idx"));
+        if (File.Exists(indexPath))
+            File.Delete(indexPath);
+
+        // TODO: trigger index rebuild
+        return Task.CompletedTask;
+    }
+
+    private string GetAgentFolder(Guid id) => Path.Combine(_basePath, id.ToString());
+}
+

--- a/ChatClient.Api/appsettings.json
+++ b/ChatClient.Api/appsettings.json
@@ -10,6 +10,9 @@
   "McpServers": {
     "FilePath": "Data/mcp_servers.json"
   },
+  "RagFiles": {
+    "BasePath": "Data/agents"
+  },
   "Logging": {
     "LogLevel": { "Default": "Information" }
   }

--- a/ChatClient.Shared/Models/AgentDescription.cs
+++ b/ChatClient.Shared/Models/AgentDescription.cs
@@ -4,7 +4,8 @@ namespace ChatClient.Shared.Models;
 
 public class AgentDescription
 {
-    public Guid? Id { get; set; }
+    /// <summary>Internal identifier not displayed in UI.</summary>
+    public Guid Id { get; set; }
     public string AgentName { get; set; } = string.Empty;
     public string Content { get; set; } = string.Empty;
     public string? ShortName { get; set; }

--- a/ChatClient.Shared/Models/RagFile.cs
+++ b/ChatClient.Shared/Models/RagFile.cs
@@ -1,0 +1,8 @@
+namespace ChatClient.Shared.Models;
+
+public class RagFile
+{
+    public string FileName { get; set; } = string.Empty;
+    public string Content { get; set; } = string.Empty;
+}
+

--- a/ChatClient.Shared/Services/IRagFileService.cs
+++ b/ChatClient.Shared/Services/IRagFileService.cs
@@ -1,0 +1,12 @@
+using ChatClient.Shared.Models;
+
+namespace ChatClient.Shared.Services;
+
+public interface IRagFileService
+{
+    Task<List<RagFile>> GetFilesAsync(Guid id);
+    Task<RagFile?> GetFileAsync(Guid id, string fileName);
+    Task AddOrUpdateFileAsync(Guid id, RagFile file);
+    Task DeleteFileAsync(Guid id, string fileName);
+}
+

--- a/ChatClient.Tests/AgentDescriptionServiceTests.cs
+++ b/ChatClient.Tests/AgentDescriptionServiceTests.cs
@@ -40,7 +40,7 @@ public class AgentDescriptionServiceTests
             var created = await service.CreateAsync(prompt);
 
             var serviceReloaded = new AgentDescriptionService(config, logger);
-            var retrieved = await serviceReloaded.GetByIdAsync(created.Id!.Value);
+            var retrieved = await serviceReloaded.GetByIdAsync(created.Id);
 
             Assert.NotNull(retrieved);
             Assert.Equal("test-model", retrieved!.ModelName);


### PR DESCRIPTION
## Summary
- rename AgentFile to RagFile across model, service, and controller
- expose supported file extensions in IFileConverter and validate uploads
- register Rag file services and configuration
- add internal Guid Id to AgentDescription and update service, UI, and tests

## Testing
- `/usr/share/dotnet/dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68a85893a7d8832ab2abe55bef63b86b