### PR TITLE
feat: manage LLM server configurations

### DIFF
--- a/ChatClient.Api/Client/Components/LlmServerEditor.razor
+++ b/ChatClient.Api/Client/Components/LlmServerEditor.razor
@@ -1,0 +1,42 @@
+@using ChatClient.Shared.Models
+
+<MudTextField @bind-Value="Server.Name"
+              Label="Server Name"
+              Required="true"
+              Immediate="true" />
+
+<MudSelect T="ServerType" @bind-Value="Server.ServerType" Label="Server Type" Class="mt-4">
+    <MudSelectItem Value="ServerType.Ollama">Ollama</MudSelectItem>
+    <MudSelectItem Value="ServerType.ChatGpt">ChatGPT</MudSelectItem>
+</MudSelect>
+
+<MudTextField @bind-Value="Server.BaseUrl"
+              Label="Base URL"
+              Variant="Variant.Outlined"
+              Class="mt-4"
+              Required="true" />
+
+<MudTextField @bind-Value="Server.ApiKey"
+              Label="API Key"
+              Variant="Variant.Outlined"
+              Class="mt-4" />
+
+<MudTextField @bind-Value="Server.Password"
+              Label="Password"
+              Variant="Variant.Outlined"
+              InputType="InputType.Password"
+              Class="mt-4" />
+
+<MudNumericField T="int" @bind-Value="Server.HttpTimeoutSeconds"
+                 Label="HTTP Timeout (seconds)"
+                 Variant="Variant.Outlined"
+                 Min="1" Max="3600"
+                 Class="mt-4" />
+
+<MudSwitch @bind-Value="Server.IgnoreSslErrors" Class="mt-4">
+    Ignore SSL certificate errors
+</MudSwitch>
+
+@code {
+    [Parameter] public LlmServerConfig Server { get; set; } = new();
+}

--- a/ChatClient.Api/Client/Layout/NavMenu.razor
+++ b/ChatClient.Api/Client/Layout/NavMenu.razor
@@ -3,6 +3,7 @@
     <MudNavLink Href="multi-agent-chat" Match="NavLinkMatch.Prefix" Icon="@Icons.Material.Filled.Groups">Multi-Agent</MudNavLink>
     <MudNavLink Href="vector-search" Match="NavLinkMatch.Prefix" Icon="@Icons.Material.Filled.Search">Vector Search</MudNavLink>
     <MudNavLink Href="agent-descriptions" Match="NavLinkMatch.Prefix" Icon="@Icons.Material.Filled.List">Agent Descriptions</MudNavLink>
+    <MudNavLink Href="llm-servers" Match="NavLinkMatch.Prefix" Icon="@Icons.Material.Filled.Cloud">LLM Servers</MudNavLink>
     <MudNavLink Href="mcp-servers" Match="NavLinkMatch.Prefix" Icon="@Icons.Material.Filled.Link">MCP Servers</MudNavLink>
     <MudNavLink Href="models" Match="NavLinkMatch.Prefix" Icon="@Icons.Material.Filled.Memory">Models</MudNavLink>
     <MudNavLink Href="ollama-connection-settings" Match="NavLinkMatch.Prefix" Icon="@Icons.Material.Filled.Link">Ollama Connection</MudNavLink>

--- a/ChatClient.Api/Client/Pages/LlmServers.razor
+++ b/ChatClient.Api/Client/Pages/LlmServers.razor
@@ -1,0 +1,240 @@
+@page "/llm-servers"
+@using ChatClient.Shared.Models
+@using ChatClient.Api.Services
+@using System.Net.Http
+@inject ILlmServerConfigService LlmServerConfigService
+@inject ISnackbar Snackbar
+
+<PageTitle>LLM Servers</PageTitle>
+
+<MudContainer MaxWidth="MaxWidth.ExtraLarge" Class="mt-3">
+    <MudText Class="page-header">LLM Servers</MudText>
+
+    <MudPaper Elevation="3" Class="pa-3 rounded-lg">
+        <MudToolBar Dense="true">
+            <MudButton Variant="Variant.Filled"
+                       Color="Color.Primary"
+                       StartIcon="@Icons.Material.Filled.Add"
+                       OnClick="AddServer"
+                       Size="Size.Small">
+                Add Server
+            </MudButton>
+        </MudToolBar>
+
+        @if (loading)
+        {
+            <MudStack Justify="Justify.Center" Class="my-4">
+                <MudProgressCircular Color="Color.Primary" Indeterminate="true" />
+            </MudStack>
+        }
+        else
+        {
+            <MudTable Items="servers" Hover="true" Striped="true" Bordered="true" Class="mt-4">
+                <HeaderContent>
+                    <MudTh>Name</MudTh>
+                    <MudTh>Type</MudTh>
+                    <MudTh>Base URL</MudTh>
+                    <MudTh>Updated</MudTh>
+                    <MudTh></MudTh>
+                </HeaderContent>
+                <RowTemplate>
+                    <MudTd DataLabel="Name">@context.Name</MudTd>
+                    <MudTd DataLabel="Type">@context.ServerType</MudTd>
+                    <MudTd DataLabel="Base URL">@context.BaseUrl</MudTd>
+                    <MudTd DataLabel="Updated">@context.UpdatedAt.ToLocalTime().ToString("g")</MudTd>
+                    <MudTd Class="d-flex justify-end">
+                        <MudIconButton Icon="@Icons.Material.Filled.PlayArrow"
+                                        Size="Size.Small"
+                                        Color="Color.Info"
+                                        OnClick="@( () => TestServer(context) )" />
+                        <MudIconButton Icon="@Icons.Material.Filled.Edit"
+                                        Size="Size.Small"
+                                        OnClick="@( () => StartEdit(context) )" />
+                        <MudIconButton Icon="@Icons.Material.Filled.Delete"
+                                        Size="Size.Small"
+                                        Color="Color.Error"
+                                        OnClick="@( () => ConfirmDelete(context) )" />
+                    </MudTd>
+                </RowTemplate>
+                <NoRecordsContent>
+                    <MudText Class="pa-4">No servers configured.</MudText>
+                </NoRecordsContent>
+            </MudTable>
+        }
+    </MudPaper>
+</MudContainer>
+
+<MudDialog @bind-Visible="editDialog" Options="editDialogOptions">
+    <TitleContent>
+        <MudText Typo="Typo.h6">@(editingServer?.Id == null ? "Add Server" : "Edit Server")</MudText>
+    </TitleContent>
+    <DialogContent>
+        <MudForm @ref="editForm" Model="editingServer">
+            <LlmServerEditor Server="editingServer" />
+        </MudForm>
+    </DialogContent>
+    <DialogActions>
+        <MudButton OnClick="CancelEdit" Size="Size.Medium">Cancel</MudButton>
+        <MudButton Color="Color.Primary" OnClick="SaveServer" Size="Size.Medium">Save</MudButton>
+    </DialogActions>
+</MudDialog>
+
+<MudDialog @bind-Visible="deleteDialog" Options="dialogOptions">
+    <TitleContent>
+        <MudText Typo="Typo.h6">Confirm Delete</MudText>
+    </TitleContent>
+    <DialogContent>
+        <MudText>Delete server "@serverToDelete?.Name"?</MudText>
+    </DialogContent>
+    <DialogActions>
+        <MudButton OnClick="CancelDelete" Size="Size.Medium">Cancel</MudButton>
+        <MudButton Color="Color.Error" OnClick="DeleteServer" Size="Size.Medium">Delete</MudButton>
+    </DialogActions>
+</MudDialog>
+
+@code {
+    private List<LlmServerConfig> servers = new();
+    private bool loading = true;
+    private bool editDialog;
+    private bool deleteDialog;
+    private LlmServerConfig editingServer = new();
+    private LlmServerConfig? serverToDelete;
+    private MudForm? editForm;
+
+    private DialogOptions dialogOptions = new() { CloseOnEscapeKey = true, CloseButton = true };
+    private DialogOptions editDialogOptions = new() { CloseOnEscapeKey = true, CloseButton = true, MaxWidth = MaxWidth.Small, FullWidth = true };
+
+    protected override async Task OnInitializedAsync() => await LoadServers();
+
+    private async Task LoadServers()
+    {
+        try
+        {
+            loading = true;
+            servers = await LlmServerConfigService.GetAllAsync();
+        }
+        catch (Exception ex)
+        {
+            Snackbar.Add($"Error loading servers: {ex.Message}", Severity.Error);
+        }
+        finally
+        {
+            loading = false;
+        }
+    }
+
+    private void AddServer()
+    {
+        editingServer = new LlmServerConfig { ServerType = ServerType.Ollama };
+        editDialog = true;
+    }
+
+    private void StartEdit(LlmServerConfig server)
+    {
+        editingServer = new LlmServerConfig
+        {
+            Id = server.Id,
+            Name = server.Name,
+            ServerType = server.ServerType,
+            BaseUrl = server.BaseUrl,
+            ApiKey = server.ApiKey,
+            Password = server.Password,
+            IgnoreSslErrors = server.IgnoreSslErrors,
+            HttpTimeoutSeconds = server.HttpTimeoutSeconds,
+            CreatedAt = server.CreatedAt,
+            UpdatedAt = server.UpdatedAt
+        };
+        editDialog = true;
+    }
+
+    private async Task SaveServer()
+    {
+        if (editForm is null)
+            return;
+
+        await editForm.Validate();
+        if (!editForm.IsValid)
+            return;
+
+        try
+        {
+            if (editingServer.Id == null)
+            {
+                await LlmServerConfigService.CreateAsync(editingServer);
+                Snackbar.Add("Server created", Severity.Success);
+            }
+            else
+            {
+                await LlmServerConfigService.UpdateAsync(editingServer);
+                Snackbar.Add("Server updated", Severity.Success);
+            }
+            editDialog = false;
+            await LoadServers();
+        }
+        catch (Exception ex)
+        {
+            Snackbar.Add($"Error saving server: {ex.Message}", Severity.Error);
+        }
+    }
+
+    private void CancelEdit() => editDialog = false;
+
+    private void ConfirmDelete(LlmServerConfig server)
+    {
+        serverToDelete = server;
+        deleteDialog = true;
+    }
+
+    private void CancelDelete() => deleteDialog = false;
+
+    private async Task DeleteServer()
+    {
+        if (serverToDelete?.Id == null)
+            return;
+
+        try
+        {
+            await LlmServerConfigService.DeleteAsync(serverToDelete.Id.Value);
+            Snackbar.Add("Server deleted", Severity.Success);
+            await LoadServers();
+        }
+        catch (Exception ex)
+        {
+            Snackbar.Add($"Error deleting server: {ex.Message}", Severity.Error);
+        }
+        finally
+        {
+            deleteDialog = false;
+        }
+    }
+
+    private async Task TestServer(LlmServerConfig server)
+    {
+        try
+        {
+            using var handler = new HttpClientHandler();
+            if (server.IgnoreSslErrors)
+                handler.ServerCertificateCustomValidationCallback = (_, _, _, _) => true;
+
+            using var client = new HttpClient(handler)
+            {
+                Timeout = TimeSpan.FromSeconds(server.HttpTimeoutSeconds),
+                BaseAddress = new Uri(server.BaseUrl)
+            };
+
+            if (!string.IsNullOrEmpty(server.Password))
+            {
+                var auth = Convert.ToBase64String(System.Text.Encoding.UTF8.GetBytes($":{server.Password}"));
+                client.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Basic", auth);
+            }
+
+            var response = await client.GetAsync("api/tags");
+            response.EnsureSuccessStatusCode();
+            Snackbar.Add("Connection successful", Severity.Success);
+        }
+        catch (Exception ex)
+        {
+            Snackbar.Add($"Connection failed: {ex.Message}", Severity.Error);
+        }
+    }
+}

--- a/ChatClient.Api/Client/Pages/OllamaConnectionSettings.razor
+++ b/ChatClient.Api/Client/Pages/OllamaConnectionSettings.razor
@@ -21,34 +21,18 @@
     else
     {
         <MudPaper Elevation="3" Class="pa-3 rounded-lg">
-            <MudForm @ref="_form" Model="@_settings">
+            <MudForm @ref="_form" Model="@_server">
                 <MudCard Class="mb-4" Elevation="1">
                     <MudCardHeader Class="pb-2">
                         <MudText Class="section-header">Server Connection</MudText>
                     </MudCardHeader>
                     <MudCardContent Class="pt-0">
-                        <MudTextField T="string" Label="Server URL" @bind-Value="_settings.OllamaServerUrl"
-                                      Variant="Variant.Outlined"
-                                      HelperText="Ollama server URL including protocol and port (e.g., https://my-server:11434)"
-                                      Placeholder="@OllamaDefaults.ServerUrl" />
-
-                        <MudTextField T="string" Label="Basic Auth Password" @bind-Value="_settings.OllamaBasicAuthPassword"
-                                      Variant="Variant.Outlined" InputType="InputType.Password"
-                                      HelperText="Password for basic authentication (leave empty if not required)"
-                                      Class="mt-3" />                        <MudNumericField T="int" Label="HTTP Timeout (seconds)" @bind-Value="_settings.HttpTimeoutSeconds"
-                                         Variant="Variant.Outlined" Min="1" Max="3600"
-                                         HelperText="Timeout for HTTP requests to Ollama server (1-3600 seconds)"
-                                         Class="mt-3" />
+                        <LlmServerEditor Server="_server" />
 
                         <MudNumericField T="int" Label="MCP Sampling Timeout (seconds)" @bind-Value="_settings.McpSamplingTimeoutSeconds"
                                          Variant="Variant.Outlined" Min="60" Max="7200"
                                          HelperText="Timeout for MCP sampling requests - typically longer than regular API calls (60-7200 seconds)"
-                                         Class="mt-3" />
-
-                        <MudSwitch T="bool" @bind-Value="_settings.IgnoreSslErrors" Color="Color.Primary" Class="mt-3">
-                            Ignore SSL certificate errors (for self-signed certificates)
-                        </MudSwitch>
-
+                                         Class="mt-4" />
                     </MudCardContent>
                 </MudCard>
 
@@ -90,6 +74,7 @@
 
 @code {
     private UserSettings _settings = new();
+    private LlmServerConfig _server = new();
     private bool _loading = true;
     private bool _testingConnection = false;
     private MudForm? _form;
@@ -113,6 +98,15 @@
         try
         {
             _settings = await UserSettingsService.GetSettingsAsync();
+            _server = new LlmServerConfig
+            {
+                Name = "Ollama",
+                ServerType = ServerType.Ollama,
+                BaseUrl = _settings.OllamaServerUrl,
+                Password = _settings.OllamaBasicAuthPassword,
+                IgnoreSslErrors = _settings.IgnoreSslErrors,
+                HttpTimeoutSeconds = _settings.HttpTimeoutSeconds
+            };
         }
         catch (Exception ex)
         {
@@ -125,6 +119,10 @@
     {
         try
         {
+            _settings.OllamaServerUrl = _server.BaseUrl;
+            _settings.OllamaBasicAuthPassword = _server.Password;
+            _settings.IgnoreSslErrors = _server.IgnoreSslErrors;
+            _settings.HttpTimeoutSeconds = _server.HttpTimeoutSeconds;
             await UserSettingsService.SaveSettingsAsync(_settings);
             Snackbar.Add("Connection settings saved successfully", Severity.Success);
         }
@@ -150,9 +148,12 @@
         try
         {
             // Save current settings temporarily to test them
+            _settings.OllamaServerUrl = _server.BaseUrl;
+            _settings.OllamaBasicAuthPassword = _server.Password;
+            _settings.IgnoreSslErrors = _server.IgnoreSslErrors;
+            _settings.HttpTimeoutSeconds = _server.HttpTimeoutSeconds;
             await UserSettingsService.SaveSettingsAsync(_settings);
 
-            // Try to get models to test connection
             var models = await OllamaService.GetModelsAsync();
 
             _connectionTestResult = new ConnectionTestResult


### PR DESCRIPTION
## Summary
- add reusable LLM server editor component
- introduce LLM Servers page with CRUD and connection test
- reuse editor in Ollama connection settings and link in nav menu

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68aa35e86858832a91be7912dc750106