### PR TITLE
Persist migrated settings and remove legacy fields

### DIFF
--- a/ChatClient.Api/Services/UserSettingsService.cs
+++ b/ChatClient.Api/Services/UserSettingsService.cs
@@ -50,7 +50,14 @@ public class UserSettingsService : IUserSettingsService
         var version = doc.RootElement.TryGetProperty("version", out var v) ? v.GetInt32() : 1;
         settings.Version = version;
 
-        return version < CurrentVersion ? await MigrateSettingsAsync(settings, doc.RootElement) : settings;
+        if (version < CurrentVersion)
+        {
+            var migrated = await MigrateSettingsAsync(settings, doc.RootElement);
+            await SaveSettingsAsync(migrated);
+            return migrated;
+        }
+
+        return settings;
     }
 
     public async Task SaveSettingsAsync(UserSettings settings)
@@ -117,7 +124,6 @@ public class UserSettingsService : IUserSettingsService
         }
 
         settings.Version = CurrentVersion;
-        await SaveSettingsAsync(settings);
         return settings;
     }
 }

--- a/ChatClient.Tests/UserSettingsServiceTests.cs
+++ b/ChatClient.Tests/UserSettingsServiceTests.cs
@@ -1,0 +1,58 @@
+using System;
+using System.IO;
+using System.Text.Json;
+using ChatClient.Api.Services;
+using ChatClient.Shared.Models;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+
+namespace ChatClient.Tests;
+
+public class UserSettingsServiceTests
+{
+    [Fact]
+    public async Task MigrationSavesSettingsAndRemovesLegacyFields()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        Directory.CreateDirectory(tempDir);
+        var filePath = Path.Combine(tempDir, "user_settings.json");
+        var legacy = """
+        {
+            "version":1,
+            "ollamaServerUrl":"http://localhost:11434",
+            "ollamaBasicAuthPassword":"secret",
+            "ignoreSslErrors":true,
+            "httpTimeoutSeconds":10
+        }
+        """;
+        await File.WriteAllTextAsync(filePath, legacy);
+        try
+        {
+            var config = new ConfigurationBuilder()
+                .AddInMemoryCollection(new Dictionary<string, string?>
+                {
+                    ["UserSettings:Directory"] = tempDir
+                })
+                .Build();
+            var logger = new LoggerFactory().CreateLogger<UserSettingsService>();
+            var service = new UserSettingsService(config, logger);
+
+            var settings = await service.GetSettingsAsync();
+
+            var json = await File.ReadAllTextAsync(filePath);
+            using var doc = JsonDocument.Parse(json);
+            var root = doc.RootElement;
+            Assert.False(root.TryGetProperty("ollamaServerUrl", out _));
+            Assert.False(root.TryGetProperty("ollamaBasicAuthPassword", out _));
+            Assert.False(root.TryGetProperty("ignoreSslErrors", out _));
+            Assert.False(root.TryGetProperty("httpTimeoutSeconds", out _));
+            Assert.NotEmpty(settings.Llms);
+            Assert.Equal(2, settings.Version);
+            Assert.NotNull(settings.DefaultLlmId);
+        }
+        finally
+        {
+            Directory.Delete(tempDir, true);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- ensure migrated user settings are saved without legacy single-server fields
- test that migration persists settings and strips obsolete properties

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68ab592f9208832abdf5b5dd4004803c