### PR TITLE
Show vector search statistics

### DIFF
--- a/ChatClient.Api/Client/Pages/VectorSearch.razor
+++ b/ChatClient.Api/Client/Pages/VectorSearch.razor
@@ -1,5 +1,6 @@
 @page "/vector-search"
 @using ChatClient.Api.Services
+@using ChatClient.Shared.Services
 @using System.Linq
 
 <PageTitle>Vector Search</PageTitle>
@@ -9,7 +10,8 @@
         <MudStack Spacing="2">
             <MudSelect T="AgentDescription"
                        Label="Select Agent"
-                       @bind-Value="selectedAgent"
+                       Value="selectedAgent"
+                       ValueChanged="AgentChanged"
                        Variant="Variant.Outlined"
                        Dense="true"
                        FullWidth="true">
@@ -19,7 +21,17 @@
                 }
             </MudSelect>
 
+            @if (selectedAgent is not null)
+            {
+                <MudText Typo="Typo.body2">Files: @fileCount, size: @FormatSize(totalSize)</MudText>
+            }
+
             <ChatInput OnSend="SearchAsync" />
+
+            @if (totalResults > 0)
+            {
+                <MudText Typo="Typo.body2" Class="mt-2">Found @totalResults segments, showing @results.Count.</MudText>
+            }
 
             @if (results.Count > 0)
             {
@@ -29,6 +41,7 @@
                         <MudListItem T="RagSearchResult">
                             <MudText Typo="Typo.subtitle2">@item.FileName</MudText>
                             <MudText Typo="Typo.body2">@item.Content</MudText>
+                            <MudText Typo="Typo.caption">Score: @item.Score.ToString("0.###")</MudText>
                         </MudListItem>
                     }
                 </MudList>
@@ -41,11 +54,15 @@
     private List<AgentDescription> agents = [];
     private AgentDescription? selectedAgent;
     private List<RagSearchResult> results = [];
+    private int totalResults;
+    private int fileCount;
+    private long totalSize;
     private string embeddingModel = string.Empty;
 
     [Inject] private IAgentDescriptionService AgentService { get; set; } = default!;
     [Inject] private IOllamaClientService OllamaService { get; set; } = default!;
     [Inject] private IRagVectorSearchService VectorSearchService { get; set; } = default!;
+    [Inject] private IRagFileService RagFileService { get; set; } = default!;
     [Inject] private IUserSettingsService UserSettingsService { get; set; } = default!;
     [Inject] private IConfiguration Configuration { get; set; } = default!;
 
@@ -58,6 +75,19 @@
             : settings.EmbeddingModelName;
     }
 
+    private async Task AgentChanged(AgentDescription? agent)
+    {
+        selectedAgent = agent;
+        results.Clear();
+        totalResults = 0;
+        fileCount = 0;
+        totalSize = 0;
+        if (selectedAgent is null) return;
+        var files = await RagFileService.GetFilesAsync(selectedAgent.Id);
+        fileCount = files.Count;
+        totalSize = files.Sum(f => f.Size);
+    }
+
     private async Task SearchAsync((string text, IReadOnlyList<AppChatMessageFile> _) data)
     {
         if (selectedAgent is null) return;
@@ -65,7 +95,21 @@
         if (string.IsNullOrWhiteSpace(text)) return;
 
         var embedding = await OllamaService.GenerateEmbeddingAsync(text, embeddingModel);
-        var found = await VectorSearchService.SearchAsync(selectedAgent.Id, new ReadOnlyMemory<float>(embedding));
-        results = found.ToList();
+        var response = await VectorSearchService.SearchAsync(selectedAgent.Id, new ReadOnlyMemory<float>(embedding));
+        results = response.Results.ToList();
+        totalResults = response.Total;
+    }
+
+    private static string FormatSize(long bytes)
+    {
+        var sizes = new[] { "B", "KB", "MB", "GB" };
+        double len = bytes;
+        var order = 0;
+        while (len >= 1024 && order < sizes.Length - 1)
+        {
+            order++;
+            len /= 1024;
+        }
+        return $"{len:0.#} {sizes[order]}";
     }
 }

--- a/ChatClient.Shared/Models/RagSearchResponse.cs
+++ b/ChatClient.Shared/Models/RagSearchResponse.cs
@@ -1,0 +1,7 @@
+namespace ChatClient.Shared.Models;
+
+public class RagSearchResponse
+{
+    public int Total { get; init; }
+    public IReadOnlyList<RagSearchResult> Results { get; init; } = [];
+}

--- a/ChatClient.Shared/Models/RagSearchResult.cs
+++ b/ChatClient.Shared/Models/RagSearchResult.cs
@@ -4,4 +4,5 @@ public class RagSearchResult
 {
     public string FileName { get; set; } = string.Empty;
     public string Content { get; set; } = string.Empty;
+    public double Score { get; set; }
 }

--- a/ChatClient.Shared/Services/IRagVectorSearchService.cs
+++ b/ChatClient.Shared/Services/IRagVectorSearchService.cs
@@ -4,5 +4,5 @@ using ChatClient.Shared.Models;
 
 public interface IRagVectorSearchService
 {
-    Task<IReadOnlyList<RagSearchResult>> SearchAsync(Guid agentId, ReadOnlyMemory<float> queryVector, int maxResults = 5, CancellationToken cancellationToken = default);
+    Task<RagSearchResponse> SearchAsync(Guid agentId, ReadOnlyMemory<float> queryVector, int maxResults = 5, CancellationToken cancellationToken = default);
 }

--- a/ChatClient.Tests/RagVectorSearchServiceTests.cs
+++ b/ChatClient.Tests/RagVectorSearchServiceTests.cs
@@ -5,6 +5,7 @@ using ChatClient.Shared.Services;
 
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.SemanticKernel.Memory;
+using Microsoft.Extensions.Configuration;
 
 namespace ChatClient.Tests;
 
@@ -23,14 +24,16 @@ public class RagVectorSearchServiceTests
         await AddAsync(store, collection, "file1.txt", 1, "B", new float[] { 1, 0 });
         await AddAsync(store, collection, "file1.txt", 3, "D", new float[] { 0, 1 });
 
-        IRagVectorSearchService service = new RagVectorSearchService(store, NullLogger<RagVectorSearchService>.Instance);
+        var config = new ConfigurationBuilder().Build();
+        IRagVectorSearchService service = new RagVectorSearchService(store, NullLogger<RagVectorSearchService>.Instance, config);
 
-        var results = await service.SearchAsync(agentId, new ReadOnlyMemory<float>(new float[] { 1, 0 }), 2);
+        var response = await service.SearchAsync(agentId, new ReadOnlyMemory<float>(new float[] { 1, 0 }), 2);
 
-        Assert.Equal(2, results.Count);
-        Assert.Equal("file1.txt", results[0].FileName);
-        Assert.Equal("AB", results[0].Content);
-        Assert.Equal("D", results[1].Content);
+        Assert.Equal(2, response.Total);
+        Assert.Equal(2, response.Results.Count);
+        Assert.Equal("file1.txt", response.Results[0].FileName);
+        Assert.Equal("AB", response.Results[0].Content);
+        Assert.Equal("D", response.Results[1].Content);
     }
 
     private static async Task AddAsync(IMemoryStore store, string collection, string file, int index, string text, float[] vector)


### PR DESCRIPTION
## Summary
- display agent file count, total size, and relevance scores on vector search page
- return total matches and scores from vector search service
- cover new search response in tests

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68a9765706b4832ab9e703e70d24e2bb