### PR TITLE
feat: manual embedding regeneration

### DIFF
--- a/ChatClient.Api/Client/Pages/AppSettings.razor
+++ b/ChatClient.Api/Client/Pages/AppSettings.razor
@@ -9,6 +9,7 @@
 @inject IOllamaClientService OllamaService
 @inject ISnackbar Snackbar
 @inject ILogger<AppSettings> Logger
+@inject McpFunctionIndexService McpFunctionIndexService
 
 <PageTitle>Application Settings</PageTitle>
 
@@ -88,10 +89,13 @@
                         <MudText Typo="Typo.caption" Class="mt-2">
                             Model used for generating embeddings.
                         </MudText>
-                        <MudNumericField T="int" @bind-Value="_settings.RagLineChunkSize" Label="Line Chunk Size" Min="1" Variant="Variant.Outlined" Class="mt-4" />
-                        <MudNumericField T="int" @bind-Value="_settings.RagParagraphChunkSize" Label="Paragraph Chunk Size" Min="1" Variant="Variant.Outlined" Class="mt-4" />
-                        <MudNumericField T="int" @bind-Value="_settings.RagParagraphOverlap" Label="Paragraph Overlap" Min="0" Variant="Variant.Outlined" Class="mt-4" />
+                        <MudNumericField T="int" @bind-Value="_settings.Embedding.RagLineChunkSize" Label="Line Chunk Size" Min="1" Variant="Variant.Outlined" Class="mt-4" />
+                        <MudNumericField T="int" @bind-Value="_settings.Embedding.RagParagraphChunkSize" Label="Paragraph Chunk Size" Min="1" Variant="Variant.Outlined" Class="mt-4" />
+                        <MudNumericField T="int" @bind-Value="_settings.Embedding.RagParagraphOverlap" Label="Paragraph Overlap" Min="0" Variant="Variant.Outlined" Class="mt-4" />
                         <MudText Typo="Typo.caption" Class="mt-2">Text chunking parameters for building RAG indexes.</MudText>
+                        <MudButton Variant="Variant.Outlined" Color="Color.Primary" OnClick="RestartEmbeddings" Class="mt-4">
+                            Restart Embedding Generation
+                        </MudButton>
                     </MudCardContent>
                 </MudCard>
 
@@ -139,7 +143,7 @@
     private Task OnEmbeddingModelChanged(ServerModel model)
     {
         _embeddingModel = model;
-        _settings.EmbeddingModel = model;
+        _settings.Embedding.Model = model;
         return Task.CompletedTask;
     }
 
