### PR TITLE
Validate RAG file names

### DIFF
--- a/ChatClient.Api/Controllers/RagFilesController.cs
+++ b/ChatClient.Api/Controllers/RagFilesController.cs
@@ -25,6 +25,14 @@ public class RagFilesController : ControllerBase
     [HttpGet("{fileName}")]
     public async Task<ActionResult<RagFile>> GetFile(Guid id, string fileName)
     {
+        try
+        {
+            FileNameValidator.Validate(fileName);
+        }
+        catch (ArgumentException)
+        {
+            return BadRequest("Invalid file name.");
+        }
         var file = await _fileService.GetFileAsync(id, fileName);
         if (file is null)
             return NotFound();
@@ -34,6 +42,14 @@ public class RagFilesController : ControllerBase
     [HttpPost]
     public async Task<ActionResult> Upload(Guid id, [FromForm] IFormFile file)
     {
+        try
+        {
+            FileNameValidator.Validate(file.FileName);
+        }
+        catch (ArgumentException)
+        {
+            return BadRequest("Invalid file name.");
+        }
         var ext = Path.GetExtension(file.FileName);
         if (!_converter.GetSupportedExtensions().Contains(ext, StringComparer.OrdinalIgnoreCase))
             return BadRequest($"Unsupported file type {ext}");
@@ -46,6 +62,15 @@ public class RagFilesController : ControllerBase
     [HttpPut("{fileName}")]
     public async Task<ActionResult> Update(Guid id, string fileName, [FromForm] IFormFile file)
     {
+        try
+        {
+            FileNameValidator.Validate(fileName);
+            FileNameValidator.Validate(file.FileName);
+        }
+        catch (ArgumentException)
+        {
+            return BadRequest("Invalid file name.");
+        }
         var ext = Path.GetExtension(file.FileName);
         if (!_converter.GetSupportedExtensions().Contains(ext, StringComparer.OrdinalIgnoreCase))
             return BadRequest($"Unsupported file type {ext}");
@@ -58,6 +83,14 @@ public class RagFilesController : ControllerBase
     [HttpDelete("{fileName}")]
     public async Task<ActionResult> Delete(Guid id, string fileName)
     {
+        try
+        {
+            FileNameValidator.Validate(fileName);
+        }
+        catch (ArgumentException)
+        {
+            return BadRequest("Invalid file name.");
+        }
         await _fileService.DeleteFileAsync(id, fileName);
         return NoContent();
     }

--- a/ChatClient.Api/Services/FileNameValidator.cs
+++ b/ChatClient.Api/Services/FileNameValidator.cs
@@ -1,0 +1,17 @@
+using System;
+using System.IO;
+
+namespace ChatClient.Api.Services;
+
+public static class FileNameValidator
+{
+    public static void Validate(string fileName)
+    {
+        if (string.IsNullOrWhiteSpace(fileName) ||
+            fileName.IndexOfAny(Path.GetInvalidFileNameChars()) >= 0 ||
+            fileName != Path.GetFileName(fileName) ||
+            fileName is "." or "..")
+            throw new ArgumentException("Invalid file name.", nameof(fileName));
+    }
+}
+

--- a/ChatClient.Api/Services/Rag/RagFileService.cs
+++ b/ChatClient.Api/Services/Rag/RagFileService.cs
@@ -1,5 +1,6 @@
 using ChatClient.Shared.Models;
 using ChatClient.Shared.Services;
+using ChatClient.Api.Services;
 
 namespace ChatClient.Api.Services.Rag;
 
@@ -36,6 +37,7 @@ public class RagFileService(IRagVectorIndexBackgroundService indexBackgroundServ
 
     public async Task<RagFile?> GetFileAsync(Guid id, string fileName)
     {
+        FileNameValidator.Validate(fileName);
         var agentFolder = GetAgentFolder(id);
         var filePath = Path.Combine(agentFolder, "files", fileName);
         if (!File.Exists(filePath))
@@ -55,6 +57,7 @@ public class RagFileService(IRagVectorIndexBackgroundService indexBackgroundServ
 
     public async Task AddOrUpdateFileAsync(Guid id, RagFile file)
     {
+        FileNameValidator.Validate(file.FileName);
         var agentFolder = GetAgentFolder(id);
         Directory.CreateDirectory(Path.Combine(agentFolder, "files"));
         Directory.CreateDirectory(Path.Combine(agentFolder, "index"));
@@ -70,6 +73,7 @@ public class RagFileService(IRagVectorIndexBackgroundService indexBackgroundServ
 
     public Task DeleteFileAsync(Guid id, string fileName)
     {
+        FileNameValidator.Validate(fileName);
         var agentFolder = GetAgentFolder(id);
         var indexPath = Path.Combine(agentFolder, "index", Path.ChangeExtension(fileName, ".idx"));
         if (File.Exists(indexPath))

--- a/ChatClient.Tests/FileNameValidatorTests.cs
+++ b/ChatClient.Tests/FileNameValidatorTests.cs
@@ -1,0 +1,18 @@
+using System;
+using ChatClient.Api.Services;
+
+public class FileNameValidatorTests
+{
+    [Theory]
+    [InlineData("valid.txt")]
+    [InlineData("another_file.md")]
+    public void Validate_AllowsValidNames(string fileName)
+        => FileNameValidator.Validate(fileName);
+
+    [Theory]
+    [InlineData("../secret.txt")]
+    [InlineData("..")]
+    [InlineData("na/me.txt")]
+    public void Validate_RejectsInvalidNames(string fileName)
+        => Assert.Throws<ArgumentException>(() => FileNameValidator.Validate(fileName));
+}


### PR DESCRIPTION
## Summary
- guard RAG file operations with a file name validator
- prevent path traversal by rejecting invalid file names
- add tests for file name validation

## Testing
- `dotnet test --logger "console;verbosity=detailed"`


------
https://chatgpt.com/codex/tasks/task_e_68bc9fb10778832ab05f389f35b7a7a6