### PR TITLE
Encapsulate chat state in AppChat model

### DIFF
--- a/ChatClient.Api/Client/Services/AppChatService.cs
+++ b/ChatClient.Api/Client/Services/AppChatService.cs
@@ -29,7 +29,7 @@ public class AppChatService(
     private readonly Dictionary<string, StreamingAppChatMessage> _activeStreams = new();
     private const string PlaceholderAgent = "__placeholder__";
     private const string DeleteMarkerAgent = "?";
-    private Dictionary<string, AgentDescription> _agentsByName = new();
+    private readonly AppChat _chat = new();
 
     public event Action<bool>? AnsweringStateChanged;
     public event Action? ChatReset;
@@ -38,16 +38,16 @@ public class AppChatService(
     public event Func<Guid, Task>? MessageDeleted;
 
     public bool IsAnswering { get; private set; }
-    public Guid Id { get; private set; } = Guid.NewGuid();
-    public ObservableCollection<IAppChatMessage> Messages { get; } = [];
-    IReadOnlyCollection<IAppChatMessage> IAppChatService.Messages => Messages;
+    public Guid Id => _chat.Id;
+    public ObservableCollection<IAppChatMessage> Messages => _chat.Messages;
+    IReadOnlyCollection<IAppChatMessage> IAppChatService.Messages => _chat.Messages;
 
     private TrackingFiltersScope CreateTrackingScope()
     {
         return new TrackingFiltersScope();
     }
 
-    public IReadOnlyCollection<AgentDescription> AgentDescriptions => _agentsByName.Values;
+    public IReadOnlyCollection<AgentDescription> AgentDescriptions => _chat.AgentDescriptions;
 
     public void InitializeChat(IReadOnlyCollection<AgentDescription> agents)
     {
@@ -58,15 +58,11 @@ public class AppChatService(
         if (agents.Count == 0)
             throw new ArgumentException("At least one agent must be selected.", nameof(agents));
 
-        Id = Guid.NewGuid();
-        Messages.Clear();
+        _chat.Reset();
         _activeStreams.Clear();
         _streamingManager = new AppStreamingMessageManager();
 
-        _agentsByName = agents.ToDictionary(
-            desc => desc.AgentId,
-            desc => desc,
-            StringComparer.OrdinalIgnoreCase);
+        _chat.SetAgents(agents);
 
         ChatReset?.Invoke();
     }
@@ -74,11 +70,9 @@ public class AppChatService(
     public void ResetChat()
     {
         logger.LogInformation("Resetting chat");
-        Id = Guid.NewGuid();
-        Messages.Clear();
+        _chat.Reset();
         _activeStreams.Clear();
         _streamingManager = new AppStreamingMessageManager();
-        _agentsByName.Clear();
         ChatReset?.Invoke();
     }
 
@@ -120,6 +114,11 @@ public class AppChatService(
             return;
 
         var userMessage = new AppChatMessage(text, DateTime.Now, ChatRole.User, string.Empty, files);
+        if (_chat.FirstUserMessage is null)
+        {
+            _chat.FirstUserMessage = userMessage;
+            _chat.InitialConfiguration = chatConfiguration;
+        }
         await AddMessageAsync(userMessage);
 
         var placeholder = _activeStreams[PlaceholderAgent] = CreateInitialPlaceholderMessage();
@@ -156,7 +155,9 @@ public class AppChatService(
                 if (firstAgent?.Kernel == null)
                     throw new InvalidOperationException("No agents available or agent kernel is null");
 
-                var agentId = _agentsByName[firstAgent.Name!].Id;
+                if (!_chat.TryGetAgent(firstAgent.Name!, out var desc))
+                    throw new InvalidOperationException($"Agent '{firstAgent.Name}' not found");
+                var agentId = desc!.Id;
                 var built = await chatHistoryBuilder.BuildChatHistoryAsync(filteredMessages, firstAgent.Kernel, agentId, ct);
 
                 var rag = built.FirstOrDefault(m => m.Role == AuthorRole.Tool);
@@ -240,11 +241,11 @@ public class AppChatService(
         AppChatConfiguration chatConfiguration,
         CancellationToken cancellationToken)
     {
-        var agentNames = string.Join(", ", _agentsByName.Keys);
-        logger.LogInformation("Creating {AgentCount} agents: [{AgentNames}]", _agentsByName.Count, agentNames);
+        var agentNames = string.Join(", ", _chat.AgentDescriptions.Select(a => a.AgentId));
+        logger.LogInformation("Creating {AgentCount} agents: [{AgentNames}]", _chat.AgentDescriptions.Count, agentNames);
         List<ChatCompletionAgent> agents = [];
 
-        foreach (var desc in _agentsByName.Values)
+        foreach (var desc in _chat.AgentDescriptions)
         {
             cancellationToken.ThrowIfCancellationRequested();
             var functionsToRegister = await kernelService.GetFunctionsToRegisterAsync(desc.FunctionSettings, userMessage, cancellationToken);
@@ -344,7 +345,7 @@ public class AppChatService(
             {
                 var agentName = streamingContent.AuthorName;
                 if (string.IsNullOrWhiteSpace(agentName))
-                    agentName = _agentsByName.Values.FirstOrDefault()?.AgentName ?? "Assistant";
+                    agentName = _chat.AgentDescriptions.FirstOrDefault()?.AgentName ?? "Assistant";
 
                 if (!_activeStreams.TryGetValue(agentName, out var message))
                 {
@@ -384,7 +385,7 @@ public class AppChatService(
                     await (MessageUpdated?.Invoke(final, true) ?? Task.CompletedTask);
                     _activeStreams.Remove(agentName);
 
-                    if (_agentsByName.Count > 1)
+                    if (_chat.AgentDescriptions.Count > 1)
                     {
                         var next = CreateNextAgentPlaceholder();
                         _activeStreams[PlaceholderAgent] = next;
@@ -499,8 +500,8 @@ public class AppChatService(
 
         var processingTime = DateTime.Now - message.MsgDateTime;
 
-        var modelName = !string.IsNullOrEmpty(message.AgentName) && _agentsByName.TryGetValue(message.AgentName, out var agentDesc)
-            ? agentDesc.ModelName ?? string.Empty
+        var modelName = !string.IsNullOrEmpty(message.AgentName) && _chat.TryGetAgent(message.AgentName, out var agentDesc)
+            ? agentDesc!.ModelName ?? string.Empty
             : string.Empty;
 
         var statistics = _streamingManager.BuildStatistics(

--- a/ChatClient.Shared/Models/AppChat.cs
+++ b/ChatClient.Shared/Models/AppChat.cs
@@ -1,0 +1,37 @@
+using System.Collections.ObjectModel;
+using System.Collections.Generic;
+
+namespace ChatClient.Shared.Models;
+
+public class AppChat
+{
+    private readonly Dictionary<string, AgentDescription> _agentsByName = new(StringComparer.OrdinalIgnoreCase);
+
+    public Guid Id { get; private set; } = Guid.NewGuid();
+    public ObservableCollection<IAppChatMessage> Messages { get; } = [];
+    public IReadOnlyCollection<AgentDescription> AgentDescriptions => _agentsByName.Values;
+    public IAppChatMessage? FirstUserMessage { get; set; }
+    public AppChatConfiguration? InitialConfiguration { get; set; }
+
+    public void SetAgents(IEnumerable<AgentDescription> agents)
+    {
+        _agentsByName.Clear();
+        foreach (var agent in agents)
+        {
+            _agentsByName[agent.AgentId] = agent;
+        }
+    }
+
+    public bool TryGetAgent(string agentId, out AgentDescription? description) =>
+        _agentsByName.TryGetValue(agentId, out description);
+
+    public void Reset()
+    {
+        Id = Guid.NewGuid();
+        Messages.Clear();
+        _agentsByName.Clear();
+        FirstUserMessage = null;
+        InitialConfiguration = null;
+    }
+}
+


### PR DESCRIPTION
## Summary
- encapsulate chat state inside new `AppChat` model
- adapt `AppChatService` to use `AppChat` and track initial chat data

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68bb0a054930832aad7e632d1672407e