### PR TITLE
Refine MCP playground result toggle

### DIFF
--- a/ChatClient.Api/Client/Pages/McpPlayground.razor
+++ b/ChatClient.Api/Client/Pages/McpPlayground.razor
@@ -176,13 +176,46 @@
             var obj = await tool.CallAsync(args, null, null);
             var elem = JsonSerializer.SerializeToElement(obj);
             rawResult = JsonSerializer.Serialize(elem, new JsonSerializerOptions { WriteIndented = true });
-            contentResult = elem.TryGetProperty("content", out var c)
-                ? JsonSerializer.Serialize(c, new JsonSerializerOptions { WriteIndented = true })
-                : null;
+            contentResult = FormatContent(elem);
+            showRaw = contentResult is null;
         }
         catch (Exception ex)
         {
             Snackbar.Add($"Error calling function: {ex.Message}", Severity.Error);
+        }
+    }
+
+    private static string? FormatContent(JsonElement elem)
+    {
+        if (!elem.TryGetProperty("content", out var content))
+            return null;
+        return content.ValueKind switch
+        {
+            JsonValueKind.Array => string.Join("\n", content.EnumerateArray().Select(FormatContentItem)),
+            JsonValueKind.String => FormatStringContent(content.GetString()),
+            _ => JsonSerializer.Serialize(content, new JsonSerializerOptions { WriteIndented = true })
+        };
+    }
+
+    private static string FormatContentItem(JsonElement elem)
+    {
+        if (elem.ValueKind == JsonValueKind.Object && elem.TryGetProperty("text", out var text) && text.ValueKind == JsonValueKind.String)
+            return FormatStringContent(text.GetString());
+        return JsonSerializer.Serialize(elem, new JsonSerializerOptions { WriteIndented = true });
+    }
+
+    private static string FormatStringContent(string? str)
+    {
+        if (string.IsNullOrEmpty(str))
+            return string.Empty;
+        try
+        {
+            using var doc = JsonDocument.Parse(str);
+            return JsonSerializer.Serialize(doc.RootElement, new JsonSerializerOptions { WriteIndented = true });
+        }
+        catch
+        {
+            return str;
         }
     }
 


### PR DESCRIPTION
## Summary
- switch content formatting to display parsed MCP content instead of full raw response
- attempt to beautify JSON strings and decode nested structures

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68b970df3680832a9e4774302394329f