### PR TITLE
feat: allow selecting server and model for agents

### DIFF
--- a/ChatClient.Api/Client/Pages/AgentDescriptions.razor
+++ b/ChatClient.Api/Client/Pages/AgentDescriptions.razor
@@ -5,14 +5,15 @@
 @using ChatClient.Shared.Models
 @using ChatClient.Shared.Services
 @using ChatClient.Api.Services
+@using ChatClient.Api.Client.Components
 @using Microsoft.AspNetCore.Components.Forms
 @using Microsoft.AspNetCore.Http
 @inject IAgentDescriptionService AgentService
 @inject ISnackbar Snackbar
-@inject IOllamaClientService OllamaService
 @inject KernelService KernelService
 @inject IRagFileService RagFileService
 @inject IFileConverter FileConverter
+@inject ILlmServerConfigService LlmServerConfigService
 
 <PageTitle>Agent Descriptions Management</PageTitle>
 
@@ -81,10 +82,11 @@
                     <TemplateColumn Title="Model" isEditable="false">
                         <CellTemplate>
                             <div>
-                                @if (!string.IsNullOrWhiteSpace(context.Item.ModelName))
+                                @{ var modelDisplay = GetModelDisplay(context.Item); }
+                                @if (!string.IsNullOrWhiteSpace(modelDisplay))
                                 {
                                     <MudChip T="string" Color="Color.Secondary" Size="Size.Small">
-                                        @context.Item.ModelName
+                                        @modelDisplay
                                     </MudChip>
                                 }
                                 else
@@ -202,12 +204,7 @@
                           HelperText="Custom short name for this agent. If empty, uses global agent name from settings."
                           Placeholder="Enter short name..." />
 
-            <MudSelect T="string" @bind-Value="editingAgent.ModelName" Label="Model (Optional)" Class="mt-4" Dense="true" Clearable="true">
-                @foreach (var model in availableModels)
-                {
-                    <MudSelectItem Value="@model.Name">@model.Name</MudSelectItem>
-                }
-            </MudSelect>
+            <ServerModelPicker @bind-Value="editingServerModel" Class="mt-4" />
             <MudText Typo="Typo.caption">Leave blank to use chat's default model.</MudText>
 
             <MudNumericField T="double?" @bind-Value="editingAgent.Temperature" Label="Temperature (Optional)" Class="mt-4" Immediate="true" Min="0" Max="2" Step="0.1" />
@@ -290,11 +287,12 @@
     private string searchString = string.Empty;
     private MudForm? editAgentForm;
     private MudDataGrid<AgentDescription>? dataGrid;
-    private List<OllamaModel> availableModels = new();
     private List<FunctionInfo> availableFunctions = new();
     private bool functionsExpanded;
     private Dictionary<Guid, int> ragCounts = new();
     private List<RagFile> ragFiles = new();
+    private ServerModel editingServerModel = new(Guid.Empty, string.Empty);
+    private List<LlmServerConfig> servers = new();
     private DialogOptions dialogOptions = new()
     {
         CloseOnEscapeKey = true,
@@ -313,7 +311,7 @@
     protected override async Task OnInitializedAsync()
     {
         await LoadAgents();
-        await LoadAvailableModels();
+        servers = await LlmServerConfigService.GetAllAsync();
         await LoadAvailableFunctions();
     }
 
@@ -346,19 +344,6 @@
         }
     }
 
-    private async Task LoadAvailableModels()
-    {
-        try
-        {
-            availableModels = (await OllamaService.GetModelsAsync(Guid.Empty)).ToList();
-        }
-        catch (Exception ex)
-        {
-            Snackbar.Add($"Error loading models: {ex.Message}", Severity.Error);
-            availableModels = new();
-        }
-    }
-
     private async Task LoadAvailableFunctions()
     {
         try
@@ -369,6 +354,16 @@
         {
             availableFunctions = new();
         }
+    }
+
+    private string GetModelDisplay(AgentDescription agent)
+    {
+        if (string.IsNullOrWhiteSpace(agent.ModelName))
+            return string.Empty;
+        var server = servers.FirstOrDefault(s => s.Id == (agent.LlmId ?? Guid.Empty));
+        return server is null || server.Id == Guid.Empty
+            ? agent.ModelName
+            : $"{server.Name}/{agent.ModelName}";
     }
 
     private void AddNewAgent()
