### PR TITLE
Reset cached saved chat ID when query cleared

### DIFF
--- a/ChatClient.Api/Client/Pages/Chat.razor
+++ b/ChatClient.Api/Client/Pages/Chat.razor
@@ -278,11 +278,17 @@
 
     protected override async Task OnParametersSetAsync()
     {
-        if (SavedChatId.HasValue && SavedChatId != lastSavedChatId)
+        if (!SavedChatId.HasValue)
         {
-            lastSavedChatId = SavedChatId;
-            await LoadSavedChat(SavedChatId.Value);
+            lastSavedChatId = null;
+            return;
         }
+
+        if (SavedChatId == lastSavedChatId)
+            return;
+
+        lastSavedChatId = SavedChatId;
+        await LoadSavedChat(SavedChatId.Value);
     }
 
     private void OnAnsweringStateChanged(bool answering)
@@ -309,6 +315,7 @@
     private void OnChatReset()
     {
         chatStarted = false;
+        lastSavedChatId = null;
         StateHasChanged();
     }
 

--- a/ChatClient.Api/Client/Pages/MultiAgentChat.razor
+++ b/ChatClient.Api/Client/Pages/MultiAgentChat.razor
@@ -320,11 +320,17 @@
 
     protected override async Task OnParametersSetAsync()
     {
-        if (SavedChatId.HasValue && SavedChatId != lastSavedChatId)
+        if (!SavedChatId.HasValue)
         {
-            lastSavedChatId = SavedChatId;
-            await LoadSavedChat(SavedChatId.Value);
+            lastSavedChatId = null;
+            return;
         }
+
+        if (SavedChatId == lastSavedChatId)
+            return;
+
+        lastSavedChatId = SavedChatId;
+        await LoadSavedChat(SavedChatId.Value);
     }
 
     private void OnAnsweringStateChanged(bool answering)
@@ -351,6 +357,7 @@
     private void OnChatReset()
     {
         chatStarted = true;
+        lastSavedChatId = null;
         StateHasChanged();
     }
 


### PR DESCRIPTION
## Summary
- reset cached saved chat ID when query parameter is missing to allow reloading same chat
- clear saved chat cache on chat reset

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68bb077ddbd4832aaf02e4777acf3d3f