### PR TITLE
Inject RAG context via chat history

### DIFF
--- a/ChatClient.Api/Client/Components/RagDisplay.razor
+++ b/ChatClient.Api/Client/Components/RagDisplay.razor
@@ -1,0 +1,29 @@
+@using Microsoft.AspNetCore.Components
+@using MudBlazor
+
+<MudChatBubble Class="@($"think-line {(isExpanded ? "expanded" : "collapsed")}")" OnClick="Toggle">
+    @if (isExpanded)
+    {
+        <MudText Typo="Typo.caption" Class="mud-text-secondary" Style="white-space: pre-wrap; font-style: italic;">
+            @Text
+        </MudText>
+    }
+    else
+    {
+        <MudText Typo="Typo.caption" Class="mud-text-secondary" Style="font-style: italic;">
+            @ContextIcon @Truncate(Text, 100)
+        </MudText>
+    }
+</MudChatBubble>
+
+@code {
+    [Parameter] public string Text { get; set; } = string.Empty;
+
+    bool isExpanded;
+
+    const string ContextIcon = "\uD83D\uDCC4"; // 📄
+
+    void Toggle() => isExpanded = !isExpanded;
+
+    static string Truncate(string text, int length) => text.Length <= length ? text : text.Substring(0, length) + "...";
+}