@@ -382,6 +377,7 @@
             Content = "",
             ShortName = null,
             ModelName = null,
+            LlmId = null,
             Temperature = null,
             RepeatPenalty = null,
             FunctionSettings = new FunctionSettings
@@ -390,6 +386,7 @@
                 SelectedFunctions = []
             }
         };
+        editingServerModel = new ServerModel(Guid.Empty, string.Empty);
         ragFiles = new();
         showEditAgentDialog = true;
     }
@@ -488,6 +485,7 @@
             Content = agent.Content,
             ShortName = agent.ShortName,
             ModelName = agent.ModelName,
+            LlmId = agent.LlmId,
             Temperature = agent.Temperature,
             RepeatPenalty = agent.RepeatPenalty,
             CreatedAt = agent.CreatedAt,
@@ -499,6 +497,7 @@
             }
         };
 
+        editingServerModel = new ServerModel(agent.LlmId ?? Guid.Empty, agent.ModelName ?? string.Empty);
         await LoadRagFiles(agent.Id);
         showEditAgentDialog = true;
     }
@@ -579,6 +578,8 @@
         {
             try
             {
+                editingAgent.LlmId = editingServerModel.ServerId == Guid.Empty ? null : editingServerModel.ServerId;
+                editingAgent.ModelName = string.IsNullOrWhiteSpace(editingServerModel.ModelName) ? null : editingServerModel.ModelName;
                 if (editingAgent.Id == Guid.Empty)
                 {
                     var result = await AgentService.CreateAsync(editingAgent);

--- a/ChatClient.Api/Client/Pages/Chat.razor
+++ b/ChatClient.Api/Client/Pages/Chat.razor
@@ -235,6 +235,9 @@
     private string CurrentModelName => string.IsNullOrWhiteSpace(SelectedModel?.ModelName)
         ? userSettings.DefaultModelName
         : SelectedModel.ModelName;
+    private Guid CurrentServerId => SelectedModel?.ServerId != Guid.Empty
+        ? SelectedModel.ServerId
+        : userSettings.DefaultLlmId ?? Guid.Empty;
 
     private UserSettings userSettings = new();
 
@@ -315,6 +318,8 @@
 
         if (string.IsNullOrWhiteSpace(agents[0].ModelName))
             agents[0].ModelName = CurrentModelName;
+        if (!agents[0].LlmId.HasValue || agents[0].LlmId == Guid.Empty)
+            agents[0].LlmId = CurrentServerId;
 
         ChatService.InitializeChat(agents);
         chatStarted = true;

--- a/ChatClient.Api/Client/Pages/MultiAgentChat.razor
+++ b/ChatClient.Api/Client/Pages/MultiAgentChat.razor
@@ -259,6 +259,9 @@
     private string CurrentModelName => string.IsNullOrWhiteSpace(SelectedModel?.ModelName)
         ? userSettings.DefaultModelName
         : SelectedModel.ModelName;
+    private Guid CurrentServerId => SelectedModel?.ServerId != Guid.Empty
+        ? SelectedModel.ServerId
+        : userSettings.DefaultLlmId ?? Guid.Empty;
 
     private const string RoundRobinStopAgent = "RoundRobin";
     private const string RoundRobinSummaryStopAgent = "RoundRobinWithSummary";
@@ -396,8 +399,12 @@
             return;
 
         foreach (var agent in selectedAgents)
+        {
             if (string.IsNullOrWhiteSpace(agent.ModelName))
                 agent.ModelName = CurrentModelName;
+            if (!agent.LlmId.HasValue || agent.LlmId == Guid.Empty)
+                agent.LlmId = CurrentServerId;
+        }
 
         userSettings.StopAgentName = stopAgentName;
         userSettings.MultiAgentSelectedAgents = selectedAgents.Select(a => a.AgentName).ToList();

--- a/ChatClient.Api/Client/Services/AppChatService.cs
+++ b/ChatClient.Api/Client/Services/AppChatService.cs
@@ -263,7 +263,7 @@ public class AppChatService(
             }
 
             // Create Kernel using modern approach for this agent
-            var kernel = await CreateModernKernelAsync(modelName, functionsToRegister, desc.AgentName, cancellationToken);
+            var kernel = await CreateModernKernelAsync(modelName, functionsToRegister, desc.AgentName, desc.LlmId ?? Guid.Empty, cancellationToken);
             
             // Add tracking filter to the kernel
             kernel.FunctionInvocationFilters.Add(trackingFilter);
@@ -293,6 +293,7 @@ public class AppChatService(
         string modelName,
         IEnumerable<string>? functionsToRegister,
         string agentName,
+        Guid serverId,
         CancellationToken cancellationToken = default)
     {
         // Create a kernel with proper IChatCompletionService registration
@@ -302,7 +303,7 @@ public class AppChatService(
         builder.Services.AddLogging(c => c.AddConsole().SetMinimumLevel(LogLevel.Information));
 
         // Get Ollama client and add IChatCompletionService - required for ChatCompletionAgent
-        var ollamaClient = await ollamaClientService.GetClientAsync(Guid.Empty);
+        var ollamaClient = await ollamaClientService.GetClientAsync(serverId);
         var baseChatService = ollamaClient.AsChatCompletionService();
         builder.Services.AddSingleton<IChatCompletionService>(_ =>
             new AppForceLastUserChatCompletionService(baseChatService, _reducer));

--- a/ChatClient.Shared/Models/AgentDescription.cs
+++ b/ChatClient.Shared/Models/AgentDescription.cs
@@ -10,6 +10,7 @@ public class AgentDescription
     public string Content { get; set; } = string.Empty;
     public string? ShortName { get; set; }
     public string? ModelName { get; set; }
+    public Guid? LlmId { get; set; }
     public double? Temperature { get; set; }
     public double? RepeatPenalty { get; set; }
 

--- a/ChatClient.Tests/AgentDescriptionServiceTests.cs
+++ b/ChatClient.Tests/AgentDescriptionServiceTests.cs
@@ -25,11 +25,13 @@ public class AgentDescriptionServiceTests
             var logger = new LoggerFactory().CreateLogger<AgentDescriptionService>();
             var service = new AgentDescriptionService(config, logger);
 
+            var serverId = Guid.NewGuid();
             var prompt = new AgentDescription
             {
                 AgentName = "Test",
                 Content = "Test content",
                 ModelName = "test-model",
+                LlmId = serverId,
                 FunctionSettings = new FunctionSettings
                 {
                     SelectedFunctions = ["srv:fn1", "srv:fn2"],
@@ -44,6 +46,7 @@ public class AgentDescriptionServiceTests
 
             Assert.NotNull(retrieved);
             Assert.Equal("test-model", retrieved!.ModelName);
+            Assert.Equal(serverId, retrieved.LlmId);
             Assert.Equal(["srv:fn1", "srv:fn2"], retrieved.FunctionSettings.SelectedFunctions);
             Assert.Equal(3, retrieved.FunctionSettings.AutoSelectCount);
         }


### PR DESCRIPTION
## Summary
- add LlmId to AgentDescription model
- allow picking server and model when editing agents
- use agent server in chat kernel creation

## Testing
- `dotnet test` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_68ac80204300832aa0d9445d47741e1e