### PR TITLE
fix: show vector index stats before search

### DIFF
--- a/ChatClient.Api/Client/Pages/VectorSearch.razor
+++ b/ChatClient.Api/Client/Pages/VectorSearch.razor
@@ -12,7 +12,7 @@
         <MudStack Spacing="2">
             <MudSelect T="AgentDescription"
                        Label="Select Agent"
-                       Value="selectedAgent"
+                       Value="@selectedAgent"
                        ValueChanged="AgentChanged"
                        Variant="Variant.Outlined"
                        Dense="true"
@@ -109,6 +109,7 @@
         totalSize = files.Sum(f => f.Size);
         indexedFiles = files.Count(f => f.HasIndex);
         indexStatus = IndexBackgroundService.GetCurrentStatus();
+        StateHasChanged();
     }
 
     private async Task SearchAsync((string text, IReadOnlyList<AppChatMessageFile> _) data)


### PR DESCRIPTION
## Summary
- ensure agent selection binds correctly on vector search page
- refresh UI after agent selection to display index stats

## Testing
- `dotnet build`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68a97c4e6270832a93bc6ce494a5babd