### PR TITLE
Use async dialog API and handle null results

### DIFF
--- a/ChatClient.Api/Client/Pages/Chat.razor
+++ b/ChatClient.Api/Client/Pages/Chat.razor
@@ -414,9 +414,9 @@
             return;
         }
 
-        var dialog = DialogService.Show<SaveChatDialog>("Save Chat");
+        var dialog = await DialogService.ShowAsync<SaveChatDialog>("Save Chat");
         var result = await dialog.Result;
-        if (result.Canceled)
+        if (result?.Canceled != false)
             return;
 
         var title = result.Data as string ?? string.Empty;

--- a/ChatClient.Api/Client/Pages/MultiAgentChat.razor
+++ b/ChatClient.Api/Client/Pages/MultiAgentChat.razor
@@ -530,9 +530,9 @@
             return;
         }
 
-        var dialog = DialogService.Show<SaveChatDialog>("Save Chat");
+        var dialog = await DialogService.ShowAsync<SaveChatDialog>("Save Chat");
         var result = await dialog.Result;
-        if (result.Canceled)
+        if (result?.Canceled != false)
             return;
 
         var title = result.Data as string ?? string.Empty;


### PR DESCRIPTION
## Summary
- replace obsolete `DialogService.Show<T>` with `ShowAsync<T>` in chat saving dialogs
- guard against null or canceled dialog results before processing

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68bb3cf084d4832a92e357c72c713023