### PR TITLE
feat: add MCP playground

### DIFF
--- a/ChatClient.Api/Client/Layout/NavMenu.razor
+++ b/ChatClient.Api/Client/Layout/NavMenu.razor
@@ -5,6 +5,7 @@
     <MudNavLink Href="agent-descriptions" Match="NavLinkMatch.Prefix" Icon="@Icons.Material.Filled.List">Agent Descriptions</MudNavLink>
     <MudNavLink Href="llm-servers" Match="NavLinkMatch.Prefix" Icon="@Icons.Material.Filled.Cloud">LLM Servers</MudNavLink>
     <MudNavLink Href="mcp-servers" Match="NavLinkMatch.Prefix" Icon="@Icons.Material.Filled.Link">MCP Servers</MudNavLink>
+        <MudNavLink Href="mcp-playground" Match="NavLinkMatch.Prefix" Icon="@Icons.Material.Filled.PlayArrow">MCP Playground</MudNavLink>
     <MudNavLink Href="models" Match="NavLinkMatch.Prefix" Icon="@Icons.Material.Filled.Memory">Models</MudNavLink>
     <MudNavLink Href="app-settings" Match="NavLinkMatch.Prefix" Icon="@Icons.Material.Filled.Tune">App Settings</MudNavLink>
 </MudNavMenu>

--- a/ChatClient.Api/Client/Pages/McpPlayground.razor
+++ b/ChatClient.Api/Client/Pages/McpPlayground.razor
@@ -1,0 +1,135 @@
+@page "/mcp-playground"
+@using ChatClient.Shared.Models
+@using System.Text.Json
+@using System.Net.Http.Json
+@using System.Linq
+@inject HttpClient Http
+@inject ISnackbar Snackbar
+
+<PageTitle>MCP Playground</PageTitle>
+<MudText Class="page-header">MCP Playground</MudText>
+
+<MudStack Spacing="2">
+    <MudSelect Label="Server" T="string" Value="@selectedServer" ValueChanged="OnServerChanged" Dense="true">
+        @foreach (var s in servers)
+        {
+            <MudSelectItem Value="@s">@s</MudSelectItem>
+        }
+    </MudSelect>
+
+    <MudSelect Label="Function" T="string" Value="@selectedFunction" ValueChanged="OnFunctionChanged" Disabled="@(!tools.Any())" Dense="true">
+        @foreach (var t in tools)
+        {
+            <MudSelectItem Value="@t.Name">@t.Name</MudSelectItem>
+        }
+    </MudSelect>
+
+    @if (fields.Any())
+    {
+        @foreach (var f in fields)
+        {
+            <MudTextField @bind-Value="parameters[f]" Label="@f" />
+        }
+    }
+
+    <MudButton Variant="Variant.Filled" OnClick="Call" Disabled="@(string.IsNullOrEmpty(selectedServer) || string.IsNullOrEmpty(selectedFunction))">Go</MudButton>
+
+    @if (!string.IsNullOrEmpty(result))
+    {
+        <MudPaper Class="pa-4" Outlined="true">
+            <pre>@result</pre>
+        </MudPaper>
+    }
+</MudStack>
+
+@code {
+    private readonly List<string> servers = [];
+    private readonly List<McpToolInfo> tools = [];
+    private readonly List<string> fields = [];
+    private readonly Dictionary<string, string> parameters = new(StringComparer.OrdinalIgnoreCase);
+    private string? selectedServer;
+    private string? selectedFunction;
+    private string? result;
+
+    protected override async Task OnInitializedAsync()
+    {
+        try
+        {
+            var list = await Http.GetFromJsonAsync<List<string>>("api/mcp-playground/servers");
+            if (list != null)
+                servers.AddRange(list);
+        }
+        catch (Exception ex)
+        {
+            Snackbar.Add($"Error loading servers: {ex.Message}", Severity.Error);
+        }
+    }
+
+    private async Task OnServerChanged(string? value)
+    {
+        selectedServer = value;
+        selectedFunction = null;
+        tools.Clear();
+        fields.Clear();
+        parameters.Clear();
+        result = null;
+        if (string.IsNullOrEmpty(selectedServer))
+            return;
+        try
+        {
+            var list = await Http.GetFromJsonAsync<List<McpToolInfo>>($"api/mcp-playground/tools/{selectedServer}");
+            if (list != null)
+                tools.AddRange(list);
+        }
+        catch (Exception ex)
+        {
+            Snackbar.Add($"Error loading tools: {ex.Message}", Severity.Error);
+        }
+    }
+
+    private void OnFunctionChanged(string? value)
+    {
+        selectedFunction = value;
+        fields.Clear();
+        parameters.Clear();
+        result = null;
+        var tool = tools.FirstOrDefault(t => t.Name == selectedFunction);
+        if (tool == null)
+            return;
+        if (tool.JsonSchema.ValueKind == JsonValueKind.Undefined)
+            return;
+        if (tool.JsonSchema.TryGetProperty("properties", out var props))
+        {
+            foreach (var prop in props.EnumerateObject())
+            {
+                fields.Add(prop.Name);
+                parameters[prop.Name] = string.Empty;
+            }
+        }
+    }
+
+    private async Task Call()
+    {
+        if (string.IsNullOrEmpty(selectedServer) || string.IsNullOrEmpty(selectedFunction))
+            return;
+        var request = new McpFunctionCallRequest(selectedServer, selectedFunction, new(parameters));
+        try
+        {
+            var response = await Http.PostAsJsonAsync("api/mcp-playground/call", request);
+            var text = await response.Content.ReadAsStringAsync();
+            try
+            {
+                var elem = JsonSerializer.Deserialize<JsonElement>(text);
+                result = JsonSerializer.Serialize(elem, new JsonSerializerOptions { WriteIndented = true });
+            }
+            catch
+            {
+                result = text;
+            }
+        }
+        catch (Exception ex)
+        {
+            Snackbar.Add($"Error calling function: {ex.Message}", Severity.Error);
+        }
+    }
+}

