### PR TITLE
feat: add server model picker and propagate selection

### DIFF
--- a/ChatClient.Api/Client/Components/ServerModelPicker.razor
+++ b/ChatClient.Api/Client/Components/ServerModelPicker.razor
@@ -69,6 +69,6 @@
 
     private async Task LoadModelsAsync(Guid serverId)
     {
-        models = (await OllamaService.GetModelsAsync()).ToList();
+        models = (await OllamaService.GetModelsAsync(serverId)).ToList();
     }
 }

--- a/ChatClient.Api/Client/Layout/MainLayout.razor
+++ b/ChatClient.Api/Client/Layout/MainLayout.razor
@@ -3,10 +3,9 @@
 @inject NavigationManager NavigationManager
 @inject IAppChatService ChatService
 @inject IUserSettingsService UserSettingsService
-@inject IOllamaClientService OllamaService
 @using ChatClient.Shared.Models
 @using ChatClient.Api.Client.Pages
-@using System.Collections.Generic
+@using ChatClient.Api.Client.Components
 @using ChatClient.Api.Services
 
 <MudThemeProvider Theme="@_theme" IsDarkMode="_isDarkMode" />
@@ -26,38 +25,7 @@
                        StartIcon="@Icons.Material.Filled.AddCircle"
                        Size="Size.Small"
                        Class="ml-4">New Chat</MudButton>
-            <MudSelect T="OllamaModel"
-                       Value="selectedModel"
-                       ValueChanged="OnModelChanged"
-                       Label="Model"
-                       Variant="Variant.Filled"
-                       Dense="true"
-                       Margin="Margin.Dense"
-                       Class="ml-4"
-                       Style="min-width: 150px;">
-                @foreach (var model in availableModels)
-                {
-                    <MudSelectItem Value="@model">
-                        <span>@model.Name</span>
-                        @if (model.SupportsImages)
-                        {
-                            <MudIcon Icon="@Icons.Material.Filled.Image"
-                                     Size="Size.Small"
-                                     Class="ml-1"
-                                     title="Supports images"
-                                     Style="color: #4caf50;" />
-                        }
-                        @if (model.SupportsFunctionCalling)
-                        {
-                            <MudIcon Icon="@Icons.Material.Filled.Settings"
-                                     Size="Size.Small"
-                                     Class="ml-1"
-                                     title="Function calling support detected (may not be accurate)"
-                                     Style="color: #2196f3;" />
-                        }
-                    </MudSelectItem>
-                }
-            </MudSelect>
+            <ServerModelPicker Value="selectedModel" ValueChanged="OnModelChanged" Class="ml-4" />
         }
         <MudSpacer />
         <MudIconButton Icon="@(DarkLightModeButtonIcon)" Color="Color.Inherit" OnClick="@DarkModeToggle" Size="Size.Medium" />
@@ -92,8 +60,7 @@
     private bool _drawerOpen = true;
     private bool _isDarkMode = true;
     private bool isLLMAnswering;
-    private List<OllamaModel> availableModels = new();
-    private OllamaModel? selectedModel;
+    private ServerModel selectedModel = new(Guid.Empty, string.Empty);
     private MudTheme? _theme = null;
 
     protected override async Task OnInitializedAsync()
@@ -104,25 +71,7 @@
         isLLMAnswering = ChatService.IsAnswering;
 
         var settings = await UserSettingsService.GetSettingsAsync();
