### PR TITLE
Add in-memory vector search for agent files

### DIFF
--- a/ChatClient.Api/Program.cs
+++ b/ChatClient.Api/Program.cs
@@ -1,6 +1,7 @@
 using ChatClient.Api;
 using ChatClient.Api.Client.Services;
 using ChatClient.Api.Services;
+using Microsoft.SemanticKernel.Memory;
 
 using Microsoft.AspNetCore.Hosting.Server;
 using Microsoft.AspNetCore.Hosting.Server.Features;
@@ -48,6 +49,8 @@ builder.Services.AddSingleton<ChatClient.Shared.Services.IRagVectorIndexService,
 builder.Services.AddSingleton<ChatClient.Api.Services.RagVectorIndexBackgroundService>();
 builder.Services.AddSingleton<ChatClient.Shared.Services.IRagVectorIndexBackgroundService>(sp => sp.GetRequiredService<ChatClient.Api.Services.RagVectorIndexBackgroundService>());
 builder.Services.AddHostedService(sp => sp.GetRequiredService<ChatClient.Api.Services.RagVectorIndexBackgroundService>());
+builder.Services.AddSingleton<IMemoryStore, VolatileMemoryStore>();
+builder.Services.AddSingleton<ChatClient.Shared.Services.IRagVectorSearchService, ChatClient.Api.Services.RagVectorSearchService>();
 builder.Services.AddSingleton<ChatClient.Api.Services.IFileConverter, ChatClient.Api.Services.NoOpFileConverter>();
 builder.Services.AddScoped<ChatClient.Api.Client.Services.IAppChatService, ChatClient.Api.Client.Services.AppChatService>();
 builder.Services.AddScoped<ChatClient.Api.Client.Services.IChatViewModelService, ChatClient.Api.Client.Services.ChatViewModelService>();

