### PR TITLE
Reset indexes when embedding model changes

### DIFF
--- a/ChatClient.Api/Controllers/SettingsController.cs
+++ b/ChatClient.Api/Controllers/SettingsController.cs
@@ -10,11 +10,13 @@ namespace ChatClient.Api.Controllers;
 public class SettingsController : ControllerBase
 {
     private readonly IUserSettingsService _settingsService;
+    private readonly IEmbeddingModelChangeService _changeService;
     private readonly ILogger<SettingsController> _logger;
 
-    public SettingsController(IUserSettingsService settingsService, ILogger<SettingsController> logger)
+    public SettingsController(IUserSettingsService settingsService, IEmbeddingModelChangeService changeService, ILogger<SettingsController> logger)
     {
         _settingsService = settingsService;
+        _changeService = changeService;
         _logger = logger;
     }
 
@@ -38,7 +40,10 @@ public class SettingsController : ControllerBase
     {
         try
         {
+            var existing = await _settingsService.GetSettingsAsync();
             await _settingsService.SaveSettingsAsync(settings);
+            if (!string.Equals(existing.EmbeddingModelName, settings.EmbeddingModelName, StringComparison.OrdinalIgnoreCase))
+                await _changeService.HandleChangeAsync();
             return Ok();
         }
         catch (Exception ex)

--- a/ChatClient.Api/Program.cs
+++ b/ChatClient.Api/Program.cs
@@ -58,6 +58,7 @@ builder.Services.AddSingleton<ChatClient.Api.Client.Services.IStopAgentFactory, 
 builder.Services.AddSingleton<IChatFormatter, TextChatFormatter>();
 builder.Services.AddSingleton<IChatFormatter, MarkdownChatFormatter>();
 builder.Services.AddSingleton<IChatFormatter, HtmlChatFormatter>();
+builder.Services.AddSingleton<ChatClient.Shared.Services.IEmbeddingModelChangeService, ChatClient.Api.Services.EmbeddingModelChangeService>();
 
 builder.Services.AddRazorPages();
 builder.Services.AddServerSideBlazor();

--- a/ChatClient.Api/Services/EmbeddingModelChangeService.cs
+++ b/ChatClient.Api/Services/EmbeddingModelChangeService.cs
@@ -1,0 +1,38 @@
+using ChatClient.Shared.Services;
+
+namespace ChatClient.Api.Services;
+
+public class EmbeddingModelChangeService(
+    IConfiguration configuration,
+    IRagVectorIndexBackgroundService indexBackgroundService,
+    McpFunctionIndexService mcpFunctionIndexService,
+    ILogger<EmbeddingModelChangeService> logger) : IEmbeddingModelChangeService
+{
+    private readonly IConfiguration _configuration = configuration;
+    private readonly IRagVectorIndexBackgroundService _indexBackgroundService = indexBackgroundService;
+    private readonly McpFunctionIndexService _mcpFunctionIndexService = mcpFunctionIndexService;
+    private readonly ILogger<EmbeddingModelChangeService> _logger = logger;
+
+    public async Task HandleChangeAsync()
+    {
+        var basePath = _configuration["RagFiles:BasePath"] ?? Path.Combine("Data", "agents");
+        if (Directory.Exists(basePath))
+        {
+            foreach (var file in Directory.GetFiles(basePath, "*.idx", SearchOption.AllDirectories))
+            {
+                try
+                {
+                    File.Delete(file);
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogError(ex, "Failed to delete index {File}", file);
+                }
+            }
+        }
+
+        _mcpFunctionIndexService.Invalidate();
+        await _mcpFunctionIndexService.BuildIndexAsync();
+        _indexBackgroundService.RequestRebuild();
+    }
+}

--- a/ChatClient.Api/Services/McpFunctionIndexService.cs
+++ b/ChatClient.Api/Services/McpFunctionIndexService.cs
@@ -96,6 +96,11 @@ public class McpFunctionIndexService
         }
     }
 
+    public void Invalidate()
+    {
+        _index.Clear();
+    }
+
     private async Task<string> DetermineModelIdAsync()
     {
         var settings = await _userSettingsService.GetSettingsAsync();

--- a/ChatClient.Shared/Services/IEmbeddingModelChangeService.cs
+++ b/ChatClient.Shared/Services/IEmbeddingModelChangeService.cs
@@ -1,0 +1,6 @@
+namespace ChatClient.Shared.Services;
+
+public interface IEmbeddingModelChangeService
+{
+    Task HandleChangeAsync();
+}


### PR DESCRIPTION
## Summary
- detect embedding model changes when saving settings and trigger index reset
- clear MCP function index and add service to delete RAG indices and rebuild them

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68a9ca2b6dac832ab53bb20942099e1c