### PR TITLE
Refactor RAG index loading and search

### DIFF
--- a/ChatClient.Api/Services/RagVectorIndexService.cs
+++ b/ChatClient.Api/Services/RagVectorIndexService.cs
@@ -53,7 +53,7 @@ public sealed class RagVectorIndexService(
             var embedding = await generator.GenerateAsync(paragraph, cancellationToken: cancellationToken);
             fragments.Add(new RagVectorFragment
             {
-                Id = $"{Path.GetFileName(sourceFilePath)}#{i:D5}",
+                Index = i,
                 Text = paragraph,
                 Vector = embedding.Vector.ToArray()
             });

--- a/ChatClient.Shared/Models/RagVectorFragment.cs
+++ b/ChatClient.Shared/Models/RagVectorFragment.cs
@@ -2,7 +2,7 @@ namespace ChatClient.Shared.Models;
 
 public class RagVectorFragment
 {
-    public string Id { get; set; } = string.Empty;
+    public int Index { get; set; }
     public string Text { get; set; } = string.Empty;
     public float[] Vector { get; set; } = Array.Empty<float>();
 }


### PR DESCRIPTION
## Summary
- move fragment index out of file ID into dedicated property
- build index using explicit fragment index
- load search records from index without parsing IDs

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68b0314e7ea8832aba5b558bb76955bd