-
-        try
-        {
-            availableModels = (await OllamaService.GetModelsAsync()).ToList();
-            if (!string.IsNullOrWhiteSpace(settings.DefaultModelName) &&
-                availableModels.Any(m => m.Name == settings.DefaultModelName))
-            {
-                selectedModel = availableModels.FirstOrDefault(m => m.Name == settings.DefaultModelName);
-            }
-            else
-            {
-                selectedModel = availableModels.FirstOrDefault();
-            }
-        }
-        catch (Exception ex)
-        {
-            Console.WriteLine($"Error loading available models: {ex}");
-            availableModels = new List<OllamaModel>();
-        }
+        selectedModel = new(settings.DefaultLlmId ?? Guid.Empty, settings.DefaultModelName);
 
         _theme = new()
         {
@@ -170,9 +119,14 @@
 
     
 
-    private void OnModelChanged(OllamaModel model)
+    private async Task OnModelChanged(ServerModel model)
     {
-        selectedModel = model;
+        var settings = await UserSettingsService.GetSettingsAsync();
+        var serverId = model.ServerId != Guid.Empty ? model.ServerId : settings.DefaultLlmId ?? Guid.Empty;
+        settings.DefaultLlmId = serverId;
+        settings.DefaultModelName = model.ModelName;
+        await UserSettingsService.SaveSettingsAsync(settings);
+        selectedModel = model with { ServerId = serverId };
         StateHasChanged();
     }
 

--- a/ChatClient.Api/Client/Pages/Chat.razor
+++ b/ChatClient.Api/Client/Pages/Chat.razor
@@ -229,7 +229,7 @@
     private AgentDescription? selectedAgent { get; set; }
 
     [CascadingParameter(Name = "SelectedModel")]
-    public OllamaModel? SelectedModel { get; set; }
+    public ServerModel? SelectedModel { get; set; }
 
 
     private UserSettings userSettings = new();
@@ -310,7 +310,7 @@
             throw new InvalidOperationException("Single-agent chat requires exactly one agent.");
 
         if (string.IsNullOrWhiteSpace(agents[0].ModelName))
-            agents[0].ModelName = SelectedModel?.Name;
+            agents[0].ModelName = SelectedModel?.ModelName;
 
         ChatService.InitializeChat(agents);
         chatStarted = true;
@@ -323,7 +323,7 @@
         if (selectedAgent == null) return;
 
         var functions = selectedAgent.FunctionSettings.SelectedFunctions ?? [];
-        var chatConfiguration = new AppChatConfiguration(SelectedModel?.Name, functions);
+        var chatConfiguration = new AppChatConfiguration(SelectedModel?.ModelName, functions);
         var options = new RoundRobinStopAgentOptions { Rounds = 1 };
         var groupChatManager = StopAgentFactory.Create("RoundRobin", options);
         await ChatService.GenerateAnswerAsync(messageData.text.Trim(), chatConfiguration, groupChatManager, messageData.files);

--- a/ChatClient.Api/Client/Pages/Models.razor
+++ b/ChatClient.Api/Client/Pages/Models.razor
@@ -67,6 +67,9 @@
 </OllamaCheck>
 
 @code {
+    [CascadingParameter(Name = "SelectedModel")]
+    public ServerModel? SelectedModel { get; set; }
+
     private List<OllamaModel> _models = new();
     private bool _loading = true;
     private string? _errorMessage;
@@ -76,7 +79,7 @@
         try
         {
             _loading = true;
-            _models = (await OllamaService.GetModelsAsync()).ToList();
+            _models = (await OllamaService.GetModelsAsync(SelectedModel?.ServerId)).ToList();
             _errorMessage = null;
         }
         catch (Exception ex)

--- a/ChatClient.Api/Client/Pages/MultiAgentChat.razor
+++ b/ChatClient.Api/Client/Pages/MultiAgentChat.razor
@@ -253,7 +253,7 @@
     private List<AgentDescription> selectedAgents { get; set; } = new();
 
     [CascadingParameter(Name = "SelectedModel")]
-    public OllamaModel? SelectedModel { get; set; }
+    public ServerModel? SelectedModel { get; set; }
 
     private const string RoundRobinStopAgent = "RoundRobin";
     private const string RoundRobinSummaryStopAgent = "RoundRobinWithSummary";
@@ -392,7 +392,7 @@
 
         foreach (var agent in selectedAgents)
             if (string.IsNullOrWhiteSpace(agent.ModelName))
-                agent.ModelName = SelectedModel?.Name;
+                agent.ModelName = SelectedModel?.ModelName;
 
         userSettings.StopAgentName = stopAgentName;
         userSettings.MultiAgentSelectedAgents = selectedAgents.Select(a => a.AgentName).ToList();
@@ -469,7 +469,7 @@
             }
         }
         var groupChatManager = StopAgentFactory.Create(stopAgentName, options);
-        var chatConfiguration = new AppChatConfiguration(SelectedModel?.Name, allFunctions);
+        var chatConfiguration = new AppChatConfiguration(SelectedModel?.ModelName, allFunctions);
 
         await ChatService.GenerateAnswerAsync(messageData.text.Trim(), chatConfiguration, groupChatManager, messageData.files);
         await ScrollToBottom();

--- a/ChatClient.Api/Client/Pages/VectorSearch.razor
+++ b/ChatClient.Api/Client/Pages/VectorSearch.razor
@@ -84,6 +84,9 @@
     [Inject] private IRagVectorIndexBackgroundService IndexBackgroundService { get; set; } = default!;
     [Inject] private IJSRuntime JSRuntime { get; set; } = default!;
 
