### PR TITLE
feat: manage agent rag files

### DIFF
--- a/ChatClient.Api/Client/Pages/AgentDescriptions.razor
+++ b/ChatClient.Api/Client/Pages/AgentDescriptions.razor
@@ -1,12 +1,18 @@
 ﻿@page "/agent-descriptions"
 @using System
+@using System.IO
+@using System.Linq
 @using ChatClient.Shared.Models
 @using ChatClient.Shared.Services
 @using ChatClient.Api.Services
+@using Microsoft.AspNetCore.Components.Forms
+@using Microsoft.AspNetCore.Http
 @inject IAgentDescriptionService AgentService
 @inject ISnackbar Snackbar
 @inject IOllamaClientService OllamaService
 @inject KernelService KernelService
+@inject IRagFileService RagFileService
+@inject IFileConverter FileConverter
 
 <PageTitle>Agent Descriptions Management</PageTitle>
 
@@ -88,6 +94,11 @@
                             </div>
                         </CellTemplate>
                     </TemplateColumn>
+                    <TemplateColumn Title="RAG Files" isEditable="false" CellStyle="text-align:center; width:80px;">
+                        <CellTemplate>
+                            @(ragCounts.TryGetValue(context.Item.Id, out var count) ? count : 0)
+                        </CellTemplate>
+                    </TemplateColumn>
                     <TemplateColumn Title="Functions" isEditable="false" CellStyle="text-align:center; width:80px;">
                         <CellTemplate>
                             @{
@@ -126,7 +137,7 @@
                         <CellTemplate>
                             <MudIconButton Icon="@Icons.Material.Filled.Edit"
                                            Size="Size.Small"
-                                           OnClick="@(() => StartEditingAgent(context.Item))" />
+                                           OnClick="@(async () => await StartEditingAgent(context.Item))" />
                             <MudIconButton Icon="@Icons.Material.Filled.Delete"
                                            Size="Size.Small"
                                            Color="Color.Error"
@@ -220,6 +231,38 @@
                           Immediate="true"
                           Validation="@(new Func<string, string>(ValidateContent))"
                           Placeholder="Enter agent description here..." />
+
+            @if (editingAgent.Id != Guid.Empty)
+            {
+                <MudDivider Class="my-4" />
+                <MudText Typo="Typo.subtitle1" Class="mb-2">RAG Files</MudText>
+                <MudFileUpload T="IReadOnlyList<IBrowserFile>" OnFilesChanged="UploadFiles" />
+                <MudTable Items="@ragFiles" Dense="true" Bordered="true" Class="mt-2">
+                    <HeaderContent>
+                        <MudTh>File</MudTh>
+                        <MudTh>Size</MudTh>
+                        <MudTh>Index</MudTh>
+                        <MudTh></MudTh>
+                    </HeaderContent>
+                    <RowTemplate>
+                        <MudTd DataLabel="File">@context.FileName</MudTd>
+                        <MudTd DataLabel="Size">@FormatSize(context.Size)</MudTd>
+                        <MudTd DataLabel="Index">
+                            <MudIcon Icon="@(context.HasIndex ? Icons.Material.Filled.Check : Icons.Material.Filled.Close)"
+                                     Color="@(context.HasIndex ? Color.Success : Color.Error)" />
+                        </MudTd>
+                        <MudTd>
+                            <MudIconButton Icon="@Icons.Material.Filled.Delete"
+                                           Color="Color.Error"
+                                           Size="Size.Small"
+                                           OnClick="@(() => DeleteFile(context.FileName))" />
+                        </MudTd>
+                    </RowTemplate>
+                    <NoRecordsContent>
+                        <MudText Typo="Typo.body2" Class="mud-text-secondary pa-2">No files</MudText>
+                    </NoRecordsContent>
+                </MudTable>
+            }
         </MudForm>
     </DialogContent>
     <DialogActions>
@@ -234,14 +277,16 @@
     private bool loading = true;
     private AgentDescription? agentToDelete;
     private AgentDescription editingAgent = new();
-    private bool showDeleteDialog { get; set; } = false;
-    private bool showEditAgentDialog { get; set; } = false;
+    private bool showDeleteDialog { get; set; }
+    private bool showEditAgentDialog { get; set; }
     private string searchString = string.Empty;
     private MudForm? editAgentForm;
     private MudDataGrid<AgentDescription>? dataGrid;
     private List<OllamaModel> availableModels = new();
     private List<FunctionInfo> availableFunctions = new();
     private bool functionsExpanded;
+    private Dictionary<Guid, int> ragCounts = new();
+    private List<RagFile> ragFiles = new();
     private DialogOptions dialogOptions = new()
     {
         CloseOnEscapeKey = true,
@@ -273,6 +318,14 @@
 
             agents = await AgentService.GetAllAsync() ?? new();
             filteredAgents = agents;
+
+            ragCounts.Clear();
+            var tasks = agents.Select(async a =>
+            {
+                var files = await RagFileService.GetFilesAsync(a.Id);
+                ragCounts[a.Id] = files.Count;
+            });
+            await Task.WhenAll(tasks);
         }
         catch (Exception ex)
         {
@@ -329,7 +382,7 @@
                 SelectedFunctions = []
             }
         };
