### PR TITLE
Shutdown server when last browser session closes

### DIFF
--- a/ChatClient.Api/Program.cs
+++ b/ChatClient.Api/Program.cs
@@ -3,6 +3,7 @@ using ChatClient.Api.Client.Services;
 using ChatClient.Api.Client.Services.Formatters;
 using ChatClient.Api.Services;
 using ChatClient.Api.Services.Rag;
+using Microsoft.AspNetCore.Components.Server.Circuits;
 using Microsoft.AspNetCore.Hosting.Server;
 using Microsoft.AspNetCore.Hosting.Server.Features;
 using Microsoft.SemanticKernel.Connectors.InMemory;
@@ -72,6 +73,8 @@ builder.Services.AddServerSideBlazor();
 builder.Services.AddHttpClient();
 
 builder.Services.AddMudServices();
+
+builder.Services.AddSingleton<CircuitHandler, AutoShutdownCircuitHandler>();
 
 builder.Services.AddControllers(options =>
 {

--- a/ChatClient.Api/Services/AutoShutdownCircuitHandler.cs
+++ b/ChatClient.Api/Services/AutoShutdownCircuitHandler.cs
@@ -1,0 +1,28 @@
+using Microsoft.AspNetCore.Components.Server.Circuits;
+using System.Threading;
+
+namespace ChatClient.Api.Services;
+
+/// <summary>
+/// Stops the application when the last browser connection closes.
+/// </summary>
+public sealed class AutoShutdownCircuitHandler(IHostApplicationLifetime lifetime) : CircuitHandler
+{
+    private int connections;
+
+    public override Task OnConnectionUpAsync(Circuit circuit, CancellationToken cancellationToken)
+    {
+        Interlocked.Increment(ref connections);
+        return Task.CompletedTask;
+    }
+
+    public override Task OnConnectionDownAsync(Circuit circuit, CancellationToken cancellationToken)
+    {
+        if (Interlocked.Decrement(ref connections) == 0)
+        {
+            lifetime.StopApplication();
+        }
+
+        return Task.CompletedTask;
+    }
+}


### PR DESCRIPTION
## Summary
- stop application when last browser connection closes
- register circuit handler to monitor browser sessions

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68b61583ddf8832aaae9c4b224aec6bd