### PR TITLE
Reset chat before selecting agent for new conversation

### DIFF
--- a/ChatClient.Api/Client/Layout/MainLayout.razor
+++ b/ChatClient.Api/Client/Layout/MainLayout.razor
@@ -7,6 +7,7 @@
 @using ChatClient.Api.Client.Pages
 @using ChatClient.Api.Client.Components
 @using ChatClient.Api.Services
+@using System.Linq
 
 <MudThemeProvider Theme="@_theme" IsDarkMode="_isDarkMode" />
 <MudDialogProvider />
@@ -17,7 +18,7 @@
     <MudAppBar Elevation="1" Dense="true">
         <MudIconButton Icon="@Icons.Material.Filled.Menu" Color="Color.Inherit" Edge="Edge.Start" OnClick="@((e) => DrawerToggle())" Size="Size.Medium" />
         <MudText Typo="Typo.h6" Class="ml-3" Style="flex-shrink: 0;">Ollama chat with MCP</MudText>
-        @if (!isLLMAnswering)
+        @if (!isLLMAnswering && ChatService.AgentDescriptions.Any())
         {
             <MudButton OnClick="NewChat"
                        Color="Color.Secondary"
@@ -108,10 +109,7 @@
 
     private void NewChat()
     {
-        if (ChatService.AgentDescriptions.Count == 0)
-            return;
-
-        ChatService.InitializeChat(ChatService.AgentDescriptions);
+        ChatService.ResetChat();
         if (!IsOnChatPage())
         {
             NavigationManager.NavigateTo("/chat");

--- a/ChatClient.Api/Client/Pages/Chat.razor
+++ b/ChatClient.Api/Client/Pages/Chat.razor
@@ -293,7 +293,7 @@
 
     private void OnChatReset()
     {
-        chatStarted = true;
+        chatStarted = false;
         StateHasChanged();
     }
 

--- a/ChatClient.Api/Client/Services/AppChatService.cs
+++ b/ChatClient.Api/Client/Services/AppChatService.cs
@@ -72,6 +72,8 @@ public class AppChatService(
         logger.LogInformation("Resetting chat");
         Messages.Clear();
         _activeStreams.Clear();
+        _streamingManager = new AppStreamingMessageManager();
+        _agentsByName.Clear();
         ChatReset?.Invoke();
     }
 

--- a/ChatClient.Tests/ChatServiceTests.cs
+++ b/ChatClient.Tests/ChatServiceTests.cs
@@ -86,4 +86,29 @@ public class ChatServiceTests
 
         Assert.Empty(chatService.Messages);
     }
+
+    [Fact]
+    public void ResetChat_ClearsAgents()
+    {
+        var chatService = new AppChatService(
+            kernelService: null!,
+            logger: new LoggerFactory().CreateLogger<AppChatService>(),
+            chatHistoryBuilder: new DummyHistoryBuilder(),
+            reducer: new AppForceLastUserReducer(),
+            ollamaKernelService: new MockOllamaKernelService(),
+            openAIClientService: new MockOpenAIClientService(),
+            userSettingsService: new MockUserSettingsService(),
+            llmServerConfigService: new MockLlmServerConfigService());
+
+        var prompt = new AgentDescription { AgentName = "Agent", Content = "Hello" };
+        chatService.InitializeChat([prompt]);
+        Assert.Single(chatService.AgentDescriptions);
+
+        var resetRaised = false;
+        chatService.ChatReset += () => resetRaised = true;
+        chatService.ResetChat();
+
+        Assert.Empty(chatService.AgentDescriptions);
+        Assert.True(resetRaised);
+    }
 }


### PR DESCRIPTION
## Summary
- Disable New Chat button until an agent is selected and conversation is active
- Reset chat state so New Chat returns to agent selection
- Add unit test for chat reset behavior

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68b9df9df34c832a81931c207b420e13