### PR TITLE
Reload saved chats when switching conversations

### DIFF
--- a/ChatClient.Api/Client/Pages/Chat.razor
+++ b/ChatClient.Api/Client/Pages/Chat.razor
@@ -226,6 +226,7 @@
     private bool isLLMAnswering { get; set; } = false;
     private bool isLoadingInitialData = true;
     private bool chatStarted = false;
+    private Guid? lastSavedChatId;
     private ElementReference messagesElement;
 
     private List<AgentDescription> agents = new();
@@ -277,7 +278,7 @@
 
     protected override async Task OnParametersSetAsync()
     {
-        if (SavedChatId.HasValue && !chatStarted)
+        if (SavedChatId.HasValue && SavedChatId != lastSavedChatId)
             await LoadSavedChat(SavedChatId.Value);
     }
 
@@ -305,6 +306,7 @@
     private void OnChatReset()
     {
         chatStarted = false;
+        lastSavedChatId = null;
         StateHasChanged();
     }
 
@@ -376,6 +378,7 @@
         var session = new ChatSessionParameters(groupChatManager, chatConfiguration, agentsForChat, savedMessages);
         await ChatService.StartAsync(session);
         chatStarted = true;
+        lastSavedChatId = id;
     }
 
     private async Task StartChat()

--- a/ChatClient.Api/Client/Pages/MultiAgentChat.razor
+++ b/ChatClient.Api/Client/Pages/MultiAgentChat.razor
@@ -250,6 +250,7 @@
 
     private bool isLoadingInitialData = true;
     private bool chatStarted = false;
+    private Guid? lastSavedChatId;
     private ElementReference messagesElement;
 
     private List<AgentDescription> agents = new();
@@ -319,7 +320,7 @@
 
     protected override async Task OnParametersSetAsync()
     {
-        if (SavedChatId.HasValue && !chatStarted)
+        if (SavedChatId.HasValue && SavedChatId != lastSavedChatId)
             await LoadSavedChat(SavedChatId.Value);
     }
 
@@ -347,6 +348,7 @@
     private void OnChatReset()
     {
         chatStarted = false;
+        lastSavedChatId = null;
         StateHasChanged();
     }
 
@@ -445,6 +447,7 @@
         var session = new ChatSessionParameters(manager, chatConfiguration, selectedAgents, savedMessages);
         await ChatService.StartAsync(session);
         chatStarted = true;
+        lastSavedChatId = id;
     }
     
     private async Task StartChat()


### PR DESCRIPTION
## Summary
- Track last loaded chat ID to ensure navigating to a new saved chat reloads conversation
- Clear last loaded ID when chat is reset

## Testing
- `dotnet test ChatClient.Tests/ChatClient.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68bc1414348c832aa67820be90a2c4ee