### PR TITLE
Add drag-and-drop upload for RAG files

### DIFF
--- a/ChatClient.Api/Client/Pages/AgentDescriptions.razor
+++ b/ChatClient.Api/Client/Pages/AgentDescriptions.razor
@@ -236,7 +236,15 @@
             {
                 <MudDivider Class="my-4" />
                 <MudText Typo="Typo.subtitle1" Class="mb-2">RAG Files</MudText>
-                <MudFileUpload T="IReadOnlyList<IBrowserFile>" OnFilesChanged="UploadFiles" />
+                <div class="rag-drop-wrapper mt-2">
+                    <MudFileUpload T="IReadOnlyList<IBrowserFile>"
+                                   OnFilesChanged="UploadFiles"
+                                   Hidden="false"
+                                   InputClass="rag-drop-input" />
+                    <div class="rag-drop-overlay">
+                        <MudText Typo="Typo.body2" Class="mud-text-secondary">Drag and drop files here or click to browse</MudText>
+                    </div>
+                </div>
                 <MudTable Items="@ragFiles" Dense="true" Bordered="true" Class="mt-2">
                     <HeaderContent>
                         <MudTh>File</MudTh>

--- a/ChatClient.Api/Client/Pages/AgentDescriptions.razor.css
+++ b/ChatClient.Api/Client/Pages/AgentDescriptions.razor.css
@@ -1,0 +1,24 @@
+.rag-drop-wrapper {
+    position: relative;
+    width: 100%;
+    height: 100px;
+}
+
+.rag-drop-input {
+    position: absolute;
+    inset: 0;
+    width: 100%;
+    height: 100%;
+    opacity: 0;
+    cursor: pointer;
+    z-index: 2;
+}
+
+.rag-drop-overlay {
+    border: 2px dashed var(--mud-palette-lines-default);
+    height: 100%;
+    width: 100%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}


### PR DESCRIPTION
## Summary
- allow RAG files to be uploaded via drag-and-drop using MudFileUpload
- style drop zone for clarity

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68a8908651b0832ab7647e6bc30c9c3e