### PR TITLE
Store fragment offsets for RAG

### DIFF
--- a/ChatClient.Shared/Models/RagVectorFragment.cs
+++ b/ChatClient.Shared/Models/RagVectorFragment.cs
@@ -3,6 +3,7 @@ namespace ChatClient.Shared.Models;
 public class RagVectorFragment
 {
     public string Id { get; set; } = string.Empty;
-    public string Text { get; set; } = string.Empty;
+    public long Offset { get; set; }
+    public int Length { get; set; }
     public float[] Vector { get; set; } = Array.Empty<float>();
 }


### PR DESCRIPTION
## Summary
- track byte offset and length instead of storing text snippets in vector fragments
- compute offsets while building RAG vector index

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68a8a766c444832a8e0c2c40c57e9c10