### PR TITLE
Refactor chat initialization with session parameters

### DIFF
--- a/ChatClient.Api/Client/Pages/Chat.razor
+++ b/ChatClient.Api/Client/Pages/Chat.razor
@@ -371,7 +371,10 @@
         selectedAgent.ModelName = effectiveModel.ModelName;
         selectedAgent.LlmId = effectiveModel.ServerId;
 
-        ChatService.InitializeChat(agentsForChat);
+        var functions = selectedAgent.FunctionSettings.SelectedFunctions ?? [];
+        var chatConfiguration = new AppChatConfiguration(CurrentModelName, functions);
+        var options = new RoundRobinStopAgentOptions { Rounds = 1 };
+        var groupChatManager = StopAgentFactory.Create("RoundRobin", options);
 
         var savedMessages = saved.Messages
             .Select(m =>
@@ -381,11 +384,12 @@
                 return (IAppChatMessage)msg;
             }).ToList();
 
-        await ChatService.LoadHistoryAsync(savedMessages);
+        var session = new ChatSessionParameters(groupChatManager, chatConfiguration, agentsForChat, savedMessages);
+        await ChatService.StartAsync(session);
         chatStarted = true;
     }
 
-    private void StartChat()
+    private async Task StartChat()
     {
         if (selectedAgent is null)
             return;
@@ -401,7 +405,12 @@
         selectedAgent.ModelName = effectiveModel.ModelName;
         selectedAgent.LlmId = effectiveModel.ServerId;
 
-        ChatService.InitializeChat(agents);
+        var functions = selectedAgent.FunctionSettings.SelectedFunctions ?? [];
+        var chatConfiguration = new AppChatConfiguration(CurrentModelName, functions);
+        var options = new RoundRobinStopAgentOptions { Rounds = 1 };
+        var groupChatManager = StopAgentFactory.Create("RoundRobin", options);
+        var session = new ChatSessionParameters(groupChatManager, chatConfiguration, agents);
+        await ChatService.StartAsync(session);
         chatStarted = true;
         StateHasChanged();
     }
@@ -450,12 +459,7 @@
         if (string.IsNullOrWhiteSpace(messageData.text) || isLLMAnswering) return;
         if (selectedAgent == null) return;
 
-        var functions = selectedAgent.FunctionSettings.SelectedFunctions ?? [];
-        var chatConfiguration = new AppChatConfiguration(CurrentModelName, functions);
-        var options = new RoundRobinStopAgentOptions { Rounds = 1 };
-        var groupChatManager = StopAgentFactory.Create("RoundRobin", options);
-        
-        await ChatService.GenerateAnswerAsync(messageData.text.Trim(), chatConfiguration, groupChatManager, messageData.files);
+        await ChatService.SendAsync(messageData.text.Trim(), messageData.files);
         await ScrollToBottom();
     }
 

--- a/ChatClient.Api/Client/Pages/MultiAgentChat.razor
+++ b/ChatClient.Api/Client/Pages/MultiAgentChat.razor
@@ -440,7 +440,10 @@
         }
 
         currentModelName = selectedAgents[0].ModelName!;
-        ChatService.InitializeChat(selectedAgents);
+
+        var manager = StopAgentFactory.Create(stopAgentName, stopAgentOptions);
+        var allFunctions = selectedAgents.SelectMany(a => a.FunctionSettings.SelectedFunctions ?? []).ToList();
+        var chatConfiguration = new AppChatConfiguration(currentModelName, allFunctions);
 
         var savedMessages = saved.Messages
             .Select(m =>
@@ -450,7 +453,8 @@
                 return (IAppChatMessage)msg;
             }).ToList();
 
-        await ChatService.LoadHistoryAsync(savedMessages);
+        var session = new ChatSessionParameters(manager, chatConfiguration, selectedAgents, savedMessages);
+        await ChatService.StartAsync(session);
         chatStarted = true;
     }
     
@@ -517,7 +521,10 @@
             }
         }
         
-        ChatService.InitializeChat(agentsForChat);
+        var allFunctions = agentsForChat.SelectMany(a => a.FunctionSettings.SelectedFunctions ?? []).ToList();
+        var chatConfiguration = new AppChatConfiguration(currentModelName!, allFunctions);
+        var session = new ChatSessionParameters(manager, chatConfiguration, agentsForChat);
+        await ChatService.StartAsync(session);
         chatStarted = true;
         StateHasChanged();
     }
@@ -566,28 +573,7 @@
         if (string.IsNullOrWhiteSpace(messageData.text) || isLLMAnswering)
             return;
 
-        var allFunctions = selectedAgents
-            .SelectMany(a => a.FunctionSettings.SelectedFunctions)
-            .Distinct()
-            .ToList();
-
-        var options = stopAgentOptions;
-        if (selectedAgents.Count == 1)
-        {
-            switch (options)
-            {
-                case RoundRobinStopAgentOptions rr:
-                    rr.Rounds = 1;
-                    break;
-                case RoundRobinSummaryStopAgentOptions rs:
-                    rs.Rounds = 1;
-                    break;
-            }
-        }
-        var groupChatManager = StopAgentFactory.Create(stopAgentName, options);
-        var chatConfiguration = new AppChatConfiguration(currentModelName!, allFunctions);
-
-        await ChatService.GenerateAnswerAsync(messageData.text.Trim(), chatConfiguration, groupChatManager, messageData.files);
+        await ChatService.SendAsync(messageData.text.Trim(), messageData.files);
         await ScrollToBottom();
     }
 

