### PR TITLE
feat: pass serverId to service calls

### DIFF
--- a/ChatClient.Api/Services/AppChatHistoryBuilder.cs
+++ b/ChatClient.Api/Services/AppChatHistoryBuilder.cs
@@ -16,7 +16,7 @@ namespace ChatClient.Api.Services;
 
 public interface IAppChatHistoryBuilder
 {
-    Task<ChatHistory> BuildChatHistoryAsync(IEnumerable<IAppChatMessage> messages, Kernel kernel, Guid agentId, CancellationToken cancellationToken);
+    Task<ChatHistory> BuildChatHistoryAsync(IEnumerable<IAppChatMessage> messages, Kernel kernel, Guid agentId, CancellationToken cancellationToken, Guid? serverId = null);
 }
 
 public class AppChatHistoryBuilder(
@@ -73,7 +73,7 @@ public class AppChatHistoryBuilder(
         return history;
     }
 
-    public async Task<ChatHistory> BuildChatHistoryAsync(IEnumerable<IAppChatMessage> messages, Kernel kernel, Guid agentId, CancellationToken cancellationToken)
+    public async Task<ChatHistory> BuildChatHistoryAsync(IEnumerable<IAppChatMessage> messages, Kernel kernel, Guid agentId, CancellationToken cancellationToken, Guid? serverId = null)
     {
         var messageList = messages.ToList();
         logger.LogInformation("Building chat history from {MessageCount} messages", messageList.Count);
@@ -102,7 +102,7 @@ public class AppChatHistoryBuilder(
                 var query = ThinkTagParser.ExtractThinkAnswer(lastUser.Content).Answer;
                 try
                 {
-                    var embedding = await _ollama.GenerateEmbeddingAsync(query, model, cancellationToken: cancellationToken);
+                    var embedding = await _ollama.GenerateEmbeddingAsync(query, model, serverId, cancellationToken);
                     var response = await _ragSearch.SearchAsync(agentId, new ReadOnlyMemory<float>(embedding), 5, cancellationToken);
                     if (response.Results.Count > 0)
                     {

--- a/ChatClient.Api/Services/StartupOllamaChecker.cs
+++ b/ChatClient.Api/Services/StartupOllamaChecker.cs
@@ -4,11 +4,11 @@ namespace ChatClient.Api.Services;
 
 public class StartupOllamaChecker(IOllamaClientService ollamaService, ILogger<StartupOllamaChecker> logger)
 {
-    public async Task<OllamaServerStatus> CheckOllamaStatusAsync()
+    public async Task<OllamaServerStatus> CheckOllamaStatusAsync(Guid? serverId = null)
     {
         try
         {
-            var models = await ollamaService.GetModelsAsync();
+            var models = await ollamaService.GetModelsAsync(serverId);
             logger.LogInformation("Ollama is available with {ModelCount} models", models.Count);
 
             return new OllamaServerStatus

--- a/ChatClient.Shared/Services/IRagVectorIndexService.cs
+++ b/ChatClient.Shared/Services/IRagVectorIndexService.cs
@@ -4,5 +4,5 @@ namespace ChatClient.Shared.Services;
 
 public interface IRagVectorIndexService
 {
-    Task BuildIndexAsync(Guid agentId, string sourceFilePath, string indexFilePath, IProgress<RagVectorIndexStatus>? progress = null, CancellationToken cancellationToken = default);
+    Task BuildIndexAsync(Guid agentId, string sourceFilePath, string indexFilePath, IProgress<RagVectorIndexStatus>? progress = null, CancellationToken cancellationToken = default, Guid? serverId = null);
 }

--- a/ChatClient.Tests/ChatServiceTests.cs
+++ b/ChatClient.Tests/ChatServiceTests.cs
@@ -15,7 +15,7 @@ public class ChatServiceTests
 {
     private class DummyHistoryBuilder : IAppChatHistoryBuilder
     {
-        public Task<ChatHistory> BuildChatHistoryAsync(IEnumerable<IAppChatMessage> messages, Kernel kernel, Guid agentId, CancellationToken cancellationToken)
+        public Task<ChatHistory> BuildChatHistoryAsync(IEnumerable<IAppChatMessage> messages, Kernel kernel, Guid agentId, CancellationToken cancellationToken, Guid? serverId = null)
             => Task.FromResult(new ChatHistory());
     }
 


### PR DESCRIPTION
## Summary
- allow KernelService to create kernels for specific servers
- thread serverId through RAG and MCP services
- support server-aware embedding retrieval in chat history builder

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68ab10f07254832aae8b6f17171bea04