--- a/ChatClient.Api/Services/RagVectorSearchService.cs
+++ b/ChatClient.Api/Services/RagVectorSearchService.cs
@@ -1,0 +1,152 @@
+using System.Text;
+using System.Text.Json;
+
+using ChatClient.Shared.Models;
+using ChatClient.Shared.Services;
+
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using Microsoft.SemanticKernel.Memory;
+
+namespace ChatClient.Api.Services;
+
+public sealed class RagVectorSearchService(
+    IMemoryStore store,
+    IConfiguration configuration,
+    ILogger<RagVectorSearchService> logger) : IRagVectorSearchService
+{
+    private readonly IMemoryStore _store = store;
+    private readonly ILogger<RagVectorSearchService> _logger = logger;
+    private readonly string _basePath =
+        configuration["RagFiles:BasePath"] ?? Path.Combine("Data", "agents");
+
+    public async Task<IReadOnlyList<RagSearchResult>> SearchAsync(
+        Guid agentId,
+        ReadOnlyMemory<float> queryVector,
+        int maxResults = 5,
+        CancellationToken ct = default)
+    {
+        var collection = CollectionName(agentId);
+
+        var matches = await _store.GetNearestMatchesAsync(
+            collection: collection,
+            embedding: queryVector,
+            limit: Math.Max(maxResults * 8, maxResults),
+            minRelevanceScore: 0.0,
+            cancellationToken: ct);
+
+        if (matches is null || matches.Count == 0)
+            return [];
+
+        var pieces = matches
+            .Select(m => ToPiece(m.Item1, m.Item2))
+            .Where(p => p is not null)
+            .Select(p => p!)
+            .ToList();
+
+        if (pieces.Count == 0)
+            return [];
+
+        var segments = MergeAdjacent(pieces)
+            .OrderByDescending(s => s.Score)
+            .Take(maxResults)
+            .ToList();
+
+        var filesRoot = Path.Combine(_basePath, agentId.ToString("D"), "files");
+        var fileCache = new Dictionary<string, byte[]>(StringComparer.OrdinalIgnoreCase);
+        var results = new List<RagSearchResult>(segments.Count);
+
+        foreach (var seg in segments)
+        {
+            if (!fileCache.TryGetValue(seg.File, out var bytes))
+            {
+                var path = Path.Combine(filesRoot, seg.File);
+                if (!File.Exists(path))
+                    continue;
+                bytes = await File.ReadAllBytesAsync(path, ct);
+                fileCache[seg.File] = bytes;
+            }
+
+            var start = (int)Math.Clamp(seg.StartOffset, 0, bytes.Length);
+            var end = (int)Math.Clamp(seg.EndOffset, 0, bytes.Length);
+            if (end <= start)
+                continue;
+
+            var text = Encoding.UTF8.GetString(bytes.AsSpan(start, end - start));
+            results.Add(new RagSearchResult { FileName = seg.File, Content = text });
+        }
+
+        _logger.LogDebug("RAG search: agent={AgentId} pieces={Pieces} segments={Segments}", agentId, pieces.Count, segments.Count);
+        return results;
+    }
+
+    private static string CollectionName(Guid id) => $"agent_{id:N}";
+
+    private static Piece? ToPiece(MemoryRecord record, double score)
+    {
+        var metaJson = record.Metadata.AdditionalMetadata;
+        if (string.IsNullOrWhiteSpace(metaJson))
+            return null;
+
+        try
+        {
+            var meta = JsonSerializer.Deserialize<Metadata>(metaJson);
+            if (meta is null || string.IsNullOrEmpty(meta.file))
+                return null;
+
+            return new Piece(
+                File: meta.file,
+                Index: meta.index,
+                Offset: meta.offset,
+                Length: meta.length,
+                Score: score);
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    private static List<Segment> MergeAdjacent(IEnumerable<Piece> pieces)
+    {
+        var result = new List<Segment>();
+
+        foreach (var group in pieces.GroupBy(p => p.File, StringComparer.OrdinalIgnoreCase))
+        {
+            Segment? cur = null;
+
+            foreach (var p in group.OrderBy(p => p.Index))
+            {
+                if (cur is not null && p.Index == cur.EndIndex + 1)
+                {
+                    cur.EndIndex = p.Index;
+                    cur.EndOffset = Math.Max(cur.EndOffset, p.Offset + p.Length);
+                    cur.StartOffset = Math.Min(cur.StartOffset, p.Offset);
+                    cur.Score = Math.Max(cur.Score, p.Score);
+                }
+                else
+                {
+                    if (cur is not null)
+                        result.Add(cur);
+                    cur = new Segment(
+                        File: p.File,
+                        StartIndex: p.Index,
+                        EndIndex: p.Index,
+                        StartOffset: p.Offset,
+                        EndOffset: p.Offset + p.Length,
+                        Score: p.Score);
+                }
+            }
+
+            if (cur is not null)
+                result.Add(cur);
+        }
+
+        return result;
+    }
+
+    private sealed record Metadata(string file, int index, long offset, int length);
+    private sealed record Piece(string File, int Index, long Offset, int Length, double Score);
+    private sealed record Segment(string File, int StartIndex, int EndIndex, long StartOffset, long EndOffset, double Score);
+}
+

--- a/ChatClient.Shared/Models/RagSearchResult.cs
+++ b/ChatClient.Shared/Models/RagSearchResult.cs
@@ -1,0 +1,7 @@
+namespace ChatClient.Shared.Models;
+
+public class RagSearchResult
+{
+    public string FileName { get; set; } = string.Empty;
+    public string Content { get; set; } = string.Empty;
+}

--- a/ChatClient.Shared/Services/IRagVectorSearchService.cs
+++ b/ChatClient.Shared/Services/IRagVectorSearchService.cs
@@ -1,0 +1,8 @@
+namespace ChatClient.Shared.Services;
+
+using ChatClient.Shared.Models;
+
+public interface IRagVectorSearchService
+{
+    Task<IReadOnlyList<RagSearchResult>> SearchAsync(Guid agentId, ReadOnlyMemory<float> queryVector, int maxResults = 5, CancellationToken cancellationToken = default);
+}

--- a/ChatClient.Tests/RagVectorSearchServiceTests.cs
+++ b/ChatClient.Tests/RagVectorSearchServiceTests.cs
@@ -1,0 +1,63 @@
+using System.Text.Json;
+
+using ChatClient.Api.Services;
+using ChatClient.Shared.Services;
+
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.SemanticKernel.Memory;
+
+namespace ChatClient.Tests;
+
+public class RagVectorSearchServiceTests
+{
+    [Fact]
+    public async Task MergesAdjacentFragments()
+    {
+        var temp = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        try
+        {
+            var agentId = Guid.NewGuid();
+            var filesDir = Path.Combine(temp, agentId.ToString(), "files");
+            Directory.CreateDirectory(filesDir);
+            await File.WriteAllTextAsync(Path.Combine(filesDir, "file1.txt"), "ABCD");
+
+            var store = new VolatileMemoryStore();
+            var collection = $"agent_{agentId:N}";
+            await store.CreateCollectionAsync(collection);
+
+            await AddAsync(store, collection, "file1.txt", 0, 0, 1, new float[] { 1, 0 });
+            await AddAsync(store, collection, "file1.txt", 1, 1, 1, new float[] { 1, 0 });
+            await AddAsync(store, collection, "file1.txt", 3, 3, 1, new float[] { 0, 1 });
+
+            var config = new ConfigurationBuilder()
+                .AddInMemoryCollection(new Dictionary<string, string?> { ["RagFiles:BasePath"] = temp })
+                .Build();
+            IRagVectorSearchService service = new RagVectorSearchService(store, config, NullLogger<RagVectorSearchService>.Instance);
+
+            var results = await service.SearchAsync(agentId, new ReadOnlyMemory<float>(new float[] { 1, 0 }), 2);
+
+            Assert.Equal(2, results.Count);
+            Assert.Equal("file1.txt", results[0].FileName);
+            Assert.Equal("AB", results[0].Content);
+            Assert.Equal("D", results[1].Content);
+        }
+        finally
+        {
+            if (Directory.Exists(temp))
+                Directory.Delete(temp, true);
+        }
+    }
+
+    private static async Task AddAsync(IMemoryStore store, string collection, string file, int index, long offset, int length, float[] vector)
+    {
+        var meta = JsonSerializer.Serialize(new { file, index, offset, length });
+        var record = new MemoryRecord(
+            new MemoryRecordMetadata(false, $"{file}#{index:D5}", null, null, null, meta),
+            new ReadOnlyMemory<float>(vector),
+            $"{file}#{index:D5}",
+            null);
+        await store.UpsertAsync(collection, record);
+    }
+}
+


### PR DESCRIPTION
## Summary
- implement RagVectorSearchService using Semantic Kernel IMemoryStore with merging of adjacent fragments
- register VolatileMemoryStore in DI for RAG search
- add tests that load IMemoryStore and verify fragment merging

## Testing
- `dotnet test` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_68a8bccac924832a97f35ab7ff6fdf61