--- a/ChatClient.Api/Client/Services/IAppChatService.cs
+++ b/ChatClient.Api/Client/Services/IAppChatService.cs
@@ -1,8 +1,5 @@
 using ChatClient.Shared.Models;
 
-
-using Microsoft.SemanticKernel.Agents.Orchestration.GroupChat;
-
 namespace ChatClient.Api.Client.Services;
 
 public interface IAppChatService
@@ -18,14 +15,10 @@ public interface IAppChatService
     event Func<IAppChatMessage, bool, Task>? MessageUpdated;
     event Func<Guid, Task>? MessageDeleted;
 
-    void InitializeChat(IReadOnlyCollection<AgentDescription> initialAgents);
+    Task StartAsync(ChatSessionParameters parameters);
     void ResetChat();
     Task CancelAsync();
-
-    Task GenerateAnswerAsync(string text, AppChatConfiguration chatConfiguration, GroupChatManager groupChatManager, IReadOnlyList<AppChatMessageFile>? files = null);
-
-    Task LoadHistoryAsync(IEnumerable<IAppChatMessage> messages);
-
+    Task SendAsync(string text, IReadOnlyList<AppChatMessageFile>? files = null);
+    ChatSessionParameters GetState();
     Task DeleteMessageAsync(Guid id);
 }
-

--- a/ChatClient.Shared/ChatClient.Shared.csproj
+++ b/ChatClient.Shared/ChatClient.Shared.csproj
@@ -4,12 +4,14 @@
     <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <NoWarn>$(NoWarn);SKEXP0070;SKEXP0110</NoWarn>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.AI" Version="9.8.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="9.0.8" />
     <PackageReference Include="Microsoft.SemanticKernel" Version="1.64.0" />
     <PackageReference Include="Microsoft.SemanticKernel.Abstractions" Version="1.64.0" />
+    <PackageReference Include="Microsoft.SemanticKernel.Agents.Orchestration" Version="1.64.0-preview" />
   </ItemGroup>
 
 </Project>

--- a/ChatClient.Shared/Models/ChatSessionParameters.cs
+++ b/ChatClient.Shared/Models/ChatSessionParameters.cs
@@ -1,0 +1,23 @@
+using Microsoft.SemanticKernel.Agents.Orchestration.GroupChat;
+
+namespace ChatClient.Shared.Models;
+
+public class ChatSessionParameters
+{
+    public ChatSessionParameters(
+        GroupChatManager groupChatManager,
+        AppChatConfiguration configuration,
+        IEnumerable<AgentDescription> agents,
+        IEnumerable<IAppChatMessage>? history = null)
+    {
+        GroupChatManager = groupChatManager ?? throw new ArgumentNullException(nameof(groupChatManager));
+        Configuration = configuration ?? throw new ArgumentNullException(nameof(configuration));
+        Agents = agents?.ToList() ?? throw new ArgumentNullException(nameof(agents));
+        History = history?.ToList() ?? [];
+    }
+
+    public GroupChatManager GroupChatManager { get; }
+    public AppChatConfiguration Configuration { get; }
+    public IReadOnlyList<AgentDescription> Agents { get; }
+    public IReadOnlyList<IAppChatMessage> History { get; }
+}

--- a/ChatClient.Tests/ChatViewModelServiceTests.cs
+++ b/ChatClient.Tests/ChatViewModelServiceTests.cs
@@ -24,14 +24,11 @@ public class ChatViewModelServiceTests
         public event Func<IAppChatMessage, bool, Task>? MessageUpdated;
         public event Func<Guid, Task>? MessageDeleted;
 
-        public void InitializeChat(IReadOnlyCollection<AgentDescription> initialAgents) { }
+        public Task StartAsync(ChatSessionParameters parameters) => Task.CompletedTask;
         public void ResetChat() { }
         public Task CancelAsync() => Task.CompletedTask;
-
-        public Task GenerateAnswerAsync(string text, AppChatConfiguration chatConfiguration, GroupChatManager groupChatManager, IReadOnlyList<AppChatMessageFile>? files = null) => Task.CompletedTask;
-
-        public Task LoadHistoryAsync(IEnumerable<IAppChatMessage> messages) => Task.CompletedTask;
-
+        public Task SendAsync(string text, IReadOnlyList<AppChatMessageFile>? files = null) => Task.CompletedTask;
+        public ChatSessionParameters GetState() => throw new NotImplementedException();
         public Task DeleteMessageAsync(Guid id) => Task.CompletedTask;
 
         public Task RaiseMessageAdded(IAppChatMessage message) => MessageAdded?.Invoke(message) ?? Task.CompletedTask;


### PR DESCRIPTION
## Summary
- introduce ChatSessionParameters to encapsulate chat start data
- refactor AppChatService and interface to use session parameters and single SendAsync
- update UI pages and tests for new initialization flow

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68bbe939aa5c832ab55d290d63496787