### PR TITLE
Fix single-agent chat stopping after first turn

### DIFF
--- a/ChatClient.Api/Client/Services/AppChatService.cs
+++ b/ChatClient.Api/Client/Services/AppChatService.cs
@@ -11,6 +11,7 @@ using Microsoft.SemanticKernel.ChatCompletion;
 using OllamaSharp.Models.Exceptions;
 using System.Collections.ObjectModel;
 using System.Linq;
+using System.Reflection;
 
 namespace ChatClient.Api.Client.Services;
 
@@ -207,6 +208,7 @@ public class AppChatService(
         {
             CleanupWithoutTrackingFilters();
             await FinalizeProcessing(trackingScope.Filters.Values.Sum(f => f.Records.Count), trackingScope);
+            ResetInvocationCount(groupChatManager);
         }
     }
 
@@ -563,6 +565,12 @@ public class AppChatService(
         _cancellationTokenSource?.Dispose();
         _cancellationTokenSource = null;
         UpdateAnsweringState(false);
+    }
+
+    private static void ResetInvocationCount(GroupChatManager manager)
+    {
+        var field = typeof(GroupChatManager).GetField("_invocationCount", BindingFlags.Instance | BindingFlags.NonPublic);
+        field?.SetValue(manager, 0);
     }
 
     private void UpdateAnsweringState(bool isAnswering)


### PR DESCRIPTION
## Summary
- reset group chat manager invocation count after each user message
- keep stop agent round limit at one so each question gets a single reply

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68bc4bff0ac0832ab87464c5a84f13b2