### PR TITLE
Add models for saved chat dialogs

### DIFF
--- a/ChatClient.Api/Client/Services/AppChatService.cs
+++ b/ChatClient.Api/Client/Services/AppChatService.cs
@@ -37,6 +37,7 @@ public class AppChatService(
     public event Func<Guid, Task>? MessageDeleted;
 
     public bool IsAnswering { get; private set; }
+    public Guid Id { get; private set; } = Guid.NewGuid();
     public ObservableCollection<IAppChatMessage> Messages { get; } = [];
 
     private TrackingFiltersScope CreateTrackingScope()
@@ -55,6 +56,7 @@ public class AppChatService(
         if (agents.Count == 0)
             throw new ArgumentException("At least one agent must be selected.", nameof(agents));
 
+        Id = Guid.NewGuid();
         Messages.Clear();
         _activeStreams.Clear();
         _streamingManager = new AppStreamingMessageManager();
@@ -70,6 +72,7 @@ public class AppChatService(
     public void ResetChat()
     {
         logger.LogInformation("Resetting chat");
+        Id = Guid.NewGuid();
         Messages.Clear();
         _activeStreams.Clear();
         _streamingManager = new AppStreamingMessageManager();

--- a/ChatClient.Api/Client/Services/IAppChatService.cs
+++ b/ChatClient.Api/Client/Services/IAppChatService.cs
@@ -8,6 +8,7 @@ namespace ChatClient.Api.Client.Services;
 public interface IAppChatService
 {
     bool IsAnswering { get; }
+    Guid Id { get; }
     IReadOnlyCollection<AgentDescription> AgentDescriptions { get; }
 
     event Action<bool>? AnsweringStateChanged;

--- a/ChatClient.Shared/Models/SavedChat.cs
+++ b/ChatClient.Shared/Models/SavedChat.cs
@@ -1,0 +1,9 @@
+namespace ChatClient.Shared.Models;
+
+public record SavedChat(
+    Guid Id,
+    string Title,
+    DateTime SavedAt,
+    IReadOnlyList<SavedChatMessage> Messages,
+    IReadOnlyCollection<SavedChatParticipant> Participants);
+

--- a/ChatClient.Shared/Models/SavedChatMessage.cs
+++ b/ChatClient.Shared/Models/SavedChatMessage.cs
@@ -1,0 +1,12 @@
+using Microsoft.Extensions.AI;
+
+namespace ChatClient.Shared.Models;
+
+public record SavedChatMessage(
+    Guid Id,
+    string Content,
+    DateTime MsgDateTime,
+    ChatRole Role,
+    string? AgentId,
+    string? AgentName);
+

--- a/ChatClient.Shared/Models/SavedChatParticipant.cs
+++ b/ChatClient.Shared/Models/SavedChatParticipant.cs
@@ -1,0 +1,9 @@
+using Microsoft.Extensions.AI;
+
+namespace ChatClient.Shared.Models;
+
+public record SavedChatParticipant(
+    string Id,
+    string Name,
+    ChatRole Role);
+

--- a/ChatClient.Tests/ChatViewModelServiceTests.cs
+++ b/ChatClient.Tests/ChatViewModelServiceTests.cs
@@ -13,6 +13,7 @@ public class ChatViewModelServiceTests
     private class StubChatService : IAppChatService
     {
         public bool IsAnswering => false;
+        public Guid Id { get; } = Guid.NewGuid();
         public IReadOnlyCollection<AgentDescription> AgentDescriptions { get; } = [];
 #pragma warning disable CS0067
         public event Action<bool>? AnsweringStateChanged;


### PR DESCRIPTION
## Summary
- introduce models for storing saved chat sessions
- represent saved chat, message, and participant as positional records for immutable snapshots
- add chat session ID so existing IDs flow into saved records

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68b9e2a8006c832a90e31a84d32ba07c