### PR TITLE
Replace streaming placeholders with final messages

### DIFF
--- a/ChatClient.Api/Client/Services/AppChatService.cs
+++ b/ChatClient.Api/Client/Services/AppChatService.cs
@@ -103,7 +103,11 @@ public class AppChatService(
             }
 
             var canceled = _streamingManager.CancelStreaming(message);
-            Messages.Add(canceled);
+            var index = Messages.IndexOf(message);
+            if (index >= 0)
+                Messages[index] = canceled;
+            else
+                Messages.Add(canceled);
             await (MessageUpdated?.Invoke(canceled, true) ?? Task.CompletedTask);
         }
         _activeStreams.Clear();
@@ -395,7 +399,11 @@ public class AppChatService(
                 if (isFinal)
                 {
                     var final = CompleteStreamingMessage(message, functionCount, trackingScope);
-                    Messages.Add(final);
+                    var index = Messages.IndexOf(message);
+                    if (index >= 0)
+                        Messages[index] = final;
+                    else
+                        Messages.Add(final);
                     await (MessageUpdated?.Invoke(final, true) ?? Task.CompletedTask);
                     _activeStreams.Remove(agentName);
 


### PR DESCRIPTION
## Summary
- replace streaming placeholders in message list with final messages
- ensure canceled streams replace placeholders

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68bc1799f308832a94a06239f007eb41