@@ -149,7 +153,7 @@
         {
             _settings = await UserSettingsService.GetSettingsAsync();
             _defaultModel = _settings.DefaultModel;
-            _embeddingModel = _settings.EmbeddingModel;
+            _embeddingModel = _settings.Embedding.Model;
         }
         catch (Exception ex)
         {
@@ -162,13 +166,13 @@
     {
         try
         {
-            if (_settings.EmbeddingModel.ServerId != Guid.Empty && !string.IsNullOrWhiteSpace(_settings.EmbeddingModel.ModelName))
+            if (_settings.Embedding.Model.ServerId != Guid.Empty && !string.IsNullOrWhiteSpace(_settings.Embedding.Model.ModelName))
             {
-                var models = await OllamaService.GetModelsAsync(_settings.EmbeddingModel.ServerId);
-                var exists = models.Any(m => m.Name.Equals(_settings.EmbeddingModel.ModelName, StringComparison.OrdinalIgnoreCase));
+                var models = await OllamaService.GetModelsAsync(_settings.Embedding.Model.ServerId);
+                var exists = models.Any(m => m.Name.Equals(_settings.Embedding.Model.ModelName, StringComparison.OrdinalIgnoreCase));
                 if (!exists)
                 {
-                    Snackbar.Add($"Embedding model '{_settings.EmbeddingModel.ModelName}' not found.", Severity.Error);
+                    Snackbar.Add($"Embedding model '{_settings.Embedding.Model.ModelName}' not found.", Severity.Error);
                     return;
                 }
             }
@@ -180,6 +184,21 @@
         {
             Logger.LogError(ex, "Error saving settings");
             Snackbar.Add($"Failed to save settings: {ex.Message}", Severity.Error);
+        }
+    }
+
+    private async Task RestartEmbeddings()
+    {
+        await SaveSettings();
+        try
+        {
+            await McpFunctionIndexService.RebuildAsync();
+            Snackbar.Add("Embedding generation restarted", Severity.Success);
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Error restarting embeddings");
+            Snackbar.Add("Failed to restart embedding generation", Severity.Error);
         }
     }
 

--- a/ChatClient.Api/Client/Pages/VectorSearch.razor
+++ b/ChatClient.Api/Client/Pages/VectorSearch.razor
@@ -99,7 +99,7 @@
         }
         var settings = await UserSettingsService.GetSettingsAsync();
         embeddingModel = ModelSelectionHelper.GetEffectiveEmbeddingModel(
-            settings.EmbeddingModel,
+            settings.Embedding.Model,
             settings.DefaultModel,
             "Vector search UI",
             Logger);

--- a/ChatClient.Api/Services/AppChatHistoryBuilder.cs
+++ b/ChatClient.Api/Services/AppChatHistoryBuilder.cs
@@ -87,7 +87,7 @@ public class AppChatHistoryBuilder(
             {
                 var settings = await settingsService.GetSettingsAsync();
                 var embeddingModel = ModelSelectionHelper.GetEffectiveEmbeddingModel(
-                    settings.EmbeddingModel,
+                    settings.Embedding.Model,
                     settings.DefaultModel,
                     "RAG search",
                     logger);

--- a/ChatClient.Api/Services/McpFunctionIndexService.cs
+++ b/ChatClient.Api/Services/McpFunctionIndexService.cs
@@ -36,8 +36,6 @@ public class McpFunctionIndexService
         _userSettingsService = userSettingsService;
         _indexBackgroundService = indexBackgroundService;
         _logger = logger;
-
-        _userSettingsService.EmbeddingModelChanged += HandleEmbeddingModelChangeAsync;
     }
 
     public async Task BuildIndexAsync(CancellationToken cancellationToken = default, Guid? serverId = null)
@@ -142,7 +140,7 @@ public class McpFunctionIndexService
     {
         var settings = await _userSettingsService.GetSettingsAsync();
         return ModelSelectionHelper.GetEffectiveEmbeddingModel(
-            settings.EmbeddingModel,
+            settings.Embedding.Model,
             settings.DefaultModel,
             "MCP function indexing",
             _logger);
@@ -161,7 +159,7 @@ public class McpFunctionIndexService
             .ToList();
     }
 
-    private async Task HandleEmbeddingModelChangeAsync()
+    public async Task RebuildAsync()
     {
         var basePath = _configuration["RagFiles:BasePath"] ?? Path.Combine("Data", "agents");
         if (Directory.Exists(basePath))

--- a/ChatClient.Api/Services/Rag/RagVectorIndexBackgroundService.cs
+++ b/ChatClient.Api/Services/Rag/RagVectorIndexBackgroundService.cs
@@ -65,7 +65,7 @@ public sealed class RagVectorIndexBackgroundService(
             var indexService = scope.ServiceProvider.GetRequiredService<IRagVectorIndexService>();
             var settingsService = scope.ServiceProvider.GetRequiredService<IUserSettingsService>();
             var settings = await settingsService.GetSettingsAsync();
-            var embedServer = settings.EmbeddingModel.ServerId;
+            var embedServer = settings.Embedding.Model.ServerId;
 
             var basePath = _configuration["RagFiles:BasePath"] ?? Path.Combine("Data", "agents");
             List<(Guid agentId, string source, string index, string fileName)> pending = [];

--- a/ChatClient.Api/Services/Rag/RagVectorIndexService.cs
+++ b/ChatClient.Api/Services/Rag/RagVectorIndexService.cs
@@ -41,9 +41,9 @@ public sealed class RagVectorIndexService(
 
         var generator = kernel.GetRequiredService<IEmbeddingGenerator<string, Embedding<float>>>();
         var settings = await userSettings.GetSettingsAsync();
-        var maxTokensPerLine = settings.RagLineChunkSize;
-        var maxTokensPerParagraph = settings.RagParagraphChunkSize;
-        var paragraphOverlap = settings.RagParagraphOverlap;
+        var maxTokensPerLine = settings.Embedding.RagLineChunkSize;
+        var maxTokensPerParagraph = settings.Embedding.RagParagraphChunkSize;
+        var paragraphOverlap = settings.Embedding.RagParagraphOverlap;
         var lines = TextChunker.SplitPlainTextLines(text, maxTokensPerLine, null);
         var paragraphs = TextChunker.SplitPlainTextParagraphs(lines, maxTokensPerParagraph, paragraphOverlap, string.Empty, null).ToList();
         var total = paragraphs.Count;
@@ -105,7 +105,7 @@ public sealed class RagVectorIndexService(
     {
         var settings = await userSettings.GetSettingsAsync();
         return ModelSelectionHelper.GetEffectiveEmbeddingModel(
-            settings.EmbeddingModel,
+            settings.Embedding.Model,
             settings.DefaultModel,
             "RAG vector indexing",
             logger);

--- a/ChatClient.Api/UserData/user_settings.json
+++ b/ChatClient.Api/UserData/user_settings.json
@@ -9,13 +9,15 @@
   },
   "mcpSamplingTimeoutSeconds": 1800,
   "chatHistoryMode": 0,
-  "embeddingModel": {
-    "serverId": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
-    "modelName": "bge-m3:latest"
+  "embedding": {
+    "model": {
+      "serverId": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+      "modelName": "bge-m3:latest"
+    },
+    "ragLineChunkSize": 256,
+    "ragParagraphChunkSize": 512,
+    "ragParagraphOverlap": 64
   },
-  "ragLineChunkSize": 256,
-  "ragParagraphChunkSize": 512,
-  "ragParagraphOverlap": 64,
   "stopAgentName": "RoundRobinWithSummary",
   "multiAgentSelectedAgents": [
     "Friedrich Nietzsche",

--- a/ChatClient.Shared/Models/EmbeddingSettings.cs
+++ b/ChatClient.Shared/Models/EmbeddingSettings.cs
@@ -1,0 +1,18 @@
+using System.Text.Json.Serialization;
+
+namespace ChatClient.Shared.Models;
+
+public class EmbeddingSettings
+{
+    [JsonPropertyName("model")]
+    public ServerModel Model { get; set; } = new(Guid.Empty, string.Empty);
+
+    [JsonPropertyName("ragLineChunkSize")]
+    public int RagLineChunkSize { get; set; } = 256;
+
+    [JsonPropertyName("ragParagraphChunkSize")]
+    public int RagParagraphChunkSize { get; set; } = 512;
+
+    [JsonPropertyName("ragParagraphOverlap")]
+    public int RagParagraphOverlap { get; set; } = 64;
+}

--- a/ChatClient.Shared/Models/UserSettings.cs
+++ b/ChatClient.Shared/Models/UserSettings.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.Text.Json.Serialization;
 
 namespace ChatClient.Shared.Models;
@@ -31,20 +32,8 @@ public class UserSettings
     [JsonPropertyName("chatHistoryMode")]
     public AppChatHistoryMode ChatHistoryMode { get; set; } = AppChatHistoryMode.None;
 
-    /// <summary>
-    /// Embedding model used for building the function index
-    /// </summary>
-    [JsonPropertyName("embeddingModel")]
-    public ServerModel EmbeddingModel { get; set; } = new(Guid.Empty, string.Empty);
-
-    [JsonPropertyName("ragLineChunkSize")]
-    public int RagLineChunkSize { get; set; } = 256;
-
-    [JsonPropertyName("ragParagraphChunkSize")]
-    public int RagParagraphChunkSize { get; set; } = 512;
-
-    [JsonPropertyName("ragParagraphOverlap")]
-    public int RagParagraphOverlap { get; set; } = 64;
+    [JsonPropertyName("embedding")]
+    public EmbeddingSettings Embedding { get; set; } = new();
 
     [JsonPropertyName("stopAgentName")]
     public string StopAgentName { get; set; } = string.Empty;

--- a/ChatClient.Shared/Services/IUserSettingsService.cs
+++ b/ChatClient.Shared/Services/IUserSettingsService.cs
@@ -6,5 +6,4 @@ public interface IUserSettingsService
 {
     Task<UserSettings> GetSettingsAsync();
     Task SaveSettingsAsync(UserSettings settings);
-    event Func<Task>? EmbeddingModelChanged;
 }

--- a/ChatClient.Tests/AppChatHistoryBuilderTests.cs
+++ b/ChatClient.Tests/AppChatHistoryBuilderTests.cs
@@ -15,7 +15,6 @@ public class AppChatHistoryBuilderTests
 {
     private sealed class ThrowingUserSettingsService : IUserSettingsService
     {
-        public event Func<Task>? EmbeddingModelChanged;
         public Task<UserSettings> GetSettingsAsync() => throw new InvalidOperationException();
         public Task SaveSettingsAsync(UserSettings settings) => throw new InvalidOperationException();
     }

--- a/ChatClient.Tests/ChatServiceTests.cs
+++ b/ChatClient.Tests/ChatServiceTests.cs
@@ -39,8 +39,6 @@ public class ChatServiceTests
 
     private class MockUserSettingsService : IUserSettingsService
     {
-        public event Func<Task>? EmbeddingModelChanged;
-
         public Task<UserSettings> GetSettingsAsync() => Task.FromResult(new UserSettings());
         public Task SaveSettingsAsync(UserSettings settings) => Task.CompletedTask;
     }

--- a/ChatClient.Tests/OllamaServiceTests.cs
+++ b/ChatClient.Tests/OllamaServiceTests.cs
@@ -32,7 +32,6 @@ public class OllamaServiceTests
 
     private sealed class StubUserSettingsService : IUserSettingsService
     {
-        public event Func<Task>? EmbeddingModelChanged;
         public Task<UserSettings> GetSettingsAsync() => Task.FromResult(new UserSettings());
         public Task SaveSettingsAsync(UserSettings settings) => Task.CompletedTask;
     }


### PR DESCRIPTION
## Summary
- group embedding options into dedicated `EmbeddingSettings`
- remove automatic regeneration on model change
- add settings button to restart embedding generation manually

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68b554403c40832a9230657bfc4e4b77