### PR TITLE
Handle empty Ollama base URL

### DIFF
--- a/ChatClient.Api/Services/OllamaService.cs
+++ b/ChatClient.Api/Services/OllamaService.cs
@@ -140,7 +140,9 @@ public sealed class OllamaService(
         if (server != null)
             return server;
 
-        var baseUrl = configuration["Ollama:BaseUrl"] ?? OllamaDefaults.ServerUrl;
+        var baseUrl = configuration["Ollama:BaseUrl"];
+        if (string.IsNullOrWhiteSpace(baseUrl))
+            baseUrl = OllamaDefaults.ServerUrl;
         return new LlmServerConfig
         {
             Id = Guid.Empty,
@@ -161,10 +163,11 @@ public sealed class OllamaService(
             InnerHandler = handler
         };
 
+        var baseUrl = string.IsNullOrWhiteSpace(config.BaseUrl) ? OllamaDefaults.ServerUrl : config.BaseUrl;
         var client = new HttpClient(loggingHandler)
         {
             Timeout = TimeSpan.FromSeconds(config.HttpTimeoutSeconds),
-            BaseAddress = new Uri(config.BaseUrl)
+            BaseAddress = new Uri(baseUrl)
         };
 
         if (!string.IsNullOrWhiteSpace(config.Password))

--- a/ChatClient.Tests/OllamaServiceTests.cs
+++ b/ChatClient.Tests/OllamaServiceTests.cs
@@ -1,0 +1,52 @@
+using System.Reflection;
+using ChatClient.Api.Services;
+using ChatClient.Shared.Constants;
+using ChatClient.Shared.Models;
+using ChatClient.Shared.Services;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using OllamaSharp;
+
+public class OllamaServiceTests
+{
+    [Fact]
+    public async Task GetClientAsync_UsesDefaultUrl_WhenConfigurationEmpty()
+    {
+        var configValues = new Dictionary<string, string?> { ["Ollama:BaseUrl"] = "" };
+        var configuration = new ConfigurationBuilder().AddInMemoryCollection(configValues).Build();
+
+        var userSettingsService = new StubUserSettingsService();
+        var serverConfigService = new StubServerConfigService();
+        var services = new ServiceCollection();
+        services.AddLogging();
+        var provider = services.BuildServiceProvider();
+        var logger = provider.GetRequiredService<ILogger<OllamaService>>();
+
+        var service = new OllamaService(configuration, userSettingsService, serverConfigService, provider, logger);
+
+        await service.GetClientAsync(Guid.Empty);
+
+        var field = typeof(OllamaService).GetField("_clients", BindingFlags.NonPublic | BindingFlags.Instance)!;
+        var dict = (Dictionary<Guid, (OllamaApiClient Client, HttpClient HttpClient)>)field.GetValue(service)!;
+        var httpClient = dict[Guid.Empty].HttpClient;
+
+        Assert.Equal(new Uri(OllamaDefaults.ServerUrl), httpClient.BaseAddress);
+    }
+
+    private sealed class StubUserSettingsService : IUserSettingsService
+    {
+        public event Func<Task>? EmbeddingModelChanged;
+        public Task<UserSettings> GetSettingsAsync() => Task.FromResult(new UserSettings());
+        public Task SaveSettingsAsync(UserSettings settings) => Task.CompletedTask;
+    }
+
+    private sealed class StubServerConfigService : ILlmServerConfigService
+    {
+        public Task<List<LlmServerConfig>> GetAllAsync() => Task.FromResult(new List<LlmServerConfig>());
+        public Task<LlmServerConfig?> GetByIdAsync(Guid id) => Task.FromResult<LlmServerConfig?>(null);
+        public Task<LlmServerConfig> CreateAsync(LlmServerConfig server) => Task.FromResult(server);
+        public Task<LlmServerConfig> UpdateAsync(LlmServerConfig server) => Task.FromResult(server);
+        public Task DeleteAsync(Guid id) => Task.CompletedTask;
+    }
+}


### PR DESCRIPTION
## Summary
- fallback to built-in Ollama URL when configuration value is missing
- add regression test for default URL behavior

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68ab806cd568832a803e35af35f34bc4