### PR TITLE
Implement Semantic Kernel vector index builder service

### DIFF
--- a/ChatClient.Api/Program.cs
+++ b/ChatClient.Api/Program.cs
@@ -44,6 +44,7 @@ builder.Services.AddScoped<ChatClient.Api.Services.StartupOllamaChecker>();
 builder.Services.AddSingleton<ChatClient.Shared.Services.IAgentDescriptionService, ChatClient.Api.Services.AgentDescriptionService>();
 builder.Services.AddSingleton<ChatClient.Shared.Services.IUserSettingsService, ChatClient.Api.Services.UserSettingsService>();
 builder.Services.AddSingleton<ChatClient.Shared.Services.IRagFileService, ChatClient.Api.Services.RagFileService>();
+builder.Services.AddSingleton<ChatClient.Shared.Services.IRagVectorIndexService, ChatClient.Api.Services.RagVectorIndexService>();
 builder.Services.AddSingleton<ChatClient.Api.Services.IFileConverter, ChatClient.Api.Services.NoOpFileConverter>();
 builder.Services.AddScoped<ChatClient.Api.Client.Services.IAppChatService, ChatClient.Api.Client.Services.AppChatService>();
 builder.Services.AddScoped<ChatClient.Api.Client.Services.IChatViewModelService, ChatClient.Api.Client.Services.ChatViewModelService>();

--- a/ChatClient.Api/Services/RagVectorIndexService.cs
+++ b/ChatClient.Api/Services/RagVectorIndexService.cs
@@ -1,0 +1,87 @@
+#pragma warning disable SKEXP0050
+using System.Text.Json;
+
+using ChatClient.Shared.Models;
+using ChatClient.Shared.Services;
+
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.Logging;
+using Microsoft.SemanticKernel;
+using Microsoft.SemanticKernel.Text;
+
+namespace ChatClient.Api.Services;
+
+public sealed class RagVectorIndexService(
+    IUserSettingsService userSettings,
+    IConfiguration configuration,
+    ILogger<RagVectorIndexService> logger) : IRagVectorIndexService
+{
+    public async Task BuildIndexAsync(string sourceFilePath, string indexFilePath, CancellationToken cancellationToken = default)
+    {
+        if (!File.Exists(sourceFilePath))
+            throw new FileNotFoundException($"Source file not found: {sourceFilePath}");
+
+        var text = await File.ReadAllTextAsync(sourceFilePath, cancellationToken);
+        if (string.IsNullOrWhiteSpace(text))
+            throw new InvalidOperationException("Source file is empty.");
+
+        var modelId = await GetModelIdAsync();
+        var baseUrl = await GetBaseUrlAsync();
+
+        IKernelBuilder builder = Kernel.CreateBuilder();
+        builder.Services.AddLogging();
+        builder.AddOllamaEmbeddingGenerator(modelId, new Uri(baseUrl));
+        var kernel = builder.Build();
+
+        var generator = kernel.GetRequiredService<IEmbeddingGenerator<string, Embedding<float>>>();
+
+        var lines = TextChunker.SplitPlainTextLines(text, 256, null);
+        var paragraphs = TextChunker.SplitPlainTextParagraphs(lines, 512, 64, string.Empty, null);
+
+        var fragments = new List<RagVectorFragment>();
+        var fragmentIndex = 0;
+        foreach (var paragraph in paragraphs)
+        {
+            var embedding = await generator.GenerateAsync(paragraph, cancellationToken: cancellationToken);
+            fragments.Add(new RagVectorFragment
+            {
+                Id = $"{Path.GetFileName(sourceFilePath)}#{fragmentIndex:D5}",
+                Text = paragraph,
+                Vector = embedding.Vector.ToArray()
+            });
+            fragmentIndex++;
+        }
+
+        var info = new FileInfo(sourceFilePath);
+        var index = new RagVectorIndex
+        {
+            SourceFileName = Path.GetFileName(sourceFilePath),
+            SourceModifiedTime = info.LastWriteTimeUtc,
+            EmbeddingModel = modelId,
+            VectorDimensions = fragments.Count > 0 ? fragments[0].Vector.Length : 0,
+            Fragments = fragments
+        };
+
+        var options = new JsonSerializerOptions { WriteIndented = true };
+        Directory.CreateDirectory(Path.GetDirectoryName(indexFilePath)!);
+        await File.WriteAllTextAsync(indexFilePath, JsonSerializer.Serialize(index, options), cancellationToken);
+
+        logger.LogInformation("Built index {IndexPath} with {Count} fragments", indexFilePath, fragments.Count);
+    }
+
+    private async Task<string> GetBaseUrlAsync()
+    {
+        var settings = await userSettings.GetSettingsAsync();
+        if (!string.IsNullOrWhiteSpace(settings.OllamaServerUrl))
+            return settings.OllamaServerUrl;
+        return configuration["Ollama:BaseUrl"] ?? "http://localhost:11434";
+    }
+
+    private async Task<string> GetModelIdAsync()
+    {
+        var settings = await userSettings.GetSettingsAsync();
+        if (!string.IsNullOrWhiteSpace(settings.EmbeddingModelName))
+            return settings.EmbeddingModelName;
+        return configuration["Ollama:EmbeddingModel"] ?? "nomic-embed-text";
+    }
+}

--- a/ChatClient.Shared/Models/RagVectorFragment.cs
+++ b/ChatClient.Shared/Models/RagVectorFragment.cs
@@ -1,0 +1,8 @@
+namespace ChatClient.Shared.Models;
+
+public class RagVectorFragment
+{
+    public string Id { get; set; } = string.Empty;
+    public string Text { get; set; } = string.Empty;
+    public float[] Vector { get; set; } = Array.Empty<float>();
+}

--- a/ChatClient.Shared/Models/RagVectorIndex.cs
+++ b/ChatClient.Shared/Models/RagVectorIndex.cs
@@ -1,0 +1,10 @@
+namespace ChatClient.Shared.Models;
+
+public class RagVectorIndex
+{
+    public string SourceFileName { get; set; } = string.Empty;
+    public DateTime SourceModifiedTime { get; set; }
+    public string EmbeddingModel { get; set; } = string.Empty;
+    public int VectorDimensions { get; set; }
+    public List<RagVectorFragment> Fragments { get; set; } = [];
+}

--- a/ChatClient.Shared/Services/IRagVectorIndexService.cs
+++ b/ChatClient.Shared/Services/IRagVectorIndexService.cs
@@ -1,0 +1,6 @@
+namespace ChatClient.Shared.Services;
+
+public interface IRagVectorIndexService
+{
+    Task BuildIndexAsync(string sourceFilePath, string indexFilePath, CancellationToken cancellationToken = default);
+}


### PR DESCRIPTION
## Summary
- add RagVectorIndexService for generating embeddings with Semantic Kernel
- expose RagVectorIndex and fragment models
- register vector index service in API startup

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68a894168b9c832a89f43d557eebf246