### PR TITLE
refactor: migrate single ollama settings to llms list

### DIFF
--- a/ChatClient.Api/Services/OllamaService.cs
+++ b/ChatClient.Api/Services/OllamaService.cs
@@ -118,17 +118,15 @@ public sealed class OllamaService(
             }
         }
 
-        var baseUrl = !string.IsNullOrWhiteSpace(settings.OllamaServerUrl)
-            ? settings.OllamaServerUrl
-            : configuration["Ollama:BaseUrl"] ?? OllamaDefaults.ServerUrl;
+        var server = settings.Llms.FirstOrDefault();
+        if (server != null)
+            return server;
 
+        var baseUrl = configuration["Ollama:BaseUrl"] ?? OllamaDefaults.ServerUrl;
         return new LlmServerConfig
         {
             Id = Guid.Empty,
             BaseUrl = baseUrl,
-            Password = settings.OllamaBasicAuthPassword,
-            IgnoreSslErrors = settings.IgnoreSslErrors,
-            HttpTimeoutSeconds = settings.HttpTimeoutSeconds,
             ServerType = ServerType.Ollama,
             Name = "Default"
         };

--- a/ChatClient.Api/Services/RagVectorIndexService.cs
+++ b/ChatClient.Api/Services/RagVectorIndexService.cs
@@ -85,15 +85,11 @@ public sealed class RagVectorIndexService(
     private async Task<string> GetBaseUrlAsync(Guid? serverId)
     {
         var settings = await userSettings.GetSettingsAsync();
+        LlmServerConfig? server = null;
         if (serverId.HasValue && serverId.Value != Guid.Empty)
-        {
-            var server = settings.Llms.FirstOrDefault(s => s.Id == serverId.Value);
-            if (server != null)
-                return server.BaseUrl;
-        }
-        if (!string.IsNullOrWhiteSpace(settings.OllamaServerUrl))
-            return settings.OllamaServerUrl;
-        return configuration["Ollama:BaseUrl"] ?? "http://localhost:11434";
+            server = settings.Llms.FirstOrDefault(s => s.Id == serverId.Value);
+        server ??= settings.Llms.FirstOrDefault(s => s.Id == settings.DefaultLlmId) ?? settings.Llms.FirstOrDefault();
+        return server?.BaseUrl ?? configuration["Ollama:BaseUrl"] ?? "http://localhost:11434";
     }
 
     private async Task<string> GetModelIdAsync()

--- a/ChatClient.Api/Services/UserSettingsService.cs
+++ b/ChatClient.Api/Services/UserSettingsService.cs
@@ -5,11 +5,13 @@ using System.Linq;
 
 using ChatClient.Shared.Models;
 using ChatClient.Shared.Services;
+using ChatClient.Shared.Constants;
 
 namespace ChatClient.Api.Services;
 
 public class UserSettingsService : IUserSettingsService
 {
+    private const int CurrentVersion = 2;
     private readonly string _settingsFilePath;
     private readonly ILogger<UserSettingsService> _logger;
     private readonly JsonSerializerOptions _jsonOptions = new()
@@ -43,9 +45,12 @@ public class UserSettingsService : IUserSettingsService
         }
 
         var json = await File.ReadAllTextAsync(_settingsFilePath);
+        using var doc = JsonDocument.Parse(json);
         var settings = JsonSerializer.Deserialize<UserSettings>(json, _jsonOptions) ?? new UserSettings();
+        var version = doc.RootElement.TryGetProperty("version", out var v) ? v.GetInt32() : 1;
+        settings.Version = version;
 
-        return await MigrateSettingsAsync(settings);
+        return version < CurrentVersion ? await MigrateSettingsAsync(settings, doc.RootElement) : settings;
     }
 
     public async Task SaveSettingsAsync(UserSettings settings)
@@ -59,6 +64,7 @@ public class UserSettingsService : IUserSettingsService
                 existing = JsonSerializer.Deserialize<UserSettings>(jsonExisting, _jsonOptions);
             }
 
+            settings.Version = CurrentVersion;
             var json = JsonSerializer.Serialize(settings, _jsonOptions);
             await File.WriteAllTextAsync(_settingsFilePath, json);
             _logger.LogInformation("User settings saved successfully");
@@ -75,13 +81,16 @@ public class UserSettingsService : IUserSettingsService
         }
     }
 