-
+        ragFiles = new();
         showEditAgentDialog = true;
     }
 
@@ -353,7 +406,66 @@
             .ToList();
     }
 
-    private Task StartEditingAgent(AgentDescription agent)
+    private async Task LoadRagFiles(Guid id)
+    {
+        ragFiles = await RagFileService.GetFilesAsync(id);
+        ragCounts[id] = ragFiles.Count;
+    }
+
+    private async Task UploadFiles(InputFileChangeEventArgs e)
+    {
+        if (editingAgent.Id == Guid.Empty) return;
+
+        foreach (var file in e.GetMultipleFiles())
+        {
+            try
+            {
+                await using var ms = new MemoryStream();
+                await file.OpenReadStream().CopyToAsync(ms);
+                ms.Position = 0;
+                var formFile = new FormFile(ms, 0, ms.Length, file.Name, file.Name)
+                {
+                    Headers = new HeaderDictionary(),
+                    ContentType = file.ContentType
+                };
+                var content = await FileConverter.ConvertToTextAsync(formFile);
+                await RagFileService.AddOrUpdateFileAsync(editingAgent.Id, new RagFile { FileName = file.Name, Content = content });
+            }
+            catch (Exception ex)
+            {
+                Snackbar.Add($"Error adding file: {ex.Message}", Severity.Error);
+            }
+        }
+
+        await LoadRagFiles(editingAgent.Id);
+    }
+
+    private async Task DeleteFile(string fileName)
+    {
+        if (editingAgent.Id == Guid.Empty) return;
+
+        try
+        {
+            await RagFileService.DeleteFileAsync(editingAgent.Id, fileName);
+            await LoadRagFiles(editingAgent.Id);
+            Snackbar.Add("File deleted", Severity.Success);
+        }
+        catch (Exception ex)
+        {
+            Snackbar.Add($"Error deleting file: {ex.Message}", Severity.Error);
+        }
+    }
+
+    private static string FormatSize(long bytes)
+    {
+        const long kb = 1024;
+        const long mb = kb * 1024;
+        if (bytes >= mb) return $"{bytes / (double)mb:0.##} MB";
+        if (bytes >= kb) return $"{bytes / (double)kb:0.##} KB";
+        return $"{bytes} B";
+    }
+
+    private async Task StartEditingAgent(AgentDescription agent)
     {
         editingAgent = new AgentDescription
         {
@@ -373,8 +485,8 @@
             }
         };
 
+        await LoadRagFiles(agent.Id);
         showEditAgentDialog = true;
-        return Task.CompletedTask;
     }
 
     private void ConfirmDeleteAgent(AgentDescription agent)
@@ -399,6 +511,7 @@
             Snackbar.Add("Agent deleted successfully", Severity.Success);
 
             agents.Remove(agentToDelete);
+            ragCounts.Remove(agentToDelete.Id);
             ApplySearch();
         }
         catch (Exception ex)
