### PR TITLE
refactor: add server-specific clients

### DIFF
--- a/ChatClient.Api/Client/Components/OllamaCheck.razor
+++ b/ChatClient.Api/Client/Components/OllamaCheck.razor
@@ -33,7 +33,7 @@ else
         isChecking = true;
         try
         {
-            await OllamaService.GetModelsAsync();
+            await OllamaService.GetModelsAsync(Guid.Empty);
         }
         catch (Exception ex)
         {

--- a/ChatClient.Api/Client/Pages/AgentDescriptions.razor
+++ b/ChatClient.Api/Client/Pages/AgentDescriptions.razor
@@ -350,7 +350,7 @@
     {
         try
         {
-            availableModels = (await OllamaService.GetModelsAsync()).ToList();
+            availableModels = (await OllamaService.GetModelsAsync(Guid.Empty)).ToList();
         }
         catch (Exception ex)
         {

--- a/ChatClient.Api/Client/Pages/AppSettings.razor
+++ b/ChatClient.Api/Client/Pages/AppSettings.razor
@@ -167,7 +167,7 @@
     {
         try
         {
-            _availableModels = (await OllamaService.GetModelsAsync(serverId)).ToList();
+            _availableModels = (await OllamaService.GetModelsAsync(serverId ?? Guid.Empty)).ToList();
             if (_availableModels.Count == 0)
             {
                 Snackbar.Add("No models available. Settings will be saved but model selection won't take effect.", Severity.Warning);
@@ -199,7 +199,7 @@
         {
             if (!string.IsNullOrWhiteSpace(_settings.EmbeddingModelName))
             {
-                var models = await OllamaService.GetModelsAsync(_settings.DefaultLlmId);
+                var models = await OllamaService.GetModelsAsync(_settings.DefaultLlmId ?? Guid.Empty);
                 var exists = models.Any(m => m.Name.Equals(_settings.EmbeddingModelName, StringComparison.OrdinalIgnoreCase));
                 if (!exists)
                 {

--- a/ChatClient.Api/Client/Pages/McpServers.razor
+++ b/ChatClient.Api/Client/Pages/McpServers.razor
@@ -250,7 +250,7 @@
     {
         try
         {
-            availableModels = (await OllamaService.GetModelsAsync()).ToList();
+            availableModels = (await OllamaService.GetModelsAsync(Guid.Empty)).ToList();
         }
         catch (Exception ex)
         {

--- a/ChatClient.Api/Client/Pages/Models.razor
+++ b/ChatClient.Api/Client/Pages/Models.razor
@@ -86,7 +86,7 @@
                 var settings = await UserSettingsService.GetSettingsAsync();
                 serverId = settings.DefaultLlmId;
             }
-            _models = (await OllamaService.GetModelsAsync(serverId)).ToList();
+            _models = (await OllamaService.GetModelsAsync(serverId ?? Guid.Empty)).ToList();
             _errorMessage = null;
         }
         catch (Exception ex)

--- a/ChatClient.Api/Client/Pages/VectorSearch.razor
+++ b/ChatClient.Api/Client/Pages/VectorSearch.razor
@@ -140,7 +140,7 @@
                 var settings = await UserSettingsService.GetSettingsAsync();
                 serverId = settings.DefaultLlmId;
             }
-            var embedding = await OllamaService.GenerateEmbeddingAsync(text, embeddingModel, serverId);
+            var embedding = await OllamaService.GenerateEmbeddingAsync(text, embeddingModel, serverId ?? Guid.Empty);
             var response = await VectorSearchService.SearchAsync(selectedAgent.Id, new ReadOnlyMemory<float>(embedding));
             results = response.Results.ToList();
             totalResults = response.Total;

--- a/ChatClient.Api/Controllers/ModelsController.cs
+++ b/ChatClient.Api/Controllers/ModelsController.cs
@@ -10,11 +10,11 @@ namespace ChatClient.Api.Controllers;
 public class ModelsController(IOllamaClientService ollamaService, ILogger<ModelsController> logger) : ControllerBase
 {
     [HttpGet]
-    public async Task<ActionResult<IEnumerable<OllamaModel>>> GetModels()
+    public async Task<ActionResult<IEnumerable<OllamaModel>>> GetModels([FromQuery] Guid? serverId = null)
     {
         try
         {
-            var models = await ollamaService.GetModelsAsync();
+            var models = await ollamaService.GetModelsAsync(serverId ?? Guid.Empty);
             return Ok(models);
         }
         catch (Exception ex)

--- a/ChatClient.Api/Program.cs
+++ b/ChatClient.Api/Program.cs
@@ -38,7 +38,9 @@ builder.Services.AddSingleton<ChatClient.Api.Services.ILlmServerConfigService, C
 builder.Services.AddSingleton<ChatClient.Api.Services.IMcpClientService, ChatClient.Api.Services.McpClientService>();
 builder.Services.AddSingleton<ChatClient.Api.Services.McpSamplingService>();
 builder.Services.AddSingleton<ChatClient.Api.Services.KernelService>();
-builder.Services.AddSingleton<ChatClient.Api.Services.IOllamaClientService, ChatClient.Api.Services.OllamaService>();
+builder.Services.AddSingleton<IOllamaClientService, OllamaService>();
+builder.Services.AddSingleton<IOllamaEmbeddingService>(sp =>
+    (IOllamaEmbeddingService)sp.GetRequiredService<IOllamaClientService>());
 builder.Services.AddSingleton<ChatClient.Api.Services.McpFunctionIndexService>();
 builder.Services.AddSingleton<AppForceLastUserReducer>();
 builder.Services.AddSingleton<ChatClient.Api.Services.IAppChatHistoryBuilder, ChatClient.Api.Services.AppChatHistoryBuilder>();

--- a/ChatClient.Api/Services/AppChatHistoryBuilder.cs
+++ b/ChatClient.Api/Services/AppChatHistoryBuilder.cs
@@ -102,7 +102,7 @@ public class AppChatHistoryBuilder(
                 var query = ThinkTagParser.ExtractThinkAnswer(lastUser.Content).Answer;
                 try
                 {
-                    var embedding = await _ollama.GenerateEmbeddingAsync(query, model, serverId, cancellationToken);
+                    var embedding = await _ollama.GenerateEmbeddingAsync(query, model, serverId ?? Guid.Empty, cancellationToken);
                     var response = await _ragSearch.SearchAsync(agentId, new ReadOnlyMemory<float>(embedding), 5, cancellationToken);
                     if (response.Results.Count > 0)
                     {

--- a/ChatClient.Api/Services/IOllamaClientService.cs
+++ b/ChatClient.Api/Services/IOllamaClientService.cs
@@ -1,9 +1,11 @@
 namespace ChatClient.Api.Services;
 
 using ChatClient.Shared.Models;
+using OllamaSharp;
 
 public interface IOllamaClientService : IOllamaEmbeddingService
 {
-    Task<IReadOnlyList<OllamaModel>> GetModelsAsync(Guid? serverId = null);
+    Task<IReadOnlyList<OllamaModel>> GetModelsAsync(Guid serverId);
     Task<IReadOnlyList<OllamaModel>> GetModelsAsync(ServerModel serverModel);
+    Task<OllamaApiClient> GetClientAsync(Guid serverId);
 }

--- a/ChatClient.Api/Services/IOllamaEmbeddingService.cs
+++ b/ChatClient.Api/Services/IOllamaEmbeddingService.cs
@@ -4,7 +4,7 @@ using ChatClient.Shared.Models;
 
 public interface IOllamaEmbeddingService
 {
-    Task<float[]> GenerateEmbeddingAsync(string input, string modelId, Guid? serverId = null, CancellationToken cancellationToken = default);
+    Task<float[]> GenerateEmbeddingAsync(string input, string modelId, Guid serverId, CancellationToken cancellationToken = default);
     Task<float[]> GenerateEmbeddingAsync(string input, ServerModel model, CancellationToken cancellationToken = default);
     bool EmbeddingsAvailable { get; }
 }

--- a/ChatClient.Api/Services/McpFunctionIndexService.cs
+++ b/ChatClient.Api/Services/McpFunctionIndexService.cs
@@ -59,7 +59,7 @@ public class McpFunctionIndexService
 
             try
             {
-                await _ollamaService.GetModelsAsync(serverId);
+                await _ollamaService.GetModelsAsync(serverId ?? Guid.Empty);
             }
             catch (Exception ex)
             {
@@ -77,7 +77,7 @@ public class McpFunctionIndexService
                     string text = $"{tool.Name}. {tool.Description}";
                     try
                     {
-                        var embedding = await _ollamaService.GenerateEmbeddingAsync(text, _modelId, serverId, cancellationToken);
+                        var embedding = await _ollamaService.GenerateEmbeddingAsync(text, _modelId, serverId ?? Guid.Empty, cancellationToken);
                         _index[$"{client.ServerInfo.Name}:{tool.Name}"] = embedding;
                     }
                     catch (HttpRequestException ex) when (ex.StatusCode == HttpStatusCode.NotFound)
@@ -126,7 +126,7 @@ public class McpFunctionIndexService
     public async Task<IReadOnlyList<string>> SelectRelevantFunctionsAsync(string query, int topK, CancellationToken cancellationToken = default, Guid? serverId = null)
     {
         await BuildIndexAsync(cancellationToken, serverId);
-        var queryEmbedding = await _ollamaService.GenerateEmbeddingAsync(query, _modelId, serverId, cancellationToken);
+        var queryEmbedding = await _ollamaService.GenerateEmbeddingAsync(query, _modelId, serverId ?? Guid.Empty, cancellationToken);
         return _index
             .Select(kvp => new { Name = kvp.Key, Score = Dot(queryEmbedding.AsSpan(), kvp.Value) })
             .OrderByDescending(e => e.Score)

--- a/ChatClient.Api/Services/McpSamplingService.cs
+++ b/ChatClient.Api/Services/McpSamplingService.cs
@@ -202,7 +202,7 @@ public class McpSamplingService(
         McpServerConfig? mcpServerConfig,
         Guid? serverId)
     {
-        var availableModels = await _ollamaService.GetModelsAsync(serverId);
+        var availableModels = await _ollamaService.GetModelsAsync(serverId ?? Guid.Empty);
         var availableModelNames = availableModels.Select(m => m.Name).ToHashSet();
 
         var requestedModel = modelPreferences?.Hints?.FirstOrDefault()?.Name;

--- a/ChatClient.Api/Services/StartupOllamaChecker.cs
+++ b/ChatClient.Api/Services/StartupOllamaChecker.cs
@@ -8,7 +8,7 @@ public class StartupOllamaChecker(IOllamaClientService ollamaService, ILogger<St
     {
         try
         {
-            var models = await ollamaService.GetModelsAsync(serverId);
+            var models = await ollamaService.GetModelsAsync(serverId ?? Guid.Empty);
             logger.LogInformation("Ollama is available with {ModelCount} models", models.Count);
 
             return new OllamaServerStatus

--- a/ChatClient.Tests/AppChatHistoryBuilderTests.cs
+++ b/ChatClient.Tests/AppChatHistoryBuilderTests.cs
@@ -8,6 +8,7 @@ using ChatClient.Api.Services;
 using ChatClient.Api.Client.Services;
 using ChatClient.Shared.Models;
 using ChatClient.Shared.Services;
+using OllamaSharp;
 
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
@@ -28,9 +29,10 @@ public class AppChatHistoryBuilderTests
 
     private sealed class ThrowingOllamaClientService : IOllamaClientService
     {
-        public Task<IReadOnlyList<OllamaModel>> GetModelsAsync(Guid? serverId = null) => throw new InvalidOperationException();
+        public Task<IReadOnlyList<OllamaModel>> GetModelsAsync(Guid serverId) => throw new InvalidOperationException();
         public Task<IReadOnlyList<OllamaModel>> GetModelsAsync(ServerModel serverModel) => throw new InvalidOperationException();
-        public Task<float[]> GenerateEmbeddingAsync(string input, string modelId, Guid? serverId = null, CancellationToken cancellationToken = default) => throw new InvalidOperationException();
+        public Task<OllamaApiClient> GetClientAsync(Guid serverId) => throw new InvalidOperationException();
+        public Task<float[]> GenerateEmbeddingAsync(string input, string modelId, Guid serverId, CancellationToken cancellationToken = default) => throw new InvalidOperationException();
         public Task<float[]> GenerateEmbeddingAsync(string input, ServerModel model, CancellationToken cancellationToken = default) => throw new InvalidOperationException();
         public bool EmbeddingsAvailable => true;
     }


### PR DESCRIPTION
## Summary
- manage Ollama clients per server ID
- require explicit server ID for model and embedding requests
- wire IOllamaClientService and IOllamaEmbeddingService in DI

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68ab4e21bb70832a822b259c26efbbb6