-    private async Task<UserSettings> MigrateSettingsAsync(UserSettings settings)
+    private async Task<UserSettings> MigrateSettingsAsync(UserSettings settings, JsonElement root)
     {
-        var needsSave = false;
+        var serverId = Guid.NewGuid();
+        var baseUrl = root.TryGetProperty("ollamaServerUrl", out var urlEl) ? urlEl.GetString() : null;
+        var password = root.TryGetProperty("ollamaBasicAuthPassword", out var passEl) ? passEl.GetString() : null;
+        var ignoreSsl = root.TryGetProperty("ignoreSslErrors", out var sslEl) && sslEl.GetBoolean();
+        var httpTimeout = root.TryGetProperty("httpTimeoutSeconds", out var tEl) ? tEl.GetInt32() : 600;
 
         if (settings.Llms == null || settings.Llms.Count == 0)
         {
-            var serverId = Guid.NewGuid();
             settings.Llms = new List<LlmServerConfig>
             {
                 new()
@@ -89,16 +98,15 @@ public class UserSettingsService : IUserSettingsService
                     Id = serverId,
                     Name = "Ollama",
                     ServerType = ServerType.Ollama,
-                    BaseUrl = settings.OllamaServerUrl,
-                    Password = settings.OllamaBasicAuthPassword,
-                    IgnoreSslErrors = settings.IgnoreSslErrors,
-                    HttpTimeoutSeconds = settings.HttpTimeoutSeconds,
+                    BaseUrl = string.IsNullOrWhiteSpace(baseUrl) ? OllamaDefaults.ServerUrl : baseUrl,
+                    Password = password,
+                    IgnoreSslErrors = ignoreSsl,
+                    HttpTimeoutSeconds = httpTimeout,
                     CreatedAt = DateTime.UtcNow,
                     UpdatedAt = DateTime.UtcNow
                 }
             };
             settings.DefaultLlmId = serverId;
-            needsSave = true;
         }
         else if (settings.DefaultLlmId == null && settings.Llms.Count > 0)
         {
@@ -106,12 +114,10 @@ public class UserSettingsService : IUserSettingsService
                 settings.Llms[0].Id = Guid.NewGuid();
 
             settings.DefaultLlmId = settings.Llms[0].Id;
-            needsSave = true;
         }
 
-        if (needsSave)
-            await SaveSettingsAsync(settings);
-
+        settings.Version = CurrentVersion;
+        await SaveSettingsAsync(settings);
         return settings;
     }
 }

--- a/ChatClient.Shared/Models/UserSettings.cs
+++ b/ChatClient.Shared/Models/UserSettings.cs
@@ -9,6 +9,9 @@ namespace ChatClient.Shared.Models;
 
 public class UserSettings
 {
+    [JsonPropertyName("version")]
+    public int Version { get; set; } = 2;
+
     [JsonPropertyName("defaultModelName")]
     public string DefaultModelName { get; set; } = string.Empty;
 
@@ -29,27 +32,6 @@ public class UserSettings
 
     [JsonPropertyName("defaultLlmId")]
     public Guid? DefaultLlmId { get; set; }
-
-    /// <summary>
-    /// Ollama server URL (including protocol and port)
-    /// </summary>
-    [JsonPropertyName("ollamaServerUrl")]
-    public string OllamaServerUrl { get; set; } = OllamaDefaults.ServerUrl;
-
-    [JsonPropertyName("ollamaBasicAuthPassword")]
-    public string OllamaBasicAuthPassword { get; set; } = string.Empty;
-
-    /// <summary>
-    /// Whether to ignore SSL certificate errors (for self-signed certificates)
-    /// </summary>
-    [JsonPropertyName("ignoreSslErrors")]
-    public bool IgnoreSslErrors { get; set; } = false;
-
-    /// <summary>
-    /// HTTP request timeout in seconds for Ollama API calls
-    /// </summary>
-    [JsonPropertyName("httpTimeoutSeconds")]
-    public int HttpTimeoutSeconds { get; set; } = 600;
 
     /// <summary>
     /// HTTP request timeout in seconds for MCP sampling requests (typically longer than regular API calls)


### PR DESCRIPTION
## Summary
- remove obsolete Ollama-specific properties from user settings
- add versioned migration for user settings
- rely on LLMS list for server connection details

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68ab45538170832a8bdd34e0b86186eb