### PR TITLE
Ensure chat services clean up event handlers and cancel sessions

### DIFF
--- a/ChatClient.Api/Client/Pages/Chat.razor
+++ b/ChatClient.Api/Client/Pages/Chat.razor
@@ -506,8 +506,10 @@
         await JSRuntime.InvokeVoidAsync("copyText", text);
     }
 
-    public ValueTask DisposeAsync()
+    public async ValueTask DisposeAsync()
     {
+        await ChatService.CancelAsync();
+        ChatService.ResetChat();
         ChatService.AnsweringStateChanged -= OnAnsweringStateChanged;
         ChatViewModelService.ChatReset -= OnChatReset;
         if (_messageAddedHandler != null)
@@ -516,7 +518,6 @@
             ChatViewModelService.MessageUpdated -= _messageUpdatedHandler;
         if (_messageDeletedHandler != null)
             ChatViewModelService.MessageDeleted -= _messageDeletedHandler;
-        return ValueTask.CompletedTask;
     }
 
     private string GetFileIcon(string contentType)

--- a/ChatClient.Api/Client/Pages/MultiAgentChat.razor
+++ b/ChatClient.Api/Client/Pages/MultiAgentChat.razor
@@ -620,8 +620,10 @@
         await JSRuntime.InvokeVoidAsync("copyText", text);
     }
 
-    public ValueTask DisposeAsync()
+    public async ValueTask DisposeAsync()
     {
+        await ChatService.CancelAsync();
+        ChatService.ResetChat();
         ChatService.AnsweringStateChanged -= OnAnsweringStateChanged;
         ChatViewModelService.ChatReset -= OnChatReset;
         if (_messageAddedHandler != null)
@@ -630,7 +632,6 @@
             ChatViewModelService.MessageUpdated -= _messageUpdatedHandler;
         if (_messageDeletedHandler != null)
             ChatViewModelService.MessageDeleted -= _messageDeletedHandler;
-        return ValueTask.CompletedTask;
     }
 
     private string GetFileIcon(string contentType)


### PR DESCRIPTION
## Summary
- Dispose ChatViewModelService event subscriptions to avoid leaks
- Cancel and reset chat sessions when leaving Chat and MultiAgentChat pages

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68bc165ece0c832ab6cdedf7c198925a