### PR TITLE
Add LLM server config service

### DIFF
--- a/ChatClient.Api/Data/llm_servers.json
+++ b/ChatClient.Api/Data/llm_servers.json
@@ -1,0 +1,14 @@
+[
+  {
+    "Id": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+    "Name": "Ollama",
+    "ServerType": 0,
+    "BaseUrl": "http://localhost:11434",
+    "ApiKey": null,
+    "Password": null,
+    "IgnoreSslErrors": false,
+    "HttpTimeoutSeconds": 600,
+    "CreatedAt": "2025-05-24T00:00:00Z",
+    "UpdatedAt": "2025-06-01T23:42:25.155509Z"
+  }
+]

--- a/ChatClient.Api/Program.cs
+++ b/ChatClient.Api/Program.cs
@@ -34,6 +34,7 @@ Console.WriteLine($"Content Root: {builder.Environment.ContentRootPath}");
 Console.WriteLine($"Web Root: {builder.Environment.WebRootPath}");
 
 builder.Services.AddSingleton<ChatClient.Shared.Services.IMcpServerConfigService, ChatClient.Api.Services.McpServerConfigService>();
+builder.Services.AddSingleton<ChatClient.Api.Services.ILlmServerConfigService, ChatClient.Api.Services.LlmServerConfigService>();
 builder.Services.AddSingleton<ChatClient.Api.Services.IMcpClientService, ChatClient.Api.Services.McpClientService>();
 builder.Services.AddSingleton<ChatClient.Api.Services.McpSamplingService>();
 builder.Services.AddSingleton<ChatClient.Api.Services.KernelService>();

--- a/ChatClient.Api/Services/ILlmServerConfigService.cs
+++ b/ChatClient.Api/Services/ILlmServerConfigService.cs
@@ -1,0 +1,12 @@
+using ChatClient.Shared.Models;
+
+namespace ChatClient.Api.Services;
+
+public interface ILlmServerConfigService
+{
+    Task<List<LlmServerConfig>> GetAllAsync();
+    Task<LlmServerConfig?> GetByIdAsync(Guid id);
+    Task<LlmServerConfig> CreateAsync(LlmServerConfig server);
+    Task<LlmServerConfig> UpdateAsync(LlmServerConfig server);
+    Task DeleteAsync(Guid id);
+}

--- a/ChatClient.Api/Services/LlmServerConfigService.cs
+++ b/ChatClient.Api/Services/LlmServerConfigService.cs
@@ -1,0 +1,186 @@
+using System.Text.Json;
+
+using ChatClient.Shared.Models;
+
+namespace ChatClient.Api.Services;
+
+public class LlmServerConfigService : ILlmServerConfigService
+{
+    private readonly string _filePath;
+    private readonly ILogger<LlmServerConfigService> _logger;
+    private readonly SemaphoreSlim _semaphore = new(1, 1);
+
+    public LlmServerConfigService(IConfiguration configuration, ILogger<LlmServerConfigService> logger)
+    {
+        var serversFilePath = configuration["LlmServers:FilePath"] ?? "Data/llm_servers.json";
+        _filePath = Path.GetFullPath(serversFilePath);
+        _logger = logger;
+        var directory = Path.GetDirectoryName(_filePath);
+        if (!string.IsNullOrEmpty(directory) && !Directory.Exists(directory))
+        {
+            Directory.CreateDirectory(directory);
+        }
+
+        if (!File.Exists(_filePath))
+        {
+            CreateDefaultServersFile().GetAwaiter().GetResult();
+        }
+    }
+
+    private async Task CreateDefaultServersFile()
+    {
+        var defaultServers = new List<LlmServerConfig>
+        {
+            new()
+            {
+                Id = Guid.NewGuid(),
+                Name = "Ollama",
+                ServerType = ServerType.Ollama,
+                BaseUrl = "http://localhost:11434",
+                CreatedAt = DateTime.UtcNow,
+                UpdatedAt = DateTime.UtcNow
+            }
+        };
+
+        await WriteToFileAsync(defaultServers);
+    }
+
+    public async Task<List<LlmServerConfig>> GetAllAsync()
+    {
+        try
+        {
+            await _semaphore.WaitAsync();
+
+            if (!File.Exists(_filePath))
+            {
+                await CreateDefaultServersFile();
+                return await ReadFromFileAsync();
+            }
+
+            return await ReadFromFileAsync();
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error getting LLM server configs");
+            return [];
+        }
+        finally
+        {
+            _semaphore.Release();
+        }
+    }
+
+    public async Task<LlmServerConfig?> GetByIdAsync(Guid id)
+    {
+        var servers = await GetAllAsync();
+        return servers.FirstOrDefault(s => s.Id == id);
+    }
+
+    public async Task<LlmServerConfig> CreateAsync(LlmServerConfig server)
+    {
+        try
+        {
+            await _semaphore.WaitAsync();
+
+            var servers = await ReadFromFileAsync();
+
+            if (server.Id == null)
+                server.Id = Guid.NewGuid();
+
+            server.CreatedAt = DateTime.UtcNow;
+            server.UpdatedAt = DateTime.UtcNow;
+
+            servers.Add(server);
+            await WriteToFileAsync(servers);
+
+            return server;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error creating LLM server config");
+            throw;
+        }
+        finally
+        {
+            _semaphore.Release();
+        }
+    }
+
+    public async Task<LlmServerConfig> UpdateAsync(LlmServerConfig server)
+    {
+        try
+        {
+            await _semaphore.WaitAsync();
+
+            var servers = await ReadFromFileAsync();
+            var existingIndex = servers.FindIndex(s => s.Id == server.Id);
+
+            if (existingIndex == -1)
+            {
+                throw new KeyNotFoundException($"LLM server config with ID {server.Id} not found");
+            }
+
+            server.UpdatedAt = DateTime.UtcNow;
+            servers[existingIndex] = server;
+
+            await WriteToFileAsync(servers);
+
+            return server;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error updating LLM server config");
+            throw;
+        }
+        finally
+        {
+            _semaphore.Release();
+        }
+    }
+
+    public async Task DeleteAsync(Guid id)
+    {
+        try
+        {
+            await _semaphore.WaitAsync();
+
+            var servers = await ReadFromFileAsync();
+            var existingServer = servers.FirstOrDefault(s => s.Id == id);
+
+            if (existingServer == null)
+            {
+                throw new KeyNotFoundException($"LLM server config with ID {id} not found");
+            }
+
+            servers.Remove(existingServer);
+            await WriteToFileAsync(servers);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error deleting LLM server config");
+            throw;
+        }
+        finally
+        {
+            _semaphore.Release();
+        }
+    }
+
+    private async Task<List<LlmServerConfig>> ReadFromFileAsync()
+    {
+        if (!File.Exists(_filePath))
+        {
+            return [];
+        }
+
+        var json = await File.ReadAllTextAsync(_filePath);
+        return JsonSerializer.Deserialize<List<LlmServerConfig>>(json) ?? [];
+    }
+
+    private async Task WriteToFileAsync(List<LlmServerConfig> servers)
+    {
+        var options = new JsonSerializerOptions { WriteIndented = true };
+        var json = JsonSerializer.Serialize(servers, options);
+        await File.WriteAllTextAsync(_filePath, json);
+    }
+}


### PR DESCRIPTION
## Summary
- add ILlmServerConfigService interface and LlmServerConfigService implementation
- persist LLM server configs in `Data/llm_servers.json` with concurrency safety
- register LlmServerConfigService in DI container

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68aa31b276b0832a8cc3f2a185a6d983