### PR TITLE
Use MessageUpdateOptions for message update events

### DIFF
--- a/ChatClient.Api/Client/Pages/Chat.razor
+++ b/ChatClient.Api/Client/Pages/Chat.razor
@@ -255,7 +255,7 @@
     private StreamingDebouncer _renderDebouncer = null!;
 
     private Func<AppChatMessageViewModel, Task>? _messageAddedHandler;
-    private Func<AppChatMessageViewModel, bool, Task>? _messageUpdatedHandler;
+    private Func<AppChatMessageViewModel, MessageUpdateOptions, Task>? _messageUpdatedHandler;
     private Func<AppChatMessageViewModel, Task>? _messageDeletedHandler;
 
     protected override async Task OnInitializedAsync()
@@ -270,7 +270,7 @@
         ChatViewModelService.ChatReset += OnChatReset;
         _renderDebouncer = new StreamingDebouncer(UpdateIntervalMs, () => InvokeAsync(StateHasChanged));
         _messageAddedHandler = msg => InvokeAsync(() => OnMessageAdded(msg));
-        _messageUpdatedHandler = (msg, force) => InvokeAsync(() => OnMessageUpdated(msg, force));
+        _messageUpdatedHandler = (msg, opts) => InvokeAsync(() => OnMessageUpdated(msg, opts));
         _messageDeletedHandler = msg => InvokeAsync(() => OnMessageDeleted(msg));
         ChatViewModelService.MessageAdded += _messageAddedHandler;
         ChatViewModelService.MessageUpdated += _messageUpdatedHandler;
@@ -297,9 +297,9 @@
         StateHasChanged();
         await ScrollToBottom();
     }    
-    private Task OnMessageUpdated(AppChatMessageViewModel message, bool forceRender)
+    private Task OnMessageUpdated(AppChatMessageViewModel message, MessageUpdateOptions options)
     {
-        return _renderDebouncer.TriggerAsync(forceRender);
+        return _renderDebouncer.TriggerAsync(options);
     }
 
     private void OnMessageDeleted(AppChatMessageViewModel message)

--- a/ChatClient.Api/Client/Pages/MultiAgentChat.razor
+++ b/ChatClient.Api/Client/Pages/MultiAgentChat.razor
@@ -291,7 +291,7 @@
     private StreamingDebouncer _renderDebouncer = null!;
 
     private Func<AppChatMessageViewModel, Task>? _messageAddedHandler;
-    private Func<AppChatMessageViewModel, bool, Task>? _messageUpdatedHandler;
+    private Func<AppChatMessageViewModel, MessageUpdateOptions, Task>? _messageUpdatedHandler;
     private Func<AppChatMessageViewModel, Task>? _messageDeletedHandler;
 
     protected override async Task OnInitializedAsync()
@@ -308,7 +308,7 @@
         ChatViewModelService.ChatReset += OnChatReset;
         _renderDebouncer = new StreamingDebouncer(UpdateIntervalMs, () => InvokeAsync(StateHasChanged));
         _messageAddedHandler = msg => InvokeAsync(() => OnMessageAdded(msg));
-        _messageUpdatedHandler = (msg, force) => InvokeAsync(() => OnMessageUpdated(msg, force));
+        _messageUpdatedHandler = (msg, opts) => InvokeAsync(() => OnMessageUpdated(msg, opts));
         _messageDeletedHandler = msg => InvokeAsync(() => OnMessageDeleted(msg));
         ChatViewModelService.MessageAdded += _messageAddedHandler;
        ChatViewModelService.MessageUpdated += _messageUpdatedHandler;
@@ -335,9 +335,9 @@
         StateHasChanged();
         await ScrollToBottom();
     }    
-    private Task OnMessageUpdated(AppChatMessageViewModel message, bool forceRender)
+    private Task OnMessageUpdated(AppChatMessageViewModel message, MessageUpdateOptions options)
     {
-        return _renderDebouncer.TriggerAsync(forceRender);
+        return _renderDebouncer.TriggerAsync(options);
     }
 
     private void OnMessageDeleted(AppChatMessageViewModel message)

--- a/ChatClient.Api/Client/Services/IAppChatService.cs
+++ b/ChatClient.Api/Client/Services/IAppChatService.cs
@@ -12,7 +12,7 @@ public interface IAppChatService
     event Action<bool>? AnsweringStateChanged;
     event Action? ChatReset;
     event Func<IAppChatMessage, Task>? MessageAdded;
