### PR TITLE
Handle embedding model validation and failures

### DIFF
--- a/ChatClient.Api/Client/Pages/AppSettings.razor
+++ b/ChatClient.Api/Client/Pages/AppSettings.razor
@@ -197,6 +197,17 @@
     {
         try
         {
+            if (!string.IsNullOrWhiteSpace(_settings.EmbeddingModelName))
+            {
+                var models = await OllamaService.GetModelsAsync();
+                var exists = models.Any(m => m.Name.Equals(_settings.EmbeddingModelName, StringComparison.OrdinalIgnoreCase));
+                if (!exists)
+                {
+                    Snackbar.Add($"Embedding model '{_settings.EmbeddingModelName}' not found.", Severity.Error);
+                    return;
+                }
+            }
+
             await UserSettingsService.SaveSettingsAsync(_settings);
             Snackbar.Add("Application settings saved successfully", Severity.Success);
         }

--- a/ChatClient.Api/Client/Pages/VectorSearch.razor
+++ b/ChatClient.Api/Client/Pages/VectorSearch.razor
@@ -4,6 +4,7 @@
 @using ChatClient.Shared.Models
 @using System.Linq
 @using Microsoft.JSInterop
+@inject ISnackbar Snackbar
 @implements IDisposable
 
 <PageTitle>Vector Search</PageTitle>
@@ -128,10 +129,18 @@
         var text = data.text.Trim();
         if (string.IsNullOrWhiteSpace(text)) return;
 
-        var embedding = await OllamaService.GenerateEmbeddingAsync(text, embeddingModel);
-        var response = await VectorSearchService.SearchAsync(selectedAgent.Id, new ReadOnlyMemory<float>(embedding));
-        results = response.Results.ToList();
-        totalResults = response.Total;
+        try
+        {
+            var embedding = await OllamaService.GenerateEmbeddingAsync(text, embeddingModel);
+            var response = await VectorSearchService.SearchAsync(selectedAgent.Id, new ReadOnlyMemory<float>(embedding));
+            results = response.Results.ToList();
+            totalResults = response.Total;
+        }
+        catch (Exception ex) when (!OllamaService.EmbeddingsAvailable)
+        {
+            Console.Error.WriteLine($"Embedding error: {ex.Message}");
+            Snackbar.Add("Embedding service unavailable. Restart the application.", Severity.Error);
+        }
     }
 
     private async Task CopyResult(RagSearchResult item)

--- a/ChatClient.Api/Services/IOllamaEmbeddingService.cs
+++ b/ChatClient.Api/Services/IOllamaEmbeddingService.cs
@@ -3,4 +3,5 @@ namespace ChatClient.Api.Services;
 public interface IOllamaEmbeddingService
 {
     Task<float[]> GenerateEmbeddingAsync(string input, string modelId, CancellationToken cancellationToken = default);
+    bool EmbeddingsAvailable { get; }
 }

--- a/ChatClient.Api/Services/McpFunctionIndexService.cs
+++ b/ChatClient.Api/Services/McpFunctionIndexService.cs
@@ -87,6 +87,11 @@ public class McpFunctionIndexService
                     }
                     catch (Exception ex)
                     {
+                        if (!_ollamaService.EmbeddingsAvailable)
+                        {
+                            _logger.LogError(ex, "Embedding service unavailable. Stopping MCP function indexing.");
+                            return;
+                        }
                         _logger.LogError(ex, "Failed to index tool {Name}", tool.Name);
                     }
                 }

--- a/ChatClient.Tests/AppChatHistoryBuilderTests.cs
+++ b/ChatClient.Tests/AppChatHistoryBuilderTests.cs
@@ -30,6 +30,7 @@ public class AppChatHistoryBuilderTests
     {
         public Task<IReadOnlyList<OllamaModel>> GetModelsAsync() => throw new InvalidOperationException();
         public Task<float[]> GenerateEmbeddingAsync(string input, string modelId, CancellationToken cancellationToken = default) => throw new InvalidOperationException();
+        public bool EmbeddingsAvailable => true;
     }
 
     private sealed class ThrowingRagVectorSearchService : IRagVectorSearchService


### PR DESCRIPTION
## Summary
- cache embedding errors and expose availability in OllamaService
- block saving settings when embedding model is missing
- stop RAG and MCP indexing when embedding service unavailable
- add interface property and adapt UI/ tests

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68a9d670c634832a813b0ae23b7e16c7