### PR TITLE
fix: dispose chat event handlers

### DIFF
--- a/ChatClient.Api/Client/Pages/Chat.razor
+++ b/ChatClient.Api/Client/Pages/Chat.razor
@@ -508,8 +508,6 @@
 
     public async ValueTask DisposeAsync()
     {
-        await ChatService.CancelAsync();
-        ChatService.ResetChat();
         ChatService.AnsweringStateChanged -= OnAnsweringStateChanged;
         ChatViewModelService.ChatReset -= OnChatReset;
         if (_messageAddedHandler != null)
@@ -518,6 +516,10 @@
             ChatViewModelService.MessageUpdated -= _messageUpdatedHandler;
         if (_messageDeletedHandler != null)
             ChatViewModelService.MessageDeleted -= _messageDeletedHandler;
+
+        await ChatViewModelService.DisposeAsync();
+        await ChatService.CancelAsync();
+        ChatService.ResetChat();
     }
 
     private string GetFileIcon(string contentType)

--- a/ChatClient.Api/Client/Pages/MultiAgentChat.razor
+++ b/ChatClient.Api/Client/Pages/MultiAgentChat.razor
@@ -622,8 +622,6 @@
 
     public async ValueTask DisposeAsync()
     {
-        await ChatService.CancelAsync();
-        ChatService.ResetChat();
         ChatService.AnsweringStateChanged -= OnAnsweringStateChanged;
         ChatViewModelService.ChatReset -= OnChatReset;
         if (_messageAddedHandler != null)
@@ -632,6 +630,10 @@
             ChatViewModelService.MessageUpdated -= _messageUpdatedHandler;
         if (_messageDeletedHandler != null)
             ChatViewModelService.MessageDeleted -= _messageDeletedHandler;
+
+        await ChatViewModelService.DisposeAsync();
+        await ChatService.CancelAsync();
+        ChatService.ResetChat();
     }
 
     private string GetFileIcon(string contentType)

--- a/ChatClient.Api/Client/Services/IChatViewModelService.cs
+++ b/ChatClient.Api/Client/Services/IChatViewModelService.cs
@@ -1,7 +1,8 @@
+using System;
 using ChatClient.Api.Client.ViewModels;
 namespace ChatClient.Api.Client.Services;
 
-public interface IChatViewModelService
+public interface IChatViewModelService : IAsyncDisposable
 {
     IReadOnlyList<AppChatMessageViewModel> Messages { get; }
     bool IsAnswering { get; }


### PR DESCRIPTION
## Summary
- stop chat pages from handling events during teardown
- dispose chat view model service to unregister from chat service events
- expose async disposal on chat view model interface

## Testing
- `CI=1 dotnet test > /tmp/test.log && tail -n 20 /tmp/test.log`


------
https://chatgpt.com/codex/tasks/task_e_68bc33eb9f78832a8999cb9d419b8d9f