### PR TITLE
Use ServerModelPicker and fallback to default LLM

### DIFF
--- a/ChatClient.Api/Client/Components/ServerModelPicker.razor
+++ b/ChatClient.Api/Client/Components/ServerModelPicker.razor
@@ -2,6 +2,7 @@
 @using ChatClient.Shared.Models
 @inject ILlmServerConfigService LlmServerConfigService
 @inject IOllamaClientService OllamaService
+@inject IUserSettingsService UserSettingsService
 
 <MudStack Spacing="1" Row="true" AlignItems="AlignItems.Center" @attributes="Attributes" Style="flex: 1; min-width: 0;">
     <MudSelect T="Guid?" Value="selectedServerId" ValueChanged="OnServerChanged" Placeholder="Server" 
@@ -47,15 +48,21 @@
     protected override async Task OnInitializedAsync()
     {
         servers = await LlmServerConfigService.GetAllAsync();
-        if (Value.ServerId != Guid.Empty)
+        if (Value.ServerId == Guid.Empty && string.IsNullOrEmpty(Value.ModelName))
         {
-            selectedServerId = Value.ServerId;
-            await LoadModelsAsync(Value.ServerId);
+            var settings = await UserSettingsService.GetSettingsAsync();
+            selectedServerId = settings.DefaultLlmId;
+            selectedModel = settings.DefaultModelName;
+            if (selectedServerId.HasValue)
+                await LoadModelsAsync(selectedServerId.Value);
+            await NotifyValueChanged();
+            return;
         }
+        selectedServerId = Value.ServerId;
+        if (selectedServerId.HasValue)
+            await LoadModelsAsync(selectedServerId.Value);
         if (!string.IsNullOrEmpty(Value.ModelName))
-        {
             selectedModel = Value.ModelName;
-        }
     }
 
     private async Task OnServerChanged(Guid? id)

--- a/ChatClient.Api/Client/Pages/Chat.razor
+++ b/ChatClient.Api/Client/Pages/Chat.razor
@@ -231,6 +231,9 @@
     [CascadingParameter(Name = "SelectedModel")]
     public ServerModel? SelectedModel { get; set; }
 
+    private string CurrentModelName => string.IsNullOrWhiteSpace(SelectedModel?.ModelName)
+        ? userSettings.DefaultModelName
+        : SelectedModel.ModelName;
 
     private UserSettings userSettings = new();
 
@@ -310,7 +313,7 @@
             throw new InvalidOperationException("Single-agent chat requires exactly one agent.");
 
         if (string.IsNullOrWhiteSpace(agents[0].ModelName))
-            agents[0].ModelName = SelectedModel?.ModelName;
+            agents[0].ModelName = CurrentModelName;
 
         ChatService.InitializeChat(agents);
         chatStarted = true;
@@ -323,7 +326,7 @@
         if (selectedAgent == null) return;
 
         var functions = selectedAgent.FunctionSettings.SelectedFunctions ?? [];
-        var chatConfiguration = new AppChatConfiguration(SelectedModel?.ModelName, functions);
+        var chatConfiguration = new AppChatConfiguration(CurrentModelName, functions);
         var options = new RoundRobinStopAgentOptions { Rounds = 1 };
         var groupChatManager = StopAgentFactory.Create("RoundRobin", options);
         await ChatService.GenerateAnswerAsync(messageData.text.Trim(), chatConfiguration, groupChatManager, messageData.files);

--- a/ChatClient.Api/Client/Pages/Models.razor
+++ b/ChatClient.Api/Client/Pages/Models.razor
@@ -3,6 +3,7 @@
 @using System.Text.Json
 @using ChatClient.Api.Services
 @inject IOllamaClientService OllamaService
+@inject IUserSettingsService UserSettingsService
 
 <OllamaCheck>
     <MudContainer Class="mt-3">
@@ -79,7 +80,13 @@
         try
         {
             _loading = true;
-            _models = (await OllamaService.GetModelsAsync(SelectedModel?.ServerId)).ToList();
+            var serverId = SelectedModel?.ServerId;
+            if (serverId == null || serverId == Guid.Empty)
+            {
+                var settings = await UserSettingsService.GetSettingsAsync();
+                serverId = settings.DefaultLlmId;
+            }
+            _models = (await OllamaService.GetModelsAsync(serverId)).ToList();
             _errorMessage = null;
         }
         catch (Exception ex)

--- a/ChatClient.Api/Client/Pages/MultiAgentChat.razor
+++ b/ChatClient.Api/Client/Pages/MultiAgentChat.razor
@@ -255,6 +255,10 @@
     [CascadingParameter(Name = "SelectedModel")]
     public ServerModel? SelectedModel { get; set; }
 
+    private string CurrentModelName => string.IsNullOrWhiteSpace(SelectedModel?.ModelName)
+        ? userSettings.DefaultModelName
+        : SelectedModel.ModelName;
+
     private const string RoundRobinStopAgent = "RoundRobin";
     private const string RoundRobinSummaryStopAgent = "RoundRobinWithSummary";
     private List<string> stopAgents = new();
@@ -392,7 +396,7 @@
 
         foreach (var agent in selectedAgents)
             if (string.IsNullOrWhiteSpace(agent.ModelName))
-                agent.ModelName = SelectedModel?.ModelName;
+                agent.ModelName = CurrentModelName;
 
         userSettings.StopAgentName = stopAgentName;
         userSettings.MultiAgentSelectedAgents = selectedAgents.Select(a => a.AgentName).ToList();
@@ -469,7 +473,7 @@
             }
         }
         var groupChatManager = StopAgentFactory.Create(stopAgentName, options);
-        var chatConfiguration = new AppChatConfiguration(SelectedModel?.ModelName, allFunctions);
+        var chatConfiguration = new AppChatConfiguration(CurrentModelName, allFunctions);
 
         await ChatService.GenerateAnswerAsync(messageData.text.Trim(), chatConfiguration, groupChatManager, messageData.files);
         await ScrollToBottom();

--- a/ChatClient.Api/Client/Pages/VectorSearch.razor
+++ b/ChatClient.Api/Client/Pages/VectorSearch.razor
@@ -134,7 +134,13 @@
 
         try
         {
-            var embedding = await OllamaService.GenerateEmbeddingAsync(text, embeddingModel, SelectedModel?.ServerId);
+            var serverId = SelectedModel?.ServerId;
+            if (serverId == null || serverId == Guid.Empty)
+            {
+                var settings = await UserSettingsService.GetSettingsAsync();
+                serverId = settings.DefaultLlmId;
+            }
+            var embedding = await OllamaService.GenerateEmbeddingAsync(text, embeddingModel, serverId);
             var response = await VectorSearchService.SearchAsync(selectedAgent.Id, new ReadOnlyMemory<float>(embedding));
             results = response.Results.ToList();
             totalResults = response.Total;


### PR DESCRIPTION
## Summary
- Load default server and model from user settings when no selection is made
- Use default LLM ID when pages request models or embeddings without a selected server
- Fall back to saved model name in chat pages

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68ab4af88a24832aada803e3d9ff0570