### PR TITLE
Use ServerModel type for server and model pair

### DIFF
--- a/ChatClient.Api/Services/IOllamaEmbeddingService.cs
+++ b/ChatClient.Api/Services/IOllamaEmbeddingService.cs
@@ -4,7 +4,6 @@ using ChatClient.Shared.Models;
 
 public interface IOllamaEmbeddingService
 {
-    Task<float[]> GenerateEmbeddingAsync(string input, string modelId, Guid serverId, CancellationToken cancellationToken = default);
     Task<float[]> GenerateEmbeddingAsync(string input, ServerModel model, CancellationToken cancellationToken = default);
     bool EmbeddingsAvailable { get; }
 }

--- a/ChatClient.Api/Services/OllamaService.cs
+++ b/ChatClient.Api/Services/OllamaService.cs
@@ -81,9 +81,9 @@ public sealed class OllamaService(
     public bool EmbeddingsAvailable => _embeddingError is null;
 
     public Task<float[]> GenerateEmbeddingAsync(string input, ServerModel model, CancellationToken cancellationToken = default) =>
-        GenerateEmbeddingAsync(input, model.ModelName, model.ServerId, cancellationToken);
+        GenerateEmbeddingInternalAsync(input, model.ModelName, model.ServerId, cancellationToken);
 
-    public async Task<float[]> GenerateEmbeddingAsync(string input, string modelId, Guid serverId, CancellationToken cancellationToken = default)
+    private async Task<float[]> GenerateEmbeddingInternalAsync(string input, string modelId, Guid serverId, CancellationToken cancellationToken = default)
     {
         if (_embeddingError is not null)
             throw new InvalidOperationException("Embedding service unavailable. Restart the application.", _embeddingError);

--- a/ChatClient.Tests/AppChatHistoryBuilderTests.cs
+++ b/ChatClient.Tests/AppChatHistoryBuilderTests.cs
@@ -25,7 +25,6 @@ public class AppChatHistoryBuilderTests
         public Task<IReadOnlyList<OllamaModel>> GetModelsAsync(Guid serverId) => throw new InvalidOperationException();
         public Task<IReadOnlyList<OllamaModel>> GetModelsAsync(ServerModel serverModel) => throw new InvalidOperationException();
         public Task<OllamaApiClient> GetClientAsync(Guid serverId) => throw new InvalidOperationException();
-        public Task<float[]> GenerateEmbeddingAsync(string input, string modelId, Guid serverId, CancellationToken cancellationToken = default) => throw new InvalidOperationException();
         public Task<float[]> GenerateEmbeddingAsync(string input, ServerModel model, CancellationToken cancellationToken = default) => throw new InvalidOperationException();
         public bool EmbeddingsAvailable => true;
     }

--- a/ChatClient.Tests/ChatServiceTests.cs
+++ b/ChatClient.Tests/ChatServiceTests.cs
@@ -22,7 +22,6 @@ public class ChatServiceTests
     {
         public bool EmbeddingsAvailable => false;
         public Task<OllamaApiClient> GetClientAsync(Guid serverId) => Task.FromResult(new OllamaApiClient(new HttpClient()));
-        public Task<float[]> GenerateEmbeddingAsync(string input, string modelId, Guid serverId, CancellationToken cancellationToken = default) => Task.FromResult(new float[0]);
         public Task<float[]> GenerateEmbeddingAsync(string input, ServerModel model, CancellationToken cancellationToken = default) => Task.FromResult(new float[0]);
         public Task<IReadOnlyList<OllamaModel>> GetModelsAsync(Guid serverId) => Task.FromResult<IReadOnlyList<OllamaModel>>(new List<OllamaModel>());
         public Task<IReadOnlyList<OllamaModel>> GetModelsAsync(ServerModel serverModel) => Task.FromResult<IReadOnlyList<OllamaModel>>(new List<OllamaModel>());


### PR DESCRIPTION
## Summary
- use `ServerModel` for embedding interface
- adjust Ollama service and chat flow to consume `ServerModel`
- update tests accordingly

## Testing
- `dotnet test -c Release`


------
https://chatgpt.com/codex/tasks/task_e_68ac84f722d4832a887f99d431cb0ee1