### PR TITLE
Make RAG chunk sizes configurable

### DIFF
--- a/ChatClient.Api/Client/Pages/AppSettings.razor
+++ b/ChatClient.Api/Client/Pages/AppSettings.razor
@@ -100,6 +100,10 @@
                         <MudText Typo="Typo.caption" Class="mt-2">
                             Model used for generating embeddings.
                         </MudText>
+                        <MudNumericField T="int" @bind-Value="_settings.RagLineChunkSize" Label="Line Chunk Size" Min="1" Variant="Variant.Outlined" Class="mt-4" />
+                        <MudNumericField T="int" @bind-Value="_settings.RagParagraphChunkSize" Label="Paragraph Chunk Size" Min="1" Variant="Variant.Outlined" Class="mt-4" />
+                        <MudNumericField T="int" @bind-Value="_settings.RagParagraphOverlap" Label="Paragraph Overlap" Min="0" Variant="Variant.Outlined" Class="mt-4" />
+                        <MudText Typo="Typo.caption" Class="mt-2">Text chunking parameters for building RAG indexes.</MudText>
                     </MudCardContent>
                 </MudCard>
 

--- a/ChatClient.Api/Services/Rag/RagVectorIndexService.cs
+++ b/ChatClient.Api/Services/Rag/RagVectorIndexService.cs
@@ -39,10 +39,16 @@ public sealed class RagVectorIndexService(
         var kernel = builder.Build();
 
         var generator = kernel.GetRequiredService<IEmbeddingGenerator<string, Embedding<float>>>();
-
-        var maxTokensPerLine = configuration.GetValue<int?>("RagIndex:MaxTokensPerLine") ?? 256;
-        var maxTokensPerParagraph = configuration.GetValue<int?>("RagIndex:MaxTokensPerParagraph") ?? 512;
-        var paragraphOverlap = configuration.GetValue<int?>("RagIndex:ParagraphOverlap") ?? 64;
+        var settings = await userSettings.GetSettingsAsync();
+        var maxTokensPerLine = settings.RagLineChunkSize > 0
+            ? settings.RagLineChunkSize
+            : configuration.GetValue<int?>("RagIndex:MaxTokensPerLine") ?? 256;
+        var maxTokensPerParagraph = settings.RagParagraphChunkSize > 0
+            ? settings.RagParagraphChunkSize
+            : configuration.GetValue<int?>("RagIndex:MaxTokensPerParagraph") ?? 512;
+        var paragraphOverlap = settings.RagParagraphOverlap > 0
+            ? settings.RagParagraphOverlap
+            : configuration.GetValue<int?>("RagIndex:ParagraphOverlap") ?? 64;
         var lines = TextChunker.SplitPlainTextLines(text, maxTokensPerLine, null);
         var paragraphs = TextChunker.SplitPlainTextParagraphs(lines, maxTokensPerParagraph, paragraphOverlap, string.Empty, null).ToList();
         var total = paragraphs.Count;

--- a/ChatClient.Api/Services/Rag/RagVectorIndexService.cs
+++ b/ChatClient.Api/Services/Rag/RagVectorIndexService.cs
@@ -40,15 +40,9 @@ public sealed class RagVectorIndexService(
 
         var generator = kernel.GetRequiredService<IEmbeddingGenerator<string, Embedding<float>>>();
         var settings = await userSettings.GetSettingsAsync();
-        var maxTokensPerLine = settings.RagLineChunkSize > 0
-            ? settings.RagLineChunkSize
-            : configuration.GetValue<int?>("RagIndex:MaxTokensPerLine") ?? 256;
-        var maxTokensPerParagraph = settings.RagParagraphChunkSize > 0
-            ? settings.RagParagraphChunkSize
-            : configuration.GetValue<int?>("RagIndex:MaxTokensPerParagraph") ?? 512;
-        var paragraphOverlap = settings.RagParagraphOverlap > 0
-            ? settings.RagParagraphOverlap
-            : configuration.GetValue<int?>("RagIndex:ParagraphOverlap") ?? 64;
+        var maxTokensPerLine = settings.RagLineChunkSize;
+        var maxTokensPerParagraph = settings.RagParagraphChunkSize;
+        var paragraphOverlap = settings.RagParagraphOverlap;
         var lines = TextChunker.SplitPlainTextLines(text, maxTokensPerLine, null);
         var paragraphs = TextChunker.SplitPlainTextParagraphs(lines, maxTokensPerParagraph, paragraphOverlap, string.Empty, null).ToList();
         var total = paragraphs.Count;

--- a/ChatClient.Api/Services/Rag/RagVectorIndexService.cs
+++ b/ChatClient.Api/Services/Rag/RagVectorIndexService.cs
@@ -2,6 +2,7 @@
 using ChatClient.Shared.Models;
 using ChatClient.Shared.Services;
 using Microsoft.Extensions.AI;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using Microsoft.SemanticKernel;
 using Microsoft.SemanticKernel.Text;
@@ -39,8 +40,11 @@ public sealed class RagVectorIndexService(
 
         var generator = kernel.GetRequiredService<IEmbeddingGenerator<string, Embedding<float>>>();
 
-        var lines = TextChunker.SplitPlainTextLines(text, 256, null);
-        var paragraphs = TextChunker.SplitPlainTextParagraphs(lines, 512, 64, string.Empty, null).ToList();
+        var maxTokensPerLine = configuration.GetValue<int?>("RagIndex:MaxTokensPerLine") ?? 256;
+        var maxTokensPerParagraph = configuration.GetValue<int?>("RagIndex:MaxTokensPerParagraph") ?? 512;
+        var paragraphOverlap = configuration.GetValue<int?>("RagIndex:ParagraphOverlap") ?? 64;
+        var lines = TextChunker.SplitPlainTextLines(text, maxTokensPerLine, null);
+        var paragraphs = TextChunker.SplitPlainTextParagraphs(lines, maxTokensPerParagraph, paragraphOverlap, string.Empty, null).ToList();
         var total = paragraphs.Count;
 
         logger.LogInformation("Building index for {File} with {Count} fragments", sourceFilePath, total);

--- a/ChatClient.Api/appsettings.json
+++ b/ChatClient.Api/appsettings.json
@@ -13,6 +13,11 @@
   "RagFiles": {
     "BasePath": "Data/agents"
   },
+  "RagIndex": {
+    "MaxTokensPerLine": 256,
+    "MaxTokensPerParagraph": 512,
+    "ParagraphOverlap": 64
+  },
   "Logging": {
     "LogLevel": { "Default": "Information" }
   }

--- a/ChatClient.Shared/Models/UserSettings.cs
+++ b/ChatClient.Shared/Models/UserSettings.cs
@@ -56,6 +56,15 @@ public class UserSettings
     [JsonPropertyName("embeddingLlmId")]
     public Guid? EmbeddingLlmId { get; set; }
 
+    [JsonPropertyName("ragLineChunkSize")]
+    public int RagLineChunkSize { get; set; } = 256;
+
+    [JsonPropertyName("ragParagraphChunkSize")]
+    public int RagParagraphChunkSize { get; set; } = 512;
+
+    [JsonPropertyName("ragParagraphOverlap")]
+    public int RagParagraphOverlap { get; set; } = 64;
+
     [JsonPropertyName("stopAgentName")]
     public string StopAgentName { get; set; } = string.Empty;
 


### PR DESCRIPTION
## Summary
- allow configuring RAG line and paragraph chunk sizes
- document default chunk sizes in appsettings

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68b03b302418832aadfb1a17a1d6fa5c