### PR TITLE
Add vector search page

### DIFF
--- a/ChatClient.Api/Client/Layout/NavMenu.razor
+++ b/ChatClient.Api/Client/Layout/NavMenu.razor
@@ -1,6 +1,7 @@
 ﻿<MudNavMenu>
     <MudNavLink Href="/" Match="NavLinkMatch.All" Icon="@Icons.Material.Filled.Chat">Chat</MudNavLink>
     <MudNavLink Href="multi-agent-chat" Match="NavLinkMatch.Prefix" Icon="@Icons.Material.Filled.Groups">Multi-Agent</MudNavLink>
+    <MudNavLink Href="vector-search" Match="NavLinkMatch.Prefix" Icon="@Icons.Material.Filled.Search">Vector Search</MudNavLink>
     <MudNavLink Href="agent-descriptions" Match="NavLinkMatch.Prefix" Icon="@Icons.Material.Filled.List">Agent Descriptions</MudNavLink>
     <MudNavLink Href="mcp-servers" Match="NavLinkMatch.Prefix" Icon="@Icons.Material.Filled.Link">MCP Servers</MudNavLink>
     <MudNavLink Href="models" Match="NavLinkMatch.Prefix" Icon="@Icons.Material.Filled.Memory">Models</MudNavLink>

--- a/ChatClient.Api/Client/Pages/VectorSearch.razor
+++ b/ChatClient.Api/Client/Pages/VectorSearch.razor
@@ -1,0 +1,71 @@
+@page "/vector-search"
+@using ChatClient.Api.Services
+@using System.Linq
+
+<PageTitle>Vector Search</PageTitle>
+
+<OllamaCheck>
+    <MudContainer MaxWidth="MaxWidth.Small" Class="pa-4">
+        <MudStack Spacing="2">
+            <MudSelect T="AgentDescription"
+                       Label="Select Agent"
+                       @bind-Value="selectedAgent"
+                       Variant="Variant.Outlined"
+                       Dense="true"
+                       FullWidth="true">
+                @foreach (var agent in agents)
+                {
+                    <MudSelectItem Value="@agent">@agent.AgentName</MudSelectItem>
+                }
+            </MudSelect>
+
+            <ChatInput OnSend="SearchAsync" />
+
+            @if (results.Count > 0)
+            {
+                <MudList T="RagSearchResult" Dense="true" Class="mt-4">
+                    @foreach (var item in results)
+                    {
+                        <MudListItem T="RagSearchResult">
+                            <MudText Typo="Typo.subtitle2">@item.FileName</MudText>
+                            <MudText Typo="Typo.body2">@item.Content</MudText>
+                        </MudListItem>
+                    }
+                </MudList>
+            }
+        </MudStack>
+    </MudContainer>
+</OllamaCheck>
+
+@code {
+    private List<AgentDescription> agents = [];
+    private AgentDescription? selectedAgent;
+    private List<RagSearchResult> results = [];
+    private string embeddingModel = string.Empty;
+
+    [Inject] private IAgentDescriptionService AgentService { get; set; } = default!;
+    [Inject] private IOllamaClientService OllamaService { get; set; } = default!;
+    [Inject] private IRagVectorSearchService VectorSearchService { get; set; } = default!;
+    [Inject] private IUserSettingsService UserSettingsService { get; set; } = default!;
+    [Inject] private IConfiguration Configuration { get; set; } = default!;
+
+    protected override async Task OnInitializedAsync()
+    {
+        agents = await AgentService.GetAllAsync();
+        var settings = await UserSettingsService.GetSettingsAsync();
+        embeddingModel = string.IsNullOrWhiteSpace(settings.EmbeddingModelName)
+            ? Configuration["Ollama:EmbeddingModel"] ?? "nomic-embed-text"
+            : settings.EmbeddingModelName;
+    }
+
+    private async Task SearchAsync((string text, IReadOnlyList<AppChatMessageFile> _) data)
+    {
+        if (selectedAgent is null) return;
+        var text = data.text.Trim();
+        if (string.IsNullOrWhiteSpace(text)) return;
+
+        var embedding = await OllamaService.GenerateEmbeddingAsync(text, embeddingModel);
+        var found = await VectorSearchService.SearchAsync(selectedAgent.Id, new ReadOnlyMemory<float>(embedding));
+        results = found.ToList();
+    }
+}

--- a/ChatClient.Api/Services/VolatileMemoryStore.cs
+++ b/ChatClient.Api/Services/VolatileMemoryStore.cs
@@ -1,0 +1,151 @@
+using System.Collections.Concurrent;
+using System.Runtime.CompilerServices;
+using Microsoft.SemanticKernel.Memory;
+
+namespace ChatClient.Api.Services;
+
+/// <summary>
+/// Simple in-memory implementation of <see cref="IMemoryStore"/> used for RAG search.
+/// </summary>
+public sealed class VolatileMemoryStore : IMemoryStore
+{
+    private readonly ConcurrentDictionary<string, List<MemoryRecord>> _collections = new(StringComparer.OrdinalIgnoreCase);
+
+    public Task CreateCollectionAsync(string collectionName, CancellationToken cancellationToken = default)
+    {
+        _collections.TryAdd(collectionName, []);
+        return Task.CompletedTask;
+    }
+
+    public Task DeleteCollectionAsync(string collectionName, CancellationToken cancellationToken = default)
+    {
+        _collections.TryRemove(collectionName, out _);
+        return Task.CompletedTask;
+    }
+
+    public Task<bool> DoesCollectionExistAsync(string collectionName, CancellationToken cancellationToken = default)
+        => Task.FromResult(_collections.ContainsKey(collectionName));
+
+    public async IAsyncEnumerable<string> GetCollectionsAsync(
+        [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        foreach (var key in _collections.Keys)
+            yield return key;
+    }
+
+    public Task<string> UpsertAsync(string collectionName, MemoryRecord record, CancellationToken cancellationToken = default)
+    {
+        var list = _collections.GetOrAdd(collectionName, _ => []);
+        list.RemoveAll(r => r.Metadata.Id == record.Metadata.Id);
+        list.Add(record);
+        return Task.FromResult(record.Metadata.Id);
+    }
+
+    public async IAsyncEnumerable<string> UpsertBatchAsync(
+        string collectionName,
+        IEnumerable<MemoryRecord> records,
+        [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        foreach (var record in records)
+            yield return await UpsertAsync(collectionName, record, cancellationToken);
+    }
+
+    public Task RemoveAsync(string collectionName, string key, CancellationToken cancellationToken = default)
+    {
+        if (_collections.TryGetValue(collectionName, out var list))
+            list.RemoveAll(r => r.Metadata.Id == key);
+        return Task.CompletedTask;
+    }
+
+    public async Task RemoveBatchAsync(string collectionName, IEnumerable<string> keys, CancellationToken cancellationToken = default)
+    {
+        foreach (var key in keys)
+            await RemoveAsync(collectionName, key, cancellationToken);
+    }
+
+    public Task<MemoryRecord?> GetAsync(
+        string collectionName,
+        string key,
+        bool withEmbeddings = false,
+        CancellationToken cancellationToken = default)
+    {
+        if (_collections.TryGetValue(collectionName, out var list))
+        {
+            var rec = list.FirstOrDefault(r => r.Metadata.Id == key);
+            if (rec is not null && !withEmbeddings)
+                return Task.FromResult<MemoryRecord?>(new MemoryRecord(rec.Metadata, default, rec.Key, null));
+            if (rec is not null)
+                return Task.FromResult<MemoryRecord?>(rec);
+        }
+        return Task.FromResult<MemoryRecord?>(null);
+    }
+
+    public async IAsyncEnumerable<MemoryRecord> GetBatchAsync(
+        string collectionName,
+        IEnumerable<string> keys,
+        bool withEmbeddings = false,
+        [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        foreach (var key in keys)
+        {
+            var rec = await GetAsync(collectionName, key, withEmbeddings, cancellationToken);
+            if (rec is not null)
+                yield return rec;
+        }
+    }
+
+    public async IAsyncEnumerable<(MemoryRecord, double)> GetNearestMatchesAsync(
+        string collectionName,
+        ReadOnlyMemory<float> embedding,
+        int limit,
+        double minRelevanceScore = 0,
+        bool withEmbeddings = false,
+        [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        if (!_collections.TryGetValue(collectionName, out var list) || list.Count == 0)
+            yield break;
+
+        var scored = list
+            .Select(r => (Record: r, Score: CosineSimilarity(embedding.Span, r.Embedding.Span)))
+            .Where(r => r.Score >= minRelevanceScore)
+            .OrderByDescending(r => r.Score)
+            .Take(limit);
+
+        foreach (var item in scored)
+        {
+            var rec = item.Record;
+            if (!withEmbeddings)
+                rec = new MemoryRecord(rec.Metadata, default, rec.Key, null);
+            yield return (rec, item.Score);
+        }
+    }
+
+    public async Task<(MemoryRecord, double)?> GetNearestMatchAsync(
+        string collectionName,
+        ReadOnlyMemory<float> embedding,
+        double minRelevanceScore = 0,
+        bool withEmbeddings = false,
+        CancellationToken cancellationToken = default)
+    {
+        await foreach (var item in GetNearestMatchesAsync(collectionName, embedding, 1, minRelevanceScore, withEmbeddings, cancellationToken))
+            return item;
+        return null;
+    }
+
+    private static double CosineSimilarity(ReadOnlySpan<float> a, ReadOnlySpan<float> b)
+    {
+        double dot = 0, magA = 0, magB = 0;
+        var len = Math.Min(a.Length, b.Length);
+        for (var i = 0; i < len; i++)
+        {
+            var ai = a[i];
+            var bi = b[i];
+            dot += ai * bi;
+            magA += ai * ai;
+            magB += bi * bi;
+        }
+        if (magA == 0 || magB == 0)
+            return 0;
+        return dot / (Math.Sqrt(magA) * Math.Sqrt(magB));
+    }
+}

--- a/ChatClient.Tests/ChatClient.Tests.csproj
+++ b/ChatClient.Tests/ChatClient.Tests.csproj
@@ -5,6 +5,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
+    <NoWarn>SKEXP0001</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/ChatClient.Tests/RagVectorSearchServiceTests.cs
+++ b/ChatClient.Tests/RagVectorSearchServiceTests.cs
@@ -53,7 +53,7 @@ public class RagVectorSearchServiceTests
     {
         var meta = JsonSerializer.Serialize(new { file, index, offset, length });
         var record = new MemoryRecord(
-            new MemoryRecordMetadata(false, $"{file}#{index:D5}", null, null, null, meta),
+            new MemoryRecordMetadata(false, $"{file}#{index:D5}", null!, null!, null!, meta),
             new ReadOnlyMemory<float>(vector),
             $"{file}#{index:D5}",
             null);


### PR DESCRIPTION
## Summary
- add Vector Search page for querying agent vector store
- link new page from navigation menu
- implement in-memory IMemoryStore and fix RagVectorSearchService

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68a8c833b090832ab1686e55d55d3f73