-    event Func<IAppChatMessage, bool, Task>? MessageUpdated;
+    event Func<IAppChatMessage, MessageUpdateOptions, Task>? MessageUpdated;
     event Func<Guid, Task>? MessageDeleted;
 
     Task StartAsync(ChatSessionParameters parameters);

--- a/ChatClient.Api/Client/Services/IChatViewModelService.cs
+++ b/ChatClient.Api/Client/Services/IChatViewModelService.cs
@@ -9,6 +9,6 @@ public interface IChatViewModelService : IAsyncDisposable
     event Action<bool>? AnsweringStateChanged;
     event Action? ChatReset;
     event Func<AppChatMessageViewModel, Task>? MessageAdded;
-    event Func<AppChatMessageViewModel, bool, Task>? MessageUpdated;
+    event Func<AppChatMessageViewModel, MessageUpdateOptions, Task>? MessageUpdated;
     event Func<AppChatMessageViewModel, Task>? MessageDeleted;
 }

--- a/ChatClient.Api/Client/Services/MessageUpdateOptions.cs
+++ b/ChatClient.Api/Client/Services/MessageUpdateOptions.cs
@@ -1,0 +1,4 @@
+namespace ChatClient.Api.Client.Services;
+
+public readonly record struct MessageUpdateOptions(bool ForceRender);
+

--- a/ChatClient.Api/Client/Services/StreamingDebouncer.cs
+++ b/ChatClient.Api/Client/Services/StreamingDebouncer.cs
@@ -19,11 +19,11 @@ public sealed class StreamingDebouncer
     /// <summary>
     /// Triggers the update callback if the debounce interval has elapsed or when forced.
     /// </summary>
-    public Task TriggerAsync(bool forceRender = false)
+    public Task TriggerAsync(MessageUpdateOptions options = default)
     {
         var now = DateTime.UtcNow;
 
-        if (forceRender || (now - _lastUpdate).TotalMilliseconds >= _debounceDelayMs)
+        if (options.ForceRender || (now - _lastUpdate).TotalMilliseconds >= _debounceDelayMs)
         {
             _lastUpdate = now;
             return _onUpdate();

--- a/ChatClient.Tests/ChatViewModelServiceTests.cs
+++ b/ChatClient.Tests/ChatViewModelServiceTests.cs
@@ -21,7 +21,7 @@ public class ChatViewModelServiceTests
         public event Action? ChatReset;
 #pragma warning restore CS0067
         public event Func<IAppChatMessage, Task>? MessageAdded;
-        public event Func<IAppChatMessage, bool, Task>? MessageUpdated;
+        public event Func<IAppChatMessage, MessageUpdateOptions, Task>? MessageUpdated;
         public event Func<Guid, Task>? MessageDeleted;
 
         public Task StartAsync(ChatSessionParameters parameters) => Task.CompletedTask;
@@ -32,7 +32,7 @@ public class ChatViewModelServiceTests
         public Task DeleteMessageAsync(Guid id) => Task.CompletedTask;
 
         public Task RaiseMessageAdded(IAppChatMessage message) => MessageAdded?.Invoke(message) ?? Task.CompletedTask;
-        public Task RaiseMessageUpdated(IAppChatMessage message, bool forceRender = false) => MessageUpdated?.Invoke(message, forceRender) ?? Task.CompletedTask;
+        public Task RaiseMessageUpdated(IAppChatMessage message, MessageUpdateOptions options = default) => MessageUpdated?.Invoke(message, options) ?? Task.CompletedTask;
         public Task RaiseMessageDeleted(Guid id) => MessageDeleted?.Invoke(id) ?? Task.CompletedTask;
     }
 


### PR DESCRIPTION
## Summary
- replace `bool` MessageUpdated parameter with `MessageUpdateOptions`
- update event invocations, debouncer, and UI subscribers
- adjust tests for new message update options

## Testing
- `dotnet test ChatClient.Tests/ChatClient.Tests.csproj --no-restore -p:ConsoleLoggerParameters="NoSummary" -v m`


------
https://chatgpt.com/codex/tasks/task_e_68bc3d02c928832a9451235a341f6d83