--- a/ChatClient.Api/Client/Pages/Chat.razor
+++ b/ChatClient.Api/Client/Pages/Chat.razor
@@ -88,7 +88,16 @@
         <div class="chat-messages-container" @ref="messagesElement">
             @foreach (var message in ChatViewModelService.Messages)
             {
-                @if (message.Role != Microsoft.Extensions.AI.ChatRole.System)
+                if (message.Role == Microsoft.Extensions.AI.ChatRole.System)
+                {
+                    continue;
+                }
+
+                @if (message.Role == Microsoft.Extensions.AI.ChatRole.Tool)
+                {
+                    <RagDisplay Text="@message.Content" />
+                }
+                else
                 {
                     <MudChat Dense="true" ChatPosition="@(message.Role == Microsoft.Extensions.AI.ChatRole.Assistant ? ChatBubblePosition.Start : ChatBubblePosition.End)" @key="message.Id">
                          <MudChatHeader>

--- a/ChatClient.Api/Client/Pages/MultiAgentChat.razor
+++ b/ChatClient.Api/Client/Pages/MultiAgentChat.razor
@@ -111,7 +111,16 @@
         <div class="chat-messages-container" @ref="messagesElement">
             @foreach (var message in ChatViewModelService.Messages)
             {
-                @if (message.Role != Microsoft.Extensions.AI.ChatRole.System)
+                if (message.Role == Microsoft.Extensions.AI.ChatRole.System)
+                {
+                    continue;
+                }
+
+                @if (message.Role == Microsoft.Extensions.AI.ChatRole.Tool)
+                {
+                    <RagDisplay Text="@message.Content" />
+                }
+                else
                 {
                     <MudChat Dense="true" ChatPosition="@(message.Role == Microsoft.Extensions.AI.ChatRole.Assistant ? ChatBubblePosition.Start : ChatBubblePosition.End)" @key="message.Id">
                          <MudChatHeader>

--- a/ChatClient.Tests/AppChatHistoryBuilderTests.cs
+++ b/ChatClient.Tests/AppChatHistoryBuilderTests.cs
@@ -1,0 +1,93 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+using ChatClient.Api.Services;
+using ChatClient.Api.Client.Services;
+using ChatClient.Shared.Models;
+using ChatClient.Shared.Services;
+
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.AI;
+using Microsoft.SemanticKernel;
+using Microsoft.SemanticKernel.ChatCompletion;
+
+namespace ChatClient.Tests;
+
+public class AppChatHistoryBuilderTests
+{
+    private sealed class ThrowingUserSettingsService : IUserSettingsService
+    {
+        public Task<UserSettings> GetSettingsAsync() => throw new InvalidOperationException();
+        public Task SaveSettingsAsync(UserSettings settings) => throw new InvalidOperationException();
+    }
+
+    private sealed class ThrowingOllamaClientService : IOllamaClientService
+    {
+        public Task<IReadOnlyList<OllamaModel>> GetModelsAsync() => throw new InvalidOperationException();
+        public Task<float[]> GenerateEmbeddingAsync(string input, string modelId, CancellationToken cancellationToken = default) => throw new InvalidOperationException();
+    }
+
+    private sealed class ThrowingRagVectorSearchService : IRagVectorSearchService
+    {
+        public Task<RagSearchResponse> SearchAsync(Guid agentId, ReadOnlyMemory<float> queryVector, int maxResults = 5, CancellationToken cancellationToken = default) => throw new InvalidOperationException();
+    }
+
+    private sealed class ThrowingRagFileService : IRagFileService
+    {
+        public Task<List<RagFile>> GetFilesAsync(Guid id) => throw new InvalidOperationException();
+        public Task<RagFile?> GetFileAsync(Guid id, string fileName) => throw new InvalidOperationException();
+        public Task AddOrUpdateFileAsync(Guid id, RagFile file) => throw new InvalidOperationException();
+        public Task DeleteFileAsync(Guid id, string fileName) => throw new InvalidOperationException();
+    }
+
+    [Fact]
+    public async Task BuildChatHistoryAsync_SkipsRagAfterFirstUserMessage()
+    {
+        var builder = new AppChatHistoryBuilder(
+            new ThrowingUserSettingsService(),
+            new LoggerFactory().CreateLogger<AppChatHistoryBuilder>(),
+            new AppForceLastUserReducer(),
+            new ThrowingOllamaClientService(),
+            new ThrowingRagVectorSearchService(),
+            new ThrowingRagFileService(),
+            new ConfigurationBuilder().Build());
+
+        var kernel = Kernel.CreateBuilder().Build();
+        var messages = new List<IAppChatMessage>
+        {
+            new AppChatMessage("first", DateTime.UtcNow, ChatRole.User),
+            new AppChatMessage("reply", DateTime.UtcNow, ChatRole.Assistant),
+            new AppChatMessage("second", DateTime.UtcNow, ChatRole.User)
+        };
+
+        var history = await builder.BuildChatHistoryAsync(messages, kernel, Guid.NewGuid(), CancellationToken.None);
+
+        Assert.DoesNotContain(history, m => m.Role == AuthorRole.Tool);
+    }
+
+    [Fact]
+    public void BuildBaseHistory_PreservesToolRole()
+    {
+        var builder = new AppChatHistoryBuilder(
+            new ThrowingUserSettingsService(),
+            new LoggerFactory().CreateLogger<AppChatHistoryBuilder>(),
+            new AppForceLastUserReducer(),
+            new ThrowingOllamaClientService(),
+            new ThrowingRagVectorSearchService(),
+            new ThrowingRagFileService(),
+            new ConfigurationBuilder().Build());
+
+        var messages = new List<IAppChatMessage>
+        {
+            new AppChatMessage("ctx", DateTime.UtcNow, ChatRole.Tool)
+        };
+
+        var history = builder.BuildBaseHistory(messages);
+        Assert.Single(history);
+        Assert.Equal(AuthorRole.Tool, history.First().Role);
+    }
+}

--- a/ChatClient.Tests/ChatServiceTests.cs
+++ b/ChatClient.Tests/ChatServiceTests.cs
@@ -1,3 +1,5 @@
+using System;
+
 using ChatClient.Api.Client.Services;
 using ChatClient.Api.Services;
 using ChatClient.Shared.Models;
@@ -13,7 +15,7 @@ public class ChatServiceTests
 {
     private class DummyHistoryBuilder : IAppChatHistoryBuilder
     {
-        public Task<ChatHistory> BuildChatHistoryAsync(IEnumerable<IAppChatMessage> messages, Kernel kernel, CancellationToken cancellationToken)
+        public Task<ChatHistory> BuildChatHistoryAsync(IEnumerable<IAppChatMessage> messages, Kernel kernel, Guid agentId, CancellationToken cancellationToken)
             => Task.FromResult(new ChatHistory());
     }
 


### PR DESCRIPTION
## Summary
- show retrieved RAG snippets as collapsible blocks in chat pages
- preserve tool role in chat history and surface RAG context as a chat message
- cover tool role mapping with a new unit test

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68a9950cfdf0832aa4000034f2d9c873