### PR TITLE
Remove agent description management button from chat pages

### DIFF
--- a/ChatClient.Api/Client/Pages/Chat.razor
+++ b/ChatClient.Api/Client/Pages/Chat.razor
@@ -70,14 +70,6 @@
                             Start Chat
                         </MudButton>
                     </MudTooltip>
-                    <MudButton Href="/agent-descriptions"
-                               Variant="Variant.Text"
-                               Color="Color.Secondary"
-                               FullWidth="true"
-                               Class="mt-2"
-                               Size="Size.Medium">
-                        Manage Agent Descriptions
-                    </MudButton>
                 }
             </MudCardContent>
         </MudCard>

--- a/ChatClient.Api/Client/Pages/MultiAgentChat.razor
+++ b/ChatClient.Api/Client/Pages/MultiAgentChat.razor
@@ -93,14 +93,6 @@
                             Start Chat
                         </MudButton>
                     </MudTooltip>
-                    <MudButton Href="/agent-descriptions"
-                               Variant="Variant.Text"
-                               Color="Color.Secondary"
-                               FullWidth="true"
-                               Class="mt-2"
-                               Size="Size.Medium">
-                        Manage Agent Descriptions
-                    </MudButton>
                 }
             </MudCardContent>
         </MudCard>


### PR DESCRIPTION
## Summary
- remove manage agent descriptions button from Chat and MultiAgentChat pages

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68b9a0ed4188832a8ef0b6ddc154bd55