### PR TITLE
Enforce model selection before chat

### DIFF
--- a/ChatClient.Api/Client/Components/OllamaCheck.razor
+++ b/ChatClient.Api/Client/Components/OllamaCheck.razor
@@ -46,7 +46,7 @@ else
             if (server == null)
                 return;
 
-            await ValidateServerAvailability(server, settings.DefaultModel.ServerId);
+            await ValidateServerAvailability(server, settings.DefaultModel.ServerId!.Value);
         }
         catch (Exception ex)
         {
@@ -62,7 +62,7 @@ else
 
     private bool ValidateDefaultServer(UserSettings settings)
     {
-        if (settings.DefaultModel.ServerId != Guid.Empty)
+        if (settings.DefaultModel.ServerId is not null)
             return true;
 
         Logger.LogWarning("No default server configured");

--- a/ChatClient.Api/Client/Components/ServerModelPicker.razor
+++ b/ChatClient.Api/Client/Components/ServerModelPicker.razor
@@ -45,8 +45,8 @@
 </MudStack>
 
 @code {
-    [Parameter] public ServerModel Value { get; set; } = new(Guid.Empty, string.Empty);
-    [Parameter] public EventCallback<ServerModel> ValueChanged { get; set; }
+    [Parameter] public ServerModelSelection Value { get; set; } = new(null, null);
+    [Parameter] public EventCallback<ServerModelSelection> ValueChanged { get; set; }
     [Parameter] public bool ShowClearButton { get; set; } = false;
     [Parameter(CaptureUnmatchedValues = true)] public Dictionary<string, object> Attributes { get; set; } = [];
 
@@ -60,11 +60,11 @@
     protected override async Task OnInitializedAsync()
     {
         servers = await LlmServerConfigService.GetAllAsync();
-        if (Value.ServerId == Guid.Empty && string.IsNullOrEmpty(Value.ModelName))
+        if (Value.ServerId is null && string.IsNullOrEmpty(Value.ModelName))
         {
             var settings = await UserSettingsService.GetSettingsAsync();
             var defaultModel = settings.DefaultModel;
-            selectedServerId = defaultModel.ServerId == Guid.Empty ? null : defaultModel.ServerId;
+            selectedServerId = defaultModel.ServerId;
             selectedModel = defaultModel.ModelName;
             if (selectedServerId.HasValue)
                 await LoadModelsAsync(selectedServerId.Value);
@@ -106,7 +106,7 @@
 
     private async Task NotifyValueChanged()
     {
-        var selection = new ServerModel(selectedServerId ?? Guid.Empty, selectedModel ?? string.Empty);
+        var selection = new ServerModelSelection(selectedServerId, selectedModel);
         Value = selection;
         await ValueChanged.InvokeAsync(selection);
     }

--- a/ChatClient.Api/Client/Layout/MainLayout.razor
+++ b/ChatClient.Api/Client/Layout/MainLayout.razor
@@ -12,7 +12,7 @@
 <MudDialogProvider />
 <MudSnackbarProvider />
 <MudPopoverProvider />
-<CascadingValue Value="@selectedModel" Name="SelectedModel">
+<CascadingValue Value="@pickerModel" Name="UiModelSelection">
 <MudLayout>
     <MudAppBar Elevation="1" Dense="true">
         <MudIconButton Icon="@Icons.Material.Filled.Menu" Color="Color.Inherit" Edge="Edge.Start" OnClick="@((e) => DrawerToggle())" Size="Size.Medium" />
@@ -27,7 +27,7 @@
                        Class="ml-4"
                        Style="flex-shrink: 0;">New Chat</MudButton>
             <div class="ml-2" style="flex-shrink: 1; min-width: 0;">
-                <ServerModelPicker Value="selectedModel" ValueChanged="OnModelChanged" />
+                <ServerModelPicker Value="pickerModel" ValueChanged="OnModelChanged" />
             </div>
         }
         <MudSpacer />
@@ -63,7 +63,7 @@
     private bool _drawerOpen = true;
     private bool _isDarkMode = true;
     private bool isLLMAnswering;
-    private ServerModel selectedModel = new(Guid.Empty, string.Empty);
+    private ServerModelSelection pickerModel = new(null, null);
     private MudTheme? _theme = null;
 
     protected override async Task OnInitializedAsync()
@@ -74,7 +74,7 @@
         isLLMAnswering = ChatService.IsAnswering;
 
         var settings = await UserSettingsService.GetSettingsAsync();
-        selectedModel = settings.DefaultModel;
+        pickerModel = settings.DefaultModel;
 
         _theme = new()
         {
@@ -120,15 +120,13 @@
 
     
 
-    private async Task OnModelChanged(ServerModel model)
+    private async Task OnModelChanged(ServerModelSelection model)
     {
+        pickerModel = model;
+
         var settings = await UserSettingsService.GetSettingsAsync();
-        var selectedModel = model.ServerId != Guid.Empty && !string.IsNullOrWhiteSpace(model.ModelName)
-            ? model 
-            : settings.DefaultModel;
-        settings.DefaultModel = selectedModel;
+        settings.DefaultModel = model;
         await UserSettingsService.SaveSettingsAsync(settings);
-        this.selectedModel = selectedModel;
         StateHasChanged();
     }
 

--- a/ChatClient.Api/Client/Pages/AgentDescriptions.razor
+++ b/ChatClient.Api/Client/Pages/AgentDescriptions.razor
@@ -291,7 +291,7 @@
     private bool functionsExpanded;
     private Dictionary<Guid, int> ragCounts = new();
     private List<RagFile> ragFiles = new();
-    private ServerModel editingServerModel = new(Guid.Empty, string.Empty);
+    private ServerModelSelection editingServerModel = new(null, null);
     private List<LlmServerConfig> servers = new();
     private DialogOptions dialogOptions = new()
     {
@@ -386,7 +386,7 @@
                 SelectedFunctions = []
             }
         };
-        editingServerModel = new ServerModel(Guid.Empty, string.Empty);
+        editingServerModel = new ServerModelSelection(null, null);
         ragFiles = new();
         showEditAgentDialog = true;
     }
@@ -497,7 +497,7 @@
             }
         };
 
-        editingServerModel = new ServerModel(agent.LlmId ?? Guid.Empty, agent.ModelName ?? string.Empty);
+        editingServerModel = new ServerModelSelection(agent.LlmId, agent.ModelName);
         await LoadRagFiles(agent.Id);
         showEditAgentDialog = true;
     }