+    [CascadingParameter(Name = "SelectedModel")]
+    public ServerModel? SelectedModel { get; set; }
+
     protected override async Task OnInitializedAsync()
     {
         agents = await AgentService.GetAllAsync();
@@ -131,7 +134,7 @@
 
         try
         {
-            var embedding = await OllamaService.GenerateEmbeddingAsync(text, embeddingModel);
+            var embedding = await OllamaService.GenerateEmbeddingAsync(text, embeddingModel, SelectedModel?.ServerId);
             var response = await VectorSearchService.SearchAsync(selectedAgent.Id, new ReadOnlyMemory<float>(embedding));
             results = response.Results.ToList();
             totalResults = response.Total;

--- a/ChatClient.Api/Services/AppChatHistoryBuilder.cs
+++ b/ChatClient.Api/Services/AppChatHistoryBuilder.cs
@@ -102,7 +102,7 @@ public class AppChatHistoryBuilder(
                 var query = ThinkTagParser.ExtractThinkAnswer(lastUser.Content).Answer;
                 try
                 {
-                    var embedding = await _ollama.GenerateEmbeddingAsync(query, model, cancellationToken);
+                    var embedding = await _ollama.GenerateEmbeddingAsync(query, model, cancellationToken: cancellationToken);
                     var response = await _ragSearch.SearchAsync(agentId, new ReadOnlyMemory<float>(embedding), 5, cancellationToken);
                     if (response.Results.Count > 0)
                     {

--- a/ChatClient.Api/Services/IOllamaClientService.cs
+++ b/ChatClient.Api/Services/IOllamaClientService.cs
@@ -4,5 +4,5 @@ using ChatClient.Shared.Models;
 
 public interface IOllamaClientService : IOllamaEmbeddingService
 {
-    Task<IReadOnlyList<OllamaModel>> GetModelsAsync();
+    Task<IReadOnlyList<OllamaModel>> GetModelsAsync(Guid? serverId = null);
 }

--- a/ChatClient.Api/Services/IOllamaEmbeddingService.cs
+++ b/ChatClient.Api/Services/IOllamaEmbeddingService.cs
@@ -2,6 +2,6 @@ namespace ChatClient.Api.Services;
 
 public interface IOllamaEmbeddingService
 {
-    Task<float[]> GenerateEmbeddingAsync(string input, string modelId, CancellationToken cancellationToken = default);
+    Task<float[]> GenerateEmbeddingAsync(string input, string modelId, Guid? serverId = null, CancellationToken cancellationToken = default);
     bool EmbeddingsAvailable { get; }
 }

--- a/ChatClient.Api/Services/McpFunctionIndexService.cs
+++ b/ChatClient.Api/Services/McpFunctionIndexService.cs
@@ -77,7 +77,7 @@ public class McpFunctionIndexService
                     string text = $"{tool.Name}. {tool.Description}";
                     try
                     {
-                        var embedding = await _ollamaService.GenerateEmbeddingAsync(text, _modelId, cancellationToken);
+                        var embedding = await _ollamaService.GenerateEmbeddingAsync(text, _modelId, cancellationToken: cancellationToken);
                         _index[$"{client.ServerInfo.Name}:{tool.Name}"] = embedding;
                     }
                     catch (HttpRequestException ex) when (ex.StatusCode == HttpStatusCode.NotFound)
@@ -126,7 +126,7 @@ public class McpFunctionIndexService
     public async Task<IReadOnlyList<string>> SelectRelevantFunctionsAsync(string query, int topK, CancellationToken cancellationToken = default)
     {
         await BuildIndexAsync(cancellationToken);
-        var queryEmbedding = await _ollamaService.GenerateEmbeddingAsync(query, _modelId, cancellationToken);
+        var queryEmbedding = await _ollamaService.GenerateEmbeddingAsync(query, _modelId, cancellationToken: cancellationToken);
         return _index
             .Select(kvp => new { Name = kvp.Key, Score = Dot(queryEmbedding.AsSpan(), kvp.Value) })
             .OrderByDescending(e => e.Score)

--- a/ChatClient.Tests/AppChatHistoryBuilderTests.cs
+++ b/ChatClient.Tests/AppChatHistoryBuilderTests.cs
@@ -28,8 +28,8 @@ public class AppChatHistoryBuilderTests
 
     private sealed class ThrowingOllamaClientService : IOllamaClientService
     {
-        public Task<IReadOnlyList<OllamaModel>> GetModelsAsync() => throw new InvalidOperationException();
-        public Task<float[]> GenerateEmbeddingAsync(string input, string modelId, CancellationToken cancellationToken = default) => throw new InvalidOperationException();
+        public Task<IReadOnlyList<OllamaModel>> GetModelsAsync(Guid? serverId = null) => throw new InvalidOperationException();
+        public Task<float[]> GenerateEmbeddingAsync(string input, string modelId, Guid? serverId = null, CancellationToken cancellationToken = default) => throw new InvalidOperationException();
         public bool EmbeddingsAvailable => true;
     }
 


### PR DESCRIPTION
## Summary
- use `ServerModelPicker` in main layout and persist selection to user settings
- cascade selected server model to pages and pass to services
- allow Ollama service APIs to target specific servers

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68ab01a4a36c832aacda6357ef8d24de