### PR TITLE
Fix null reference in SaveChatDialog

### DIFF
--- a/ChatClient.Api/Client/Components/SaveChatDialog.razor
+++ b/ChatClient.Api/Client/Components/SaveChatDialog.razor
@@ -15,9 +15,9 @@
 </MudDialog>
 
 @code {
-    [CascadingParameter] IDialogReference DialogReference { get; set; } = null!;
+    [CascadingParameter] IMudDialogInstance? Dialog { get; set; }
     private string title = string.Empty;
 
-    private void Cancel() => DialogReference.Close(DialogResult.Cancel());
-    private void Save() => DialogReference.Close(DialogResult.Ok(title));
+    private void Cancel() => (Dialog ?? throw new InvalidOperationException("Dialog reference is missing.")).Cancel();
+    private void Save() => (Dialog ?? throw new InvalidOperationException("Dialog reference is missing.")).Close(DialogResult.Ok(title));
 }


### PR DESCRIPTION
## Summary
- prevent null reference when saving dialog by using IMudDialogInstance and explicit validation

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68bafc3b7350832a99be9ca662a98044