@@ -572,8 +572,8 @@
         {
             try
             {
-                editingAgent.LlmId = editingServerModel.ServerId == Guid.Empty ? null : editingServerModel.ServerId;
-                editingAgent.ModelName = string.IsNullOrWhiteSpace(editingServerModel.ModelName) ? null : editingServerModel.ModelName;
+                editingAgent.LlmId = editingServerModel.ServerId;
+                editingAgent.ModelName = editingServerModel.ModelName;
                 if (editingAgent.Id == Guid.Empty)
                 {
                     var result = await AgentService.CreateAsync(editingAgent);

--- a/ChatClient.Api/Client/Pages/AppSettings.razor
+++ b/ChatClient.Api/Client/Pages/AppSettings.razor
@@ -115,8 +115,8 @@
 
 @code {
     private UserSettings _settings = new();
-    private ServerModel _defaultModel = new(Guid.Empty, string.Empty);
-    private ServerModel _embeddingModel = new(Guid.Empty, string.Empty);
+    private ServerModelSelection _defaultModel = new(null, null);
+    private ServerModelSelection _embeddingModel = new(null, null);
     private bool _loading = true;
     private MudForm? _form;
 
@@ -133,14 +133,14 @@
         }
     }
 
-    private Task OnDefaultModelChanged(ServerModel model)
+    private Task OnDefaultModelChanged(ServerModelSelection model)
     {
         _defaultModel = model;
         _settings.DefaultModel = model;
         return Task.CompletedTask;
     }
 
-    private Task OnEmbeddingModelChanged(ServerModel model)
+    private Task OnEmbeddingModelChanged(ServerModelSelection model)
     {
         _embeddingModel = model;
         _settings.Embedding.Model = model;
@@ -166,9 +166,9 @@
     {
         try
         {
-            if (_settings.Embedding.Model.ServerId != Guid.Empty && !string.IsNullOrWhiteSpace(_settings.Embedding.Model.ModelName))
+            if (_settings.Embedding.Model.ServerId is { } serverId && !string.IsNullOrWhiteSpace(_settings.Embedding.Model.ModelName))
             {
-                var models = await OllamaService.GetModelsAsync(_settings.Embedding.Model.ServerId);
+                var models = await OllamaService.GetModelsAsync(serverId);
                 var exists = models.Any(m => m.Name.Equals(_settings.Embedding.Model.ModelName, StringComparison.OrdinalIgnoreCase));
                 if (!exists)
                 {

--- a/ChatClient.Api/Client/Pages/Chat.razor
+++ b/ChatClient.Api/Client/Pages/Chat.razor
@@ -12,6 +12,7 @@
 @using ChatClient.Api.Client.ViewModels
 @using ChatClient.Api.Services
 @using ChatClient.Shared.Models
+@using ChatClient.Shared.Helpers
 @using ChatClient.Shared.Models.StopAgents
 @using Microsoft.AspNetCore.Components
 @using Microsoft.AspNetCore.Components.Web
@@ -58,14 +59,17 @@
                         }
                     </MudSelect>
 
-                    <MudButton Variant="Variant.Filled"
-                               Color="Color.Primary"
-                               FullWidth="true"
-                               Class="mt-4"
-                               Size="Size.Medium"
-                               OnClick="StartChat">
-                        Start Chat
-                    </MudButton>
+                    <MudTooltip Text="Select server and model" Disabled="@CanStartChat">
+                        <MudButton Variant="Variant.Filled"
+                                   Color="Color.Primary"
+                                   FullWidth="true"
+                                   Class="mt-4"
+                                   Size="Size.Medium"
+                                   Disabled="@(!CanStartChat)"
+                                   OnClick="StartChat">
+                            Start Chat
+                        </MudButton>
+                    </MudTooltip>
                     <MudButton Href="/agent-descriptions"
                                Variant="Variant.Text"
                                Color="Color.Secondary"
@@ -230,15 +234,19 @@
     private List<AgentDescription> agents = new();
     private AgentDescription? selectedAgent { get; set; }
 
-    [CascadingParameter(Name = "SelectedModel")]
-    public ServerModel? SelectedModel { get; set; }
+    [CascadingParameter(Name = "UiModelSelection")]
+    public ServerModelSelection UiModelSelection { get; set; } = new(null, null);
 
-    private string CurrentModelName => string.IsNullOrWhiteSpace(SelectedModel?.ModelName)
-        ? userSettings.DefaultModel.ModelName
-        : SelectedModel.ModelName;
-    private Guid CurrentServerId => SelectedModel?.ServerId != Guid.Empty
-        ? SelectedModel?.ServerId ?? Guid.Empty
-        : userSettings.DefaultModel.ServerId;
+    private ServerModel? effectiveModel;
+    private string CurrentModelName => effectiveModel!.ModelName;
+    private Guid CurrentServerId => effectiveModel!.ServerId;
+
+    private bool CanStartChat =>
+        selectedAgent != null &&
+        ModelSelectionHelper.TryGetEffectiveModel(
+            new ServerModelSelection(selectedAgent.LlmId, selectedAgent.ModelName),
+            UiModelSelection,
+            out _);
 
     private UserSettings userSettings = new();
 
@@ -313,14 +321,19 @@
 
     private void StartChat()
     {
-        var agents = selectedAgent != null ? new[] { selectedAgent } : Array.Empty<AgentDescription>();
-        if (agents.Length != 1)
-            throw new InvalidOperationException("Single-agent chat requires exactly one agent.");
+        if (selectedAgent is null)
+            return;
 
-        if (string.IsNullOrWhiteSpace(agents[0].ModelName))
-            agents[0].ModelName = CurrentModelName;
-        if (!agents[0].LlmId.HasValue || agents[0].LlmId == Guid.Empty)
-            agents[0].LlmId = CurrentServerId;
+        var agents = new[] { selectedAgent };
+        var configured = new ServerModelSelection(selectedAgent.LlmId, selectedAgent.ModelName);
+        effectiveModel = ModelSelectionHelper.GetEffectiveModel(
+            configured,
+            UiModelSelection,
+            $"Agent: {selectedAgent.AgentName}",
+            Logger);
+
+        selectedAgent.ModelName = effectiveModel.ModelName;
+        selectedAgent.LlmId = effectiveModel.ServerId;
 
         ChatService.InitializeChat(agents);
         chatStarted = true;

--- a/ChatClient.Api/Client/Pages/MultiAgentChat.razor
+++ b/ChatClient.Api/Client/Pages/MultiAgentChat.razor
@@ -82,14 +82,17 @@
                         <em>Editor for '@stopAgentOptions.GetType().Name' not found</em>
                     }
 
-                    <MudButton Variant="Variant.Filled"
-                               Color="Color.Primary"
-                               FullWidth="true"
-                               Class="mt-4"
-                               Size="Size.Medium"
-                               OnClick="StartChat">
-                        Start Chat
-                    </MudButton>
+                    <MudTooltip Text="Select server and model" Disabled="@CanStartChat">
+                        <MudButton Variant="Variant.Filled"
+                                   Color="Color.Primary"
+                                   FullWidth="true"
+                                   Class="mt-4"
+                                   Size="Size.Medium"
+                                   Disabled="@(!CanStartChat)"
+                                   OnClick="StartChat">
+                            Start Chat
+                        </MudButton>
+                    </MudTooltip>
                     <MudButton Href="/agent-descriptions"
                                Variant="Variant.Text"
                                Color="Color.Secondary"
@@ -255,15 +258,18 @@
     private List<AgentDescription> agents = new();
     private List<AgentDescription> selectedAgents { get; set; } = new();
 
-    [CascadingParameter(Name = "SelectedModel")]
-    public ServerModel? SelectedModel { get; set; }
+    [CascadingParameter(Name = "UiModelSelection")]
+    public ServerModelSelection UiModelSelection { get; set; } = new(null, null);
 
-    private ServerModel CurrentModel => SelectedModel?.ServerId != Guid.Empty && !string.IsNullOrWhiteSpace(SelectedModel?.ModelName)
-        ? SelectedModel
-        : userSettings.DefaultModel;
-    
-    private string CurrentModelName => CurrentModel.ModelName;
-    private Guid CurrentServerId => CurrentModel.ServerId;
+    private string? currentModelName;
+
+    private bool CanStartChat =>
+        selectedAgents.Count > 0 &&
+        selectedAgents.All(agent =>
+            ModelSelectionHelper.TryGetEffectiveModel(
+                new ServerModelSelection(agent.LlmId, agent.ModelName),
+                UiModelSelection,
+                out _));
 
     private const string RoundRobinStopAgent = "RoundRobin";
     private const string RoundRobinSummaryStopAgent = "RoundRobinWithSummary";
@@ -386,23 +392,23 @@
     
     private async Task StartChat()
     {
-        if (selectedAgents.Count == 0)
+        if (!CanStartChat)
             return;
 
         foreach (var agent in selectedAgents)
         {
-            var configuredModel = agent.LlmId.HasValue && agent.LlmId != Guid.Empty && !string.IsNullOrWhiteSpace(agent.ModelName)
-                ? new ServerModel(agent.LlmId.Value, agent.ModelName)
-                : null;
+            var configured = new ServerModelSelection(agent.LlmId, agent.ModelName);
             var effectiveModel = ModelSelectionHelper.GetEffectiveModel(
-                configuredModel,
-                CurrentModel,
+                configured,
+                UiModelSelection,
                 $"Agent: {agent.AgentName}",
                 Logger);
-                
+
             agent.ModelName = effectiveModel.ModelName;
             agent.LlmId = effectiveModel.ServerId;
         }
+
+        currentModelName = selectedAgents[0].ModelName!;
 
         userSettings.StopAgentName = stopAgentName;
         userSettings.MultiAgentSelectedAgents = selectedAgents.Select(a => a.AgentName).ToList();
@@ -475,7 +481,7 @@
             }
         }
         var groupChatManager = StopAgentFactory.Create(stopAgentName, options);
-        var chatConfiguration = new AppChatConfiguration(CurrentModelName, allFunctions);
+        var chatConfiguration = new AppChatConfiguration(currentModelName!, allFunctions);
 
         await ChatService.GenerateAnswerAsync(messageData.text.Trim(), chatConfiguration, groupChatManager, messageData.files);
         await ScrollToBottom();

--- a/ChatClient.Api/Client/Pages/VectorSearch.razor
+++ b/ChatClient.Api/Client/Pages/VectorSearch.razor
@@ -137,11 +137,6 @@
         try
         {
             var model = embeddingModel;
-            if (model.ServerId == Guid.Empty)
-            {
-                var settings = await UserSettingsService.GetSettingsAsync();
-                model = model with { ServerId = settings.DefaultModel.ServerId };
-            }
             var embedding = await OllamaService.GenerateEmbeddingAsync(text, model);
             var response = await VectorSearchService.SearchAsync(selectedAgent.Id, new ReadOnlyMemory<float>(embedding));
             results = response.Results.ToList();

--- a/ChatClient.Api/Services/OllamaServerAvailabilityService.cs
+++ b/ChatClient.Api/Services/OllamaServerAvailabilityService.cs
@@ -16,7 +16,7 @@ public class OllamaServerAvailabilityService(
             var settings = await userSettingsService.GetSettingsAsync();
             var serverToCheck = serverId ?? settings.DefaultModel.ServerId;
 
-            if (serverToCheck == Guid.Empty)
+            if (!serverToCheck.HasValue)
             {
                 logger.LogWarning("No default server configured");
                 return new OllamaServerStatus
@@ -51,7 +51,7 @@ public class OllamaServerAvailabilityService(
                 };
             }
 
-            var models = await ollamaService.GetModelsAsync(serverToCheck);
+            var models = await ollamaService.GetModelsAsync(serverToCheck.Value);
             logger.LogInformation("Ollama server '{ServerName}' is available with {ModelCount} models",
                 server.Name, models.Count);
 

--- a/ChatClient.Api/Services/OpenAIClientService.cs
+++ b/ChatClient.Api/Services/OpenAIClientService.cs
@@ -18,12 +18,6 @@ public class OpenAIClientService(
 
     public async Task<IChatCompletionService> GetClientAsync(ServerModel serverModel, CancellationToken cancellationToken = default)
     {
-        if (serverModel.ServerId == Guid.Empty)
-            throw new ArgumentException("ServerId cannot be empty", nameof(serverModel));
-
-        if (string.IsNullOrWhiteSpace(serverModel.ModelName))
-            throw new ArgumentException("ModelName cannot be null or empty", nameof(serverModel));
-
         var server = await LlmServerConfigHelper.GetServerConfigAsync(_llmServerConfigService, _userSettingsService, serverModel.ServerId, ServerType.ChatGpt);
         if (server == null)
         {

--- a/ChatClient.Api/Services/Rag/RagVectorIndexBackgroundService.cs
+++ b/ChatClient.Api/Services/Rag/RagVectorIndexBackgroundService.cs
@@ -65,7 +65,7 @@ public sealed class RagVectorIndexBackgroundService(
             var indexService = scope.ServiceProvider.GetRequiredService<IRagVectorIndexService>();
             var settingsService = scope.ServiceProvider.GetRequiredService<IUserSettingsService>();
             var settings = await settingsService.GetSettingsAsync();
-            var embedServer = settings.Embedding.Model.ServerId;
+            var embedServer = settings.Embedding.Model.ServerId ?? Guid.Empty;
 
             var basePath = _configuration["RagFiles:BasePath"] ?? Path.Combine("Data", "agents");
             List<(Guid agentId, string source, string index, string fileName)> pending = [];

--- a/ChatClient.Api/Services/UserSettingsService.cs
+++ b/ChatClient.Api/Services/UserSettingsService.cs
@@ -53,13 +53,13 @@ public class UserSettingsService : IUserSettingsService
 
         var updated = false;
 
-        if (settings.DefaultModel.ServerId == Guid.Empty)
+        if (settings.DefaultModel.ServerId is null)
         {
             var servers = await _llmServerConfigService.GetAllAsync();
             var defaultServer = servers.FirstOrDefault(s => s.ServerType == ServerType.Ollama);
             if (defaultServer != null)
             {
-                settings.DefaultModel = settings.DefaultModel with { ServerId = defaultServer.Id ?? Guid.Empty };
+                settings.DefaultModel = settings.DefaultModel with { ServerId = defaultServer.Id }; 
                 updated = true;
             }
         }

--- a/ChatClient.Shared/Models/EmbeddingSettings.cs
+++ b/ChatClient.Shared/Models/EmbeddingSettings.cs
@@ -5,7 +5,7 @@ namespace ChatClient.Shared.Models;
 public class EmbeddingSettings
 {
     [JsonPropertyName("model")]
-    public ServerModel Model { get; set; } = new(Guid.Empty, string.Empty);
+    public ServerModelSelection Model { get; set; } = new(null, null);
 
     [JsonPropertyName("ragLineChunkSize")]
     public int RagLineChunkSize { get; set; } = 256;

--- a/ChatClient.Shared/Models/ServerModelSelection.cs
+++ b/ChatClient.Shared/Models/ServerModelSelection.cs
@@ -1,0 +1,3 @@
+namespace ChatClient.Shared.Models;
+
+public record ServerModelSelection(Guid? ServerId, string? ModelName);

--- a/ChatClient.Shared/Models/UserSettings.cs
+++ b/ChatClient.Shared/Models/UserSettings.cs
@@ -18,7 +18,7 @@ public class UserSettings
     public string AgentName { get; set; } = string.Empty;
 
     [JsonPropertyName("defaultModel")]
-    public ServerModel DefaultModel { get; set; } = new(Guid.Empty, string.Empty);
+    public ServerModelSelection DefaultModel { get; set; } = new(null, null);
 
     /// <summary>
     /// HTTP request timeout in seconds for MCP sampling requests (typically longer than regular API calls)

--- a/ChatClient.Tests/ModelSelectionHelperTests.cs
+++ b/ChatClient.Tests/ModelSelectionHelperTests.cs
@@ -1,6 +1,5 @@
 using ChatClient.Shared.Helpers;
 using ChatClient.Shared.Models;
-using Microsoft.Extensions.Logging;
 using Xunit;
 
 namespace ChatClient.Tests;
@@ -8,73 +7,52 @@ namespace ChatClient.Tests;
 public class ModelSelectionHelperTests
 {
     [Fact]
-    public void GetEffectiveModel_ConfiguredModelValid_ReturnsConfiguredModel()
+    public void TryGetEffectiveModel_UsesConfiguredWhenUiEmpty()
     {
-        // Arrange
-        var configuredModel = new ServerModel(Guid.NewGuid(), "configured-model");
-        var uiSelectedModel = new ServerModel(Guid.NewGuid(), "ui-model");
+        var configured = new ServerModelSelection(Guid.NewGuid(), "configured");
+        var ui = new ServerModelSelection(null, null);
 
-        // Act
-        var result = ModelSelectionHelper.GetEffectiveModel(
-            configuredModel,
-            uiSelectedModel,
-            "Test context");
+        var success = ModelSelectionHelper.TryGetEffectiveModel(configured, ui, out var result);
 
-        // Assert
-        Assert.Equal(configuredModel.ServerId, result.ServerId);
-        Assert.Equal(configuredModel.ModelName, result.ModelName);
+        Assert.True(success);
+        Assert.Equal(configured.ServerId, result.ServerId);
+        Assert.Equal(configured.ModelName, result.ModelName);
     }
 
     [Fact]
-    public void GetEffectiveModel_ConfiguredModelInvalid_ReturnsUIModel()
+    public void TryGetEffectiveModel_CombineServerFromUiAndModelFromConfig()
     {
-        // Arrange
-        var configuredModel = new ServerModel(Guid.Empty, string.Empty); // Invalid
-        var uiSelectedModel = new ServerModel(Guid.NewGuid(), "ui-model");
+        var configured = new ServerModelSelection(Guid.NewGuid(), "configured");
+        var ui = new ServerModelSelection(Guid.NewGuid(), null);
 
-        // Act
-        var result = ModelSelectionHelper.GetEffectiveModel(
-            configuredModel,
-            uiSelectedModel,
-            "Test context");
+        var success = ModelSelectionHelper.TryGetEffectiveModel(configured, ui, out var result);
 
-        // Assert
-        Assert.Equal(uiSelectedModel.ServerId, result.ServerId);
-        Assert.Equal(uiSelectedModel.ModelName, result.ModelName);
+        Assert.True(success);
+        Assert.Equal(ui.ServerId, result.ServerId);
+        Assert.Equal(configured.ModelName, result.ModelName);
     }
 
     [Fact]
-    public void GetEffectiveModel_ConfiguredModelNull_ReturnsUIModel()
+    public void GetEffectiveModel_IncompleteCombination_Throws()
     {
-        // Arrange
-        ServerModel? configuredModel = null;
-        var uiSelectedModel = new ServerModel(Guid.NewGuid(), "ui-model");
+        var configured = new ServerModelSelection(null, "model-only");
+        var ui = new ServerModelSelection(null, null);
 
-        // Act
-        var result = ModelSelectionHelper.GetEffectiveModel(
-            configuredModel,
-            uiSelectedModel,
-            "Test context");
-
-        // Assert
-        Assert.Equal(uiSelectedModel.ServerId, result.ServerId);
-        Assert.Equal(uiSelectedModel.ModelName, result.ModelName);
+        Assert.Throws<InvalidOperationException>(() =>
+            ModelSelectionHelper.GetEffectiveModel(configured, ui, "test"));
     }
 
     [Fact]
     public void GetEffectiveEmbeddingModel_EmbeddingModelValid_ReturnsEmbeddingModel()
     {
-        // Arrange
-        var embeddingModel = new ServerModel(Guid.NewGuid(), "embedding-model");
-        var defaultModel = new ServerModel(Guid.NewGuid(), "default-model");
+        var embeddingModel = new ServerModelSelection(Guid.NewGuid(), "embedding-model");
+        var defaultModel = new ServerModelSelection(Guid.NewGuid(), "default-model");
 
-        // Act
         var result = ModelSelectionHelper.GetEffectiveEmbeddingModel(
             embeddingModel,
             defaultModel,
-            "Test embedding");
+            "embedding");
 
-        // Assert
         Assert.Equal(embeddingModel.ServerId, result.ServerId);
         Assert.Equal(embeddingModel.ModelName, result.ModelName);
     }
@@ -82,64 +60,16 @@ public class ModelSelectionHelperTests
     [Fact]
     public void GetEffectiveEmbeddingModel_EmbeddingModelInvalid_ReturnsDefaultModel()
     {
-        // Arrange
-        var embeddingModel = new ServerModel(Guid.Empty, string.Empty); // Invalid
-        var defaultModel = new ServerModel(Guid.NewGuid(), "default-model");
+        var embeddingModel = new ServerModelSelection(Guid.Empty, string.Empty);
+        var defaultModel = new ServerModelSelection(Guid.NewGuid(), "default-model");
 
-        // Act
         var result = ModelSelectionHelper.GetEffectiveEmbeddingModel(
             embeddingModel,
             defaultModel,
-            "Test embedding");
+            "embedding");
 
-        // Assert
         Assert.Equal(defaultModel.ServerId, result.ServerId);
         Assert.Equal(defaultModel.ModelName, result.ModelName);
     }
-
-    [Fact]
-    public void GetEffectiveAgentModel_AgentModelConfigured_ReturnsAgentModel()
-    {
-        // Arrange
-        var agent = new AgentDescription
-        {
-            AgentName = "Test Agent",
-            LlmId = Guid.NewGuid(),
-            ModelName = "agent-model"
-        };
-        var uiSelectedModel = new ServerModel(Guid.NewGuid(), "ui-model");
-
-        // Act
-        var configuredModel = agent.LlmId.HasValue && agent.LlmId != Guid.Empty && !string.IsNullOrWhiteSpace(agent.ModelName)
-            ? new ServerModel(agent.LlmId.Value, agent.ModelName)
-            : null;
-        var result = ModelSelectionHelper.GetEffectiveModel(configuredModel, uiSelectedModel, $"Agent: {agent.AgentName}");
-
-        // Assert
-        Assert.Equal(agent.LlmId.Value, result.ServerId);
-        Assert.Equal(agent.ModelName, result.ModelName);
-    }
-
-    [Fact]
-    public void GetEffectiveAgentModel_AgentModelNotConfigured_ReturnsUIModel()
-    {
-        // Arrange
-        var agent = new AgentDescription
-        {
-            AgentName = "Test Agent",
-            LlmId = null,
-            ModelName = null
-        };
-        var uiSelectedModel = new ServerModel(Guid.NewGuid(), "ui-model");
-
-        // Act
-        var configuredModel = agent.LlmId.HasValue && agent.LlmId != Guid.Empty && !string.IsNullOrWhiteSpace(agent.ModelName)
-            ? new ServerModel(agent.LlmId.Value, agent.ModelName)
-            : null;
-        var result = ModelSelectionHelper.GetEffectiveModel(configuredModel, uiSelectedModel, $"Agent: {agent.AgentName}");
-
-        // Assert
-        Assert.Equal(uiSelectedModel.ServerId, result.ServerId);
-        Assert.Equal(uiSelectedModel.ModelName, result.ModelName);
-    }
 }
+


### PR DESCRIPTION
## Summary
- merge nullable agent and UI selections into required model
- block chat start until server and model resolved
- cover new selection logic with unit tests

## Testing
- `dotnet build`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68b6c2ba76f8832a9131dc5aecdb2dbd