### PR TITLE
Use saved chat ID directly

### DIFF
--- a/ChatClient.Api/Client/Pages/Chat.razor
+++ b/ChatClient.Api/Client/Pages/Chat.razor
@@ -248,7 +248,6 @@
     private UserSettings userSettings = new();
 
     private StreamingDebouncer _renderDebouncer = null!;
-    private Guid? lastSavedChatId;
 
     private Func<AppChatMessageViewModel, Task>? _messageAddedHandler;
     private Func<AppChatMessageViewModel, bool, Task>? _messageUpdatedHandler;
@@ -278,17 +277,8 @@
 
     protected override async Task OnParametersSetAsync()
     {
-        if (!SavedChatId.HasValue)
-        {
-            lastSavedChatId = null;
-            return;
-        }
-
-        if (SavedChatId == lastSavedChatId)
-            return;
-
-        lastSavedChatId = SavedChatId;
-        await LoadSavedChat(SavedChatId.Value);
+        if (SavedChatId.HasValue && !chatStarted)
+            await LoadSavedChat(SavedChatId.Value);
     }
 
     private void OnAnsweringStateChanged(bool answering)
@@ -315,7 +305,6 @@
     private void OnChatReset()
     {
         chatStarted = false;
-        lastSavedChatId = null;
         StateHasChanged();
     }
 
@@ -449,9 +438,15 @@
                 m.AgentName))
             .ToList();
 
-        var chat = new SavedChat(Guid.NewGuid(), title, DateTime.UtcNow, messages, participants);
+        var chatId = SavedChatId ?? Guid.NewGuid();
+        var chat = new SavedChat(chatId, title, DateTime.UtcNow, messages, participants);
         await SavedChatService.SaveAsync(chat);
+
+        var isNew = !SavedChatId.HasValue;
+        SavedChatId = chatId;
         Snackbar.Add("Chat saved", Severity.Success);
+        if (isNew)
+            NavigationManager.NavigateTo(NavigationManager.GetUriWithQueryParameter("saved", chatId));
     }
 
     private async Task SendChatMessageAsync((string text, IReadOnlyList<AppChatMessageFile> files) messageData)

--- a/ChatClient.Api/Client/Pages/MultiAgentChat.razor
+++ b/ChatClient.Api/Client/Pages/MultiAgentChat.razor
@@ -288,7 +288,6 @@
     private UserSettings userSettings = new();
 
     private StreamingDebouncer _renderDebouncer = null!;
-    private Guid? lastSavedChatId;
 
     private Func<AppChatMessageViewModel, Task>? _messageAddedHandler;
     private Func<AppChatMessageViewModel, bool, Task>? _messageUpdatedHandler;
@@ -320,17 +319,8 @@
 
     protected override async Task OnParametersSetAsync()
     {
-        if (!SavedChatId.HasValue)
-        {
-            lastSavedChatId = null;
-            return;
-        }
-
-        if (SavedChatId == lastSavedChatId)
-            return;
-
-        lastSavedChatId = SavedChatId;
-        await LoadSavedChat(SavedChatId.Value);
+        if (SavedChatId.HasValue && !chatStarted)
+            await LoadSavedChat(SavedChatId.Value);
     }
 
     private void OnAnsweringStateChanged(bool answering)
@@ -356,8 +346,7 @@
 
     private void OnChatReset()
     {
-        chatStarted = true;
-        lastSavedChatId = null;
+        chatStarted = false;
         StateHasChanged();
     }
 
@@ -563,9 +552,15 @@
                 m.AgentName))
             .ToList();
 
-        var chat = new SavedChat(Guid.NewGuid(), title, DateTime.UtcNow, messages, participants);
+        var chatId = SavedChatId ?? Guid.NewGuid();
+        var chat = new SavedChat(chatId, title, DateTime.UtcNow, messages, participants);
         await SavedChatService.SaveAsync(chat);
+
+        var isNew = !SavedChatId.HasValue;
+        SavedChatId = chatId;
         Snackbar.Add("Chat saved", Severity.Success);
+        if (isNew)
+            NavigationManager.NavigateTo(NavigationManager.GetUriWithQueryParameter("saved", chatId));
     }
 
     private async Task SendChatMessageAsync((string text, IReadOnlyList<AppChatMessageFile> files) messageData)


### PR DESCRIPTION
## Summary
- Remove lastSavedChatId tracking
- Persist chat ID after save and reuse existing ID

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68bbf809f6a4832ab1be962ca17c8a39