### PR TITLE
Fix model listing per server and resolve connection test error

### DIFF
--- a/ChatClient.Api/Client/Pages/Models.razor
+++ b/ChatClient.Api/Client/Pages/Models.razor
@@ -1,7 +1,9 @@
 @page "/models"
 @using ChatClient.Shared.Models
 @using ChatClient.Api.Services
+@using System.Linq
 @inject IOllamaClientService OllamaService
+@inject IOpenAIClientService OpenAIService
 @inject ILlmServerConfigService LlmServerConfigService
 
 <MudContainer Class="mt-3">
@@ -27,7 +29,7 @@
             }
             else if (server.Models.Count == 0)
             {
-                <MudAlert Severity="Severity.Info" Class="mb-4">No models available. Make sure Ollama is running and has models installed.</MudAlert>
+                <MudAlert Severity="Severity.Info" Class="mb-4">No models available.</MudAlert>
             }
             else
             {
@@ -88,7 +90,10 @@
             {
                 try
                 {
-                    var models = (await OllamaService.GetModelsAsync(s.Id ?? Guid.Empty)).ToList();
+                    var serverId = s.Id ?? Guid.Empty;
+                    List<OllamaModel> models = s.ServerType == ServerType.ChatGpt
+                        ? (await OpenAIService.GetAvailableModelsAsync(serverId)).Select(m => new OllamaModel { Name = m }).ToList()
+                        : (await OllamaService.GetModelsAsync(serverId)).ToList();
                     return new ServerModels(s, models, null);
                 }
                 catch

--- a/ChatClient.Api/Services/ServerConnectionTestService.cs
+++ b/ChatClient.Api/Services/ServerConnectionTestService.cs
@@ -59,7 +59,7 @@ public class ServerConnectionTestService(ILogger<ServerConnectionTestService> lo
 
     private HttpClient CreateHttpClient(LlmServerConfig server)
     {
-        using var handler = new HttpClientHandler();
+        var handler = new HttpClientHandler();
         if (server.IgnoreSslErrors)
             handler.ServerCertificateCustomValidationCallback = (_, _, _, _) => true;
 


### PR DESCRIPTION
## Summary
- show models from the correct LLM service based on server type
- fix connection testing by avoiding disposal of HttpClient handler

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68b562935ea8832aa9fd976f3108a0e9