### PR TITLE
Prefill title when saving existing chat

### DIFF
--- a/ChatClient.Api/Client/Components/SaveChatDialog.razor
+++ b/ChatClient.Api/Client/Components/SaveChatDialog.razor
@@ -16,7 +16,10 @@
 
 @code {
     [CascadingParameter] IMudDialogInstance? Dialog { get; set; }
+    [Parameter] public string InitialTitle { get; set; } = string.Empty;
     private string title = string.Empty;
+
+    protected override void OnInitialized() => title = InitialTitle;
 
     private void Cancel() => (Dialog ?? throw new InvalidOperationException("Dialog reference is missing.")).Cancel();
     private void Save() => (Dialog ?? throw new InvalidOperationException("Dialog reference is missing.")).Close(DialogResult.Ok(title));

--- a/ChatClient.Api/Client/Pages/Chat.razor
+++ b/ChatClient.Api/Client/Pages/Chat.razor
@@ -231,6 +231,7 @@
     private bool isLoadingInitialData = true;
     private bool chatStarted = false;
     private Guid? lastSavedChatId;
+    private string lastSavedChatTitle = string.Empty;
     private ElementReference messagesElement;
 
     private List<AgentDescription> agents = new();
@@ -311,6 +312,7 @@
     {
         chatStarted = false;
         lastSavedChatId = null;
+        lastSavedChatTitle = string.Empty;
         StateHasChanged();
     }
 
@@ -383,6 +385,7 @@
         await ChatService.StartAsync(session);
         chatStarted = true;
         lastSavedChatId = id;
+        lastSavedChatTitle = saved.Title;
     }
 
     private async Task StartChat()
@@ -419,7 +422,11 @@
             return;
         }
 
-        var dialog = await DialogService.ShowAsync<SaveChatDialog>("Save Chat");
+        var parameters = new DialogParameters
+        {
+            ["InitialTitle"] = SavedChatId.HasValue ? lastSavedChatTitle : string.Empty
+        };
+        var dialog = await DialogService.ShowAsync<SaveChatDialog>("Save Chat", parameters);
         var result = await dialog.Result;
         if (result?.Canceled != false)
             return;
@@ -451,6 +458,7 @@
 
         var isNew = !SavedChatId.HasValue;
         SavedChatId = chatId;
+        lastSavedChatTitle = title;
         Snackbar.Add("Chat saved", Severity.Success);
         if (isNew)
             NavigationManager.NavigateTo(NavigationManager.GetUriWithQueryParameter("saved", chatId));

--- a/ChatClient.Api/Client/Pages/MultiAgentChat.razor
+++ b/ChatClient.Api/Client/Pages/MultiAgentChat.razor
@@ -251,6 +251,7 @@
     private bool isLoadingInitialData = true;
     private bool chatStarted = false;
     private Guid? lastSavedChatId;
+    private string lastSavedChatTitle = string.Empty;
     private ElementReference messagesElement;
 
     private List<AgentDescription> agents = new();
@@ -349,6 +350,7 @@
     {
         chatStarted = false;
         lastSavedChatId = null;
+        lastSavedChatTitle = string.Empty;
         StateHasChanged();
     }
 
@@ -448,6 +450,7 @@
         await ChatService.StartAsync(session);
         chatStarted = true;
         lastSavedChatId = id;
+        lastSavedChatTitle = saved.Title;
     }
     
     private async Task StartChat()
@@ -529,7 +532,11 @@
             return;
         }
 
-        var dialog = await DialogService.ShowAsync<SaveChatDialog>("Save Chat");
+        var parameters = new DialogParameters
+        {
+            ["InitialTitle"] = SavedChatId.HasValue ? lastSavedChatTitle : string.Empty
+        };
+        var dialog = await DialogService.ShowAsync<SaveChatDialog>("Save Chat", parameters);
         var result = await dialog.Result;
         if (result?.Canceled != false)
             return;
@@ -561,6 +568,7 @@
 
         var isNew = !SavedChatId.HasValue;
         SavedChatId = chatId;
+        lastSavedChatTitle = title;
         Snackbar.Add("Chat saved", Severity.Success);
         if (isNew)
             NavigationManager.NavigateTo(NavigationManager.GetUriWithQueryParameter("saved", chatId));


### PR DESCRIPTION
## Summary
- prefill save chat dialog with existing title
- track last saved chat title to enable overwriting chats

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68bc5f9a2bc0832a86572692c5c8f901