@@ -456,6 +569,7 @@
                 {
                     var result = await AgentService.CreateAsync(editingAgent);
                     agents.Add(result);
+                    ragCounts[result.Id] = ragFiles.Count;
                     Snackbar.Add("Agent description created successfully", Severity.Success);
                 }
                 else
@@ -464,6 +578,7 @@
                     var result = await AgentService.UpdateAsync(editingAgent);
                     var index = agents.FindIndex(p => p.Id == editingAgent.Id);
                     if (index >= 0) agents[index] = result;
+                    ragCounts[result.Id] = ragFiles.Count;
                     Snackbar.Add("Agent description updated successfully", Severity.Success);
                 }
 

--- a/ChatClient.Api/Services/RagFileService.cs
+++ b/ChatClient.Api/Services/RagFileService.cs
@@ -16,27 +16,47 @@ public class RagFileService : IRagFileService
 
     public async Task<List<RagFile>> GetFilesAsync(Guid id)
     {
-        var filesDir = Path.Combine(GetAgentFolder(id), "files");
+        var agentFolder = GetAgentFolder(id);
+        var filesDir = Path.Combine(agentFolder, "files");
         if (!Directory.Exists(filesDir))
             return [];
 
+        var indexDir = Path.Combine(agentFolder, "index");
         var result = new List<RagFile>();
         foreach (var file in Directory.GetFiles(filesDir))
         {
+            var fileName = Path.GetFileName(file);
             var content = await File.ReadAllTextAsync(file);
-            result.Add(new RagFile { FileName = Path.GetFileName(file), Content = content });
+            var size = new FileInfo(file).Length;
+            var hasIndex = File.Exists(Path.Combine(indexDir, Path.ChangeExtension(fileName, ".idx")));
+            result.Add(new RagFile
+            {
+                FileName = fileName,
+                Content = content,
+                Size = size,
+                HasIndex = hasIndex
+            });
         }
         return result;
     }
 
     public async Task<RagFile?> GetFileAsync(Guid id, string fileName)
     {
-        var filePath = Path.Combine(GetAgentFolder(id), "files", fileName);
+        var agentFolder = GetAgentFolder(id);
+        var filePath = Path.Combine(agentFolder, "files", fileName);
         if (!File.Exists(filePath))
             return null;
 
         var content = await File.ReadAllTextAsync(filePath);
-        return new RagFile { FileName = fileName, Content = content };
+        var size = new FileInfo(filePath).Length;
+        var hasIndex = File.Exists(Path.Combine(agentFolder, "index", Path.ChangeExtension(fileName, ".idx")));
+        return new RagFile
+        {
+            FileName = fileName,
+            Content = content,
+            Size = size,
+            HasIndex = hasIndex
+        };
     }
 
     public async Task AddOrUpdateFileAsync(Guid id, RagFile file)
@@ -58,13 +78,13 @@ public class RagFileService : IRagFileService
     public Task DeleteFileAsync(Guid id, string fileName)
     {
         var agentFolder = GetAgentFolder(id);
-        var filePath = Path.Combine(agentFolder, "files", fileName);
-        if (File.Exists(filePath))
-            File.Delete(filePath);
-
         var indexPath = Path.Combine(agentFolder, "index", Path.ChangeExtension(fileName, ".idx"));
         if (File.Exists(indexPath))
             File.Delete(indexPath);
+
+        var filePath = Path.Combine(agentFolder, "files", fileName);
+        if (File.Exists(filePath))
+            File.Delete(filePath);
 
         // TODO: trigger index rebuild
         return Task.CompletedTask;

--- a/ChatClient.Shared/Models/RagFile.cs
+++ b/ChatClient.Shared/Models/RagFile.cs
@@ -4,5 +4,7 @@ public class RagFile
 {
     public string FileName { get; set; } = string.Empty;
     public string Content { get; set; } = string.Empty;
+    public long Size { get; set; }
+    public bool HasIndex { get; set; }
 }
 


### PR DESCRIPTION
## Summary
- show number of RAG files for each agent
- manage agent RAG files with upload, listing and delete
- track file metadata and index presence in RAG file service

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68a8833ba25c832aa911bbf099e73cb1