### PR TITLE
Limit MCP response area with scroll

### DIFF
--- a/ChatClient.Api/Client/Pages/McpPlayground.razor
+++ b/ChatClient.Api/Client/Pages/McpPlayground.razor
@@ -37,7 +37,7 @@
 
     @if (!string.IsNullOrEmpty(result))
     {
-        <MudPaper Class="pa-4" Outlined="true">
+        <MudPaper Class="pa-4 mcp-result" Outlined="true">
             <pre>@result</pre>
         </MudPaper>
     }

--- a/ChatClient.Api/wwwroot/css/app.css
+++ b/ChatClient.Api/wwwroot/css/app.css
@@ -112,3 +112,9 @@ code {
 .form-floating > .form-control-plaintext:focus::placeholder, .form-floating > .form-control:focus::placeholder {
     text-align: start;
 }
+
+.mcp-result {
+    width: 100%;
+    max-height: 400px;
+    overflow: auto;
+}


### PR DESCRIPTION
## Summary
- constrain MCP playground result area and make it scrollable
- add CSS class for the result container

## Testing
- `dotnet test --logger:"console;verbosity=detailed"`


------
https://chatgpt.com/codex/tasks/task_e_68b888c5f49c832abd87a0763a047ad7