--- a/ChatClient.Api/Controllers/McpPlaygroundController.cs
+++ b/ChatClient.Api/Controllers/McpPlaygroundController.cs
@@ -1,0 +1,56 @@
+using ChatClient.Api.Services;
+using ChatClient.Shared.Models;
+using Microsoft.AspNetCore.Mvc;
+using System.Text.Json;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace ChatClient.Api.Controllers;
+
+[ApiController]
+[Route("api/mcp-playground")]
+public class McpPlaygroundController(IMcpClientService clientService, ILogger<McpPlaygroundController> logger) : ControllerBase
+{
+    [HttpGet("servers")]
+    public async Task<ActionResult<IEnumerable<string>>> GetServers(CancellationToken cancellationToken)
+    {
+        var clients = await clientService.GetMcpClientsAsync(cancellationToken);
+        return Ok(clients.Select(c => c.ServerInfo.Name));
+    }
+
+    [HttpGet("tools/{server}")]
+    public async Task<ActionResult<IEnumerable<McpToolInfo>>> GetTools(string server, CancellationToken cancellationToken)
+    {
+        var clients = await clientService.GetMcpClientsAsync(cancellationToken);
+        var client = clients.FirstOrDefault(c => string.Equals(c.ServerInfo.Name, server, StringComparison.OrdinalIgnoreCase));
+        if (client == null)
+            return NotFound();
+        var tools = await clientService.GetMcpTools(client, cancellationToken);
+        var result = tools.Select(t => new McpToolInfo(t.Name, t.Description, t.JsonSchema));
+        return Ok(result);
+    }
+
+    [HttpPost("call")]
+    public async Task<ActionResult<JsonElement>> Call(McpFunctionCallRequest request, CancellationToken cancellationToken)
+    {
+        var clients = await clientService.GetMcpClientsAsync(cancellationToken);
+        var client = clients.FirstOrDefault(c => string.Equals(c.ServerInfo.Name, request.Server, StringComparison.OrdinalIgnoreCase));
+        if (client == null)
+            return NotFound($"Server {request.Server} not found");
+        var tool = (await clientService.GetMcpTools(client, cancellationToken))
+            .FirstOrDefault(t => string.Equals(t.Name, request.Function, StringComparison.OrdinalIgnoreCase));
+        if (tool == null)
+            return NotFound($"Function {request.Function} not found");
+        var args = request.Parameters?.ToDictionary(kv => kv.Key, kv => (object?)kv.Value) ?? new Dictionary<string, object?>();
+        try
+        {
+            var result = await tool.CallAsync(args, null, null, cancellationToken);
+            return Ok(JsonSerializer.SerializeToElement(result));
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Error calling tool {Function} on server {Server}", request.Function, request.Server);
+            return StatusCode(500, JsonSerializer.SerializeToElement(new { error = ex.Message }));
+        }
+    }
+}

--- a/ChatClient.Shared/Models/McpFunctionCallRequest.cs
+++ b/ChatClient.Shared/Models/McpFunctionCallRequest.cs
@@ -1,0 +1,5 @@
+using System.Collections.Generic;
+
+namespace ChatClient.Shared.Models;
+
+public record McpFunctionCallRequest(string Server, string Function, Dictionary<string, string> Parameters);

--- a/ChatClient.Shared/Models/McpToolInfo.cs
+++ b/ChatClient.Shared/Models/McpToolInfo.cs
@@ -1,0 +1,5 @@
+using System.Text.Json;
+
+namespace ChatClient.Shared.Models;
+
+public record McpToolInfo(string Name, string? Description, JsonElement JsonSchema);


### PR DESCRIPTION
## Summary
- add MCP Playground tab to test MCP servers and functions
- create API endpoints for listing MCP servers, tools and calling them
- add shared models for MCP tool info and function call request

## Testing
- `dotnet build ChatClient.Api/ChatClient.Api.csproj`
- `dotnet test OllamaChat.sln`

------
https://chatgpt.com/codex/tasks/task_e_68b8262a17e0832a80f4d4c60f88388d