### PR TITLE
Load saved chat after parameters are set

### DIFF
--- a/ChatClient.Api/Client/Pages/Chat.razor
+++ b/ChatClient.Api/Client/Pages/Chat.razor
@@ -248,6 +248,7 @@
     private UserSettings userSettings = new();
 
     private StreamingDebouncer _renderDebouncer = null!;
+    private Guid? lastSavedChatId;
 
     private Func<AppChatMessageViewModel, Task>? _messageAddedHandler;
     private Func<AppChatMessageViewModel, bool, Task>? _messageUpdatedHandler;
@@ -271,11 +272,17 @@
         ChatViewModelService.MessageUpdated += _messageUpdatedHandler;
         ChatViewModelService.MessageDeleted += _messageDeletedHandler;
 
-        if (SavedChatId.HasValue)
-            await LoadSavedChat(SavedChatId.Value);
-
         isLoadingInitialData = false;
         StateHasChanged();
+    }
+
+    protected override async Task OnParametersSetAsync()
+    {
+        if (SavedChatId.HasValue && SavedChatId != lastSavedChatId)
+        {
+            lastSavedChatId = SavedChatId;
+            await LoadSavedChat(SavedChatId.Value);
+        }
     }
 
     private void OnAnsweringStateChanged(bool answering)

--- a/ChatClient.Api/Client/Pages/MultiAgentChat.razor
+++ b/ChatClient.Api/Client/Pages/MultiAgentChat.razor
@@ -288,6 +288,7 @@
     private UserSettings userSettings = new();
 
     private StreamingDebouncer _renderDebouncer = null!;
+    private Guid? lastSavedChatId;
 
     private Func<AppChatMessageViewModel, Task>? _messageAddedHandler;
     private Func<AppChatMessageViewModel, bool, Task>? _messageUpdatedHandler;
@@ -313,11 +314,17 @@
        ChatViewModelService.MessageUpdated += _messageUpdatedHandler;
        ChatViewModelService.MessageDeleted += _messageDeletedHandler;
 
-        if (SavedChatId.HasValue)
-            await LoadSavedChat(SavedChatId.Value);
-
         isLoadingInitialData = false;
         StateHasChanged();
+    }
+
+    protected override async Task OnParametersSetAsync()
+    {
+        if (SavedChatId.HasValue && SavedChatId != lastSavedChatId)
+        {
+            lastSavedChatId = SavedChatId;
+            await LoadSavedChat(SavedChatId.Value);
+        }
     }
 
     private void OnAnsweringStateChanged(bool answering)


### PR DESCRIPTION
## Summary
- handle saved chat query after parameters are bound in Chat and MultiAgentChat components

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68bb0115d830832a83823d2cb362eeff