### PR TITLE
feat: cache ollama clients per server

### DIFF
--- a/ChatClient.Api/Services/IOllamaClientService.cs
+++ b/ChatClient.Api/Services/IOllamaClientService.cs
@@ -5,4 +5,5 @@ using ChatClient.Shared.Models;
 public interface IOllamaClientService : IOllamaEmbeddingService
 {
     Task<IReadOnlyList<OllamaModel>> GetModelsAsync(Guid? serverId = null);
+    Task<IReadOnlyList<OllamaModel>> GetModelsAsync(ServerModel serverModel);
 }

--- a/ChatClient.Api/Services/IOllamaEmbeddingService.cs
+++ b/ChatClient.Api/Services/IOllamaEmbeddingService.cs
@@ -1,7 +1,10 @@
 namespace ChatClient.Api.Services;
 
+using ChatClient.Shared.Models;
+
 public interface IOllamaEmbeddingService
 {
     Task<float[]> GenerateEmbeddingAsync(string input, string modelId, Guid? serverId = null, CancellationToken cancellationToken = default);
+    Task<float[]> GenerateEmbeddingAsync(string input, ServerModel model, CancellationToken cancellationToken = default);
     bool EmbeddingsAvailable { get; }
 }

--- a/ChatClient.Tests/AppChatHistoryBuilderTests.cs
+++ b/ChatClient.Tests/AppChatHistoryBuilderTests.cs
@@ -29,7 +29,9 @@ public class AppChatHistoryBuilderTests
     private sealed class ThrowingOllamaClientService : IOllamaClientService
     {
         public Task<IReadOnlyList<OllamaModel>> GetModelsAsync(Guid? serverId = null) => throw new InvalidOperationException();
+        public Task<IReadOnlyList<OllamaModel>> GetModelsAsync(ServerModel serverModel) => throw new InvalidOperationException();
         public Task<float[]> GenerateEmbeddingAsync(string input, string modelId, Guid? serverId = null, CancellationToken cancellationToken = default) => throw new InvalidOperationException();
+        public Task<float[]> GenerateEmbeddingAsync(string input, ServerModel model, CancellationToken cancellationToken = default) => throw new InvalidOperationException();
         public bool EmbeddingsAvailable => true;
     }
 


### PR DESCRIPTION
## Summary
- cache ollama api and http clients per server id
- create clients from `LlmServerConfig`
- expose overloads using `ServerModel`

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68ab0c5c35dc832a87f769826b136ffc