### PR TITLE
Add LLM server settings with migration

### DIFF
--- a/ChatClient.Shared/Models/UserSettings.cs
+++ b/ChatClient.Shared/Models/UserSettings.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Text.Json;
 using System.Text.Json.Serialization;
@@ -22,6 +23,12 @@ public class UserSettings
 
     [JsonPropertyName("agentName")]
     public string AgentName { get; set; } = string.Empty;
+
+    [JsonPropertyName("llms")]
+    public List<LlmServerConfig> Llms { get; set; } = [];
+
+    [JsonPropertyName("defaultLlmId")]
+    public Guid? DefaultLlmId { get; set; }
 
     /// <summary>
     /// Ollama server URL (including protocol and port)


### PR DESCRIPTION
## Summary
- add LLM server configuration list and default ID to user settings
- migrate legacy Ollama fields into new LLM configuration on load

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68aa30505948832a99f6c36b3e60186d