### PR TITLE
Store fragment text instead of offsets

### DIFF
--- a/ChatClient.Api/Services/RagVectorIndexService.cs
+++ b/ChatClient.Api/Services/RagVectorIndexService.cs
@@ -1,5 +1,4 @@
 #pragma warning disable SKEXP0050
-using System.Text;
 using System.Text.Json;
 
 using ChatClient.Shared.Models;
@@ -41,22 +40,16 @@ public sealed class RagVectorIndexService(
 
         var fragments = new List<RagVectorFragment>();
         var fragmentIndex = 0;
-        var searchOffset = 0;
         foreach (var paragraph in paragraphs)
         {
             var embedding = await generator.GenerateAsync(paragraph, cancellationToken: cancellationToken);
-            var charIndex = text.IndexOf(paragraph, searchOffset, StringComparison.Ordinal);
-            var offset = Encoding.UTF8.GetByteCount(text.AsSpan(0, charIndex));
-            var length = Encoding.UTF8.GetByteCount(paragraph);
             fragments.Add(new RagVectorFragment
             {
                 Id = $"{Path.GetFileName(sourceFilePath)}#{fragmentIndex:D5}",
-                Offset = offset,
-                Length = length,
+                Text = paragraph,
                 Vector = embedding.Vector.ToArray()
             });
             fragmentIndex++;
-            searchOffset = charIndex + paragraph.Length;
         }
 
         var info = new FileInfo(sourceFilePath);

--- a/ChatClient.Shared/Models/RagVectorFragment.cs
+++ b/ChatClient.Shared/Models/RagVectorFragment.cs
@@ -3,7 +3,6 @@ namespace ChatClient.Shared.Models;
 public class RagVectorFragment
 {
     public string Id { get; set; } = string.Empty;
-    public long Offset { get; set; }
-    public int Length { get; set; }
+    public string Text { get; set; } = string.Empty;
     public float[] Vector { get; set; } = Array.Empty<float>();
 }

--- a/ChatClient.Tests/RagVectorSearchServiceTests.cs
+++ b/ChatClient.Tests/RagVectorSearchServiceTests.cs
@@ -3,7 +3,6 @@ using System.Text.Json;
 using ChatClient.Api.Services;
 using ChatClient.Shared.Services;
 
-using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.SemanticKernel.Memory;
 
@@ -14,44 +13,29 @@ public class RagVectorSearchServiceTests
     [Fact]
     public async Task MergesAdjacentFragments()
     {
-        var temp = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
-        try
-        {
-            var agentId = Guid.NewGuid();
-            var filesDir = Path.Combine(temp, agentId.ToString(), "files");
-            Directory.CreateDirectory(filesDir);
-            await File.WriteAllTextAsync(Path.Combine(filesDir, "file1.txt"), "ABCD");
+        var agentId = Guid.NewGuid();
 
-            var store = new VolatileMemoryStore();
-            var collection = $"agent_{agentId:N}";
-            await store.CreateCollectionAsync(collection);
+        var store = new VolatileMemoryStore();
+        var collection = $"agent_{agentId:N}";
+        await store.CreateCollectionAsync(collection);
 
-            await AddAsync(store, collection, "file1.txt", 0, 0, 1, new float[] { 1, 0 });
-            await AddAsync(store, collection, "file1.txt", 1, 1, 1, new float[] { 1, 0 });
-            await AddAsync(store, collection, "file1.txt", 3, 3, 1, new float[] { 0, 1 });
+        await AddAsync(store, collection, "file1.txt", 0, "A", new float[] { 1, 0 });
+        await AddAsync(store, collection, "file1.txt", 1, "B", new float[] { 1, 0 });
+        await AddAsync(store, collection, "file1.txt", 3, "D", new float[] { 0, 1 });
 
-            var config = new ConfigurationBuilder()
-                .AddInMemoryCollection(new Dictionary<string, string?> { ["RagFiles:BasePath"] = temp })
-                .Build();
-            IRagVectorSearchService service = new RagVectorSearchService(store, config, NullLogger<RagVectorSearchService>.Instance);
+        IRagVectorSearchService service = new RagVectorSearchService(store, NullLogger<RagVectorSearchService>.Instance);
 
-            var results = await service.SearchAsync(agentId, new ReadOnlyMemory<float>(new float[] { 1, 0 }), 2);
+        var results = await service.SearchAsync(agentId, new ReadOnlyMemory<float>(new float[] { 1, 0 }), 2);
 
-            Assert.Equal(2, results.Count);
-            Assert.Equal("file1.txt", results[0].FileName);
-            Assert.Equal("AB", results[0].Content);
-            Assert.Equal("D", results[1].Content);
-        }
-        finally
-        {
-            if (Directory.Exists(temp))
-                Directory.Delete(temp, true);
-        }
+        Assert.Equal(2, results.Count);
+        Assert.Equal("file1.txt", results[0].FileName);
+        Assert.Equal("AB", results[0].Content);
+        Assert.Equal("D", results[1].Content);
     }
 
-    private static async Task AddAsync(IMemoryStore store, string collection, string file, int index, long offset, int length, float[] vector)
+    private static async Task AddAsync(IMemoryStore store, string collection, string file, int index, string text, float[] vector)
     {
-        var meta = JsonSerializer.Serialize(new { file, index, offset, length });
+        var meta = JsonSerializer.Serialize(new { file, index, text });
         var record = new MemoryRecord(
             new MemoryRecordMetadata(false, $"{file}#{index:D5}", null!, null!, null!, meta),
             new ReadOnlyMemory<float>(vector),


### PR DESCRIPTION
## Summary
- keep text with each fragment during vector index build
- simplify search service to merge adjacent fragment texts
- adjust tests for text-based fragments

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68a8eaa14d28832a8d341e9e474aa7ea