### PR TITLE
Add server-model picker component and CRUD service test

### DIFF
--- a/ChatClient.Api/Client/Components/ServerModelPicker.razor
+++ b/ChatClient.Api/Client/Components/ServerModelPicker.razor
@@ -1,0 +1,74 @@
+@using ChatClient.Api.Services
+@using ChatClient.Shared.Models
+@inject ILlmServerConfigService LlmServerConfigService
+@inject IOllamaClientService OllamaService
+
+<MudStack Spacing="2">
+    <MudSelect T="Guid?" Value="selectedServerId" ValueChanged="OnServerChanged" Label="Server" Variant="Variant.Outlined">
+        @foreach (var server in servers)
+        {
+            <MudSelectItem Value="@server.Id">@server.Name</MudSelectItem>
+        }
+    </MudSelect>
+
+    <MudSelect T="string" Value="selectedModel" ValueChanged="OnModelChanged" Label="Model" Variant="Variant.Outlined" Disabled="@(!selectedServerId.HasValue)">
+        @foreach (var model in models)
+        {
+            <MudSelectItem Value="@model.Name">@model.Name</MudSelectItem>
+        }
+    </MudSelect>
+</MudStack>
+
+@code {
+    [Parameter] public ServerModel Value { get; set; } = new(Guid.Empty, string.Empty);
+    [Parameter] public EventCallback<ServerModel> ValueChanged { get; set; }
+
+    private Guid? selectedServerId;
+    private string? selectedModel;
+    private List<LlmServerConfig> servers = [];
+    private List<OllamaModel> models = [];
+
+    protected override async Task OnInitializedAsync()
+    {
+        servers = await LlmServerConfigService.GetAllAsync();
+        if (Value.ServerId != Guid.Empty)
+        {
+            selectedServerId = Value.ServerId;
+            await LoadModelsAsync(Value.ServerId);
+        }
+        if (!string.IsNullOrEmpty(Value.ModelName))
+        {
+            selectedModel = Value.ModelName;
+        }
+    }
+
+    private async Task OnServerChanged(Guid? id)
+    {
+        selectedServerId = id;
+        selectedModel = null;
+        models.Clear();
+        if (id.HasValue)
+        {
+            await LoadModelsAsync(id.Value);
+        }
+        await NotifyValueChanged();
+    }
+
+    private async Task OnModelChanged(string? model)
+    {
+        selectedModel = model;
+        await NotifyValueChanged();
+    }
+
+    private async Task NotifyValueChanged()
+    {
+        var selection = new ServerModel(selectedServerId ?? Guid.Empty, selectedModel ?? string.Empty);
+        Value = selection;
+        await ValueChanged.InvokeAsync(selection);
+    }
+
+    private async Task LoadModelsAsync(Guid serverId)
+    {
+        models = (await OllamaService.GetModelsAsync()).ToList();
+    }
+}

--- a/ChatClient.Shared/Models/ServerModel.cs
+++ b/ChatClient.Shared/Models/ServerModel.cs
@@ -1,0 +1,5 @@
+using System;
+
+namespace ChatClient.Shared.Models;
+
+public record ServerModel(Guid ServerId, string ModelName);

--- a/ChatClient.Tests/LlmServerConfigServiceTests.cs
+++ b/ChatClient.Tests/LlmServerConfigServiceTests.cs
@@ -1,0 +1,59 @@
+using ChatClient.Api.Services;
+using ChatClient.Shared.Models;
+
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+
+namespace ChatClient.Tests;
+
+public class LlmServerConfigServiceTests
+{
+    [Fact]
+    public async Task CrudOperationsWork()
+    {
+        var tempFile = Path.GetTempFileName();
+        File.WriteAllText(tempFile, "[]");
+        try
+        {
+            var config = new ConfigurationBuilder()
+                .AddInMemoryCollection(new Dictionary<string, string?>
+                {
+                    ["LlmServers:FilePath"] = tempFile
+                })
+                .Build();
+
+            var logger = new LoggerFactory().CreateLogger<LlmServerConfigService>();
+            var service = new LlmServerConfigService(config, logger);
+
+            var server = new LlmServerConfig
+            {
+                Name = "Test",
+                ServerType = ServerType.Ollama,
+                BaseUrl = "http://localhost"
+            };
+
+            var created = await service.CreateAsync(server);
+            Assert.NotNull(created.Id);
+
+            var all = await service.GetAllAsync();
+            Assert.Single(all);
+
+            var retrieved = await service.GetByIdAsync(created.Id!.Value);
+            Assert.NotNull(retrieved);
+            Assert.Equal("Test", retrieved!.Name);
+
+            created.Name = "Updated";
+            await service.UpdateAsync(created);
+            var updated = await service.GetByIdAsync(created.Id.Value);
+            Assert.Equal("Updated", updated!.Name);
+
+            await service.DeleteAsync(created.Id.Value);
+            var afterDelete = await service.GetAllAsync();
+            Assert.Empty(afterDelete);
+        }
+        finally
+        {
+            File.Delete(tempFile);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add ServerModelPicker component for choosing server and model pairs
- cover LlmServerConfigService with CRUD operations unit test
- introduce ServerModel record and refactor ServerModelPicker to use it

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68aa25470168832ab143489dbe725dec