### PR TITLE
Propagate cancellation tokens in user settings operations

### DIFF
--- a/ChatClient.Api/Controllers/SettingsController.cs
+++ b/ChatClient.Api/Controllers/SettingsController.cs
@@ -19,11 +19,11 @@ public class SettingsController : ControllerBase
     }
 
     [HttpGet]
-    public async Task<ActionResult<UserSettings>> GetSettings()
+    public async Task<ActionResult<UserSettings>> GetSettings(CancellationToken cancellationToken)
     {
         try
         {
-            var settings = await _settingsService.GetSettingsAsync();
+            var settings = await _settingsService.GetSettingsAsync(cancellationToken);
             return Ok(settings);
         }
         catch (Exception ex)
@@ -34,11 +34,11 @@ public class SettingsController : ControllerBase
     }
 
     [HttpPost]
-    public async Task<ActionResult> SaveSettings([FromBody] UserSettings settings)
+    public async Task<ActionResult> SaveSettings([FromBody] UserSettings settings, CancellationToken cancellationToken)
     {
         try
         {
-            await _settingsService.SaveSettingsAsync(settings);
+            await _settingsService.SaveSettingsAsync(settings, cancellationToken);
             return Ok();
         }
         catch (Exception ex)

--- a/ChatClient.Api/Services/UserSettingsService.cs
+++ b/ChatClient.Api/Services/UserSettingsService.cs
@@ -36,7 +36,7 @@ public class UserSettingsService : IUserSettingsService
         _logger.LogInformation("User settings file path: {FilePath}", _settingsFilePath);
     }
 
-    public async Task<UserSettings> GetSettingsAsync()
+    public async Task<UserSettings> GetSettingsAsync(CancellationToken cancellationToken = default)
     {
         UserSettings settings;
 
@@ -47,7 +47,7 @@ public class UserSettingsService : IUserSettingsService
         }
         else
         {
-            var json = await File.ReadAllTextAsync(_settingsFilePath);
+            var json = await File.ReadAllTextAsync(_settingsFilePath, cancellationToken);
             settings = JsonSerializer.Deserialize<UserSettings>(json, _jsonOptions) ?? new UserSettings();
         }
 
@@ -67,17 +67,17 @@ public class UserSettingsService : IUserSettingsService
         settings.Embedding ??= new EmbeddingSettings();
 
         if (updated || !File.Exists(_settingsFilePath))
-            await SaveSettingsAsync(settings);
+            await SaveSettingsAsync(settings, cancellationToken);
 
         return settings;
     }
 
-    public async Task SaveSettingsAsync(UserSettings settings)
+    public async Task SaveSettingsAsync(UserSettings settings, CancellationToken cancellationToken = default)
     {
         try
         {
             var json = JsonSerializer.Serialize(settings, _jsonOptions);
-            await File.WriteAllTextAsync(_settingsFilePath, json);
+            await File.WriteAllTextAsync(_settingsFilePath, json, cancellationToken);
             _logger.LogInformation("User settings saved successfully");
         }
         catch (Exception ex)

--- a/ChatClient.Shared/Services/IUserSettingsService.cs
+++ b/ChatClient.Shared/Services/IUserSettingsService.cs
@@ -4,6 +4,6 @@ namespace ChatClient.Shared.Services;
 
 public interface IUserSettingsService
 {
-    Task<UserSettings> GetSettingsAsync();
-    Task SaveSettingsAsync(UserSettings settings);
+    Task<UserSettings> GetSettingsAsync(CancellationToken cancellationToken = default);
+    Task SaveSettingsAsync(UserSettings settings, CancellationToken cancellationToken = default);
 }

--- a/ChatClient.Tests/AppChatHistoryBuilderTests.cs
+++ b/ChatClient.Tests/AppChatHistoryBuilderTests.cs
@@ -15,8 +15,11 @@ public class AppChatHistoryBuilderTests
 {
     private sealed class ThrowingUserSettingsService : IUserSettingsService
     {
-        public Task<UserSettings> GetSettingsAsync() => throw new InvalidOperationException();
-        public Task SaveSettingsAsync(UserSettings settings) => throw new InvalidOperationException();
+        public Task<UserSettings> GetSettingsAsync(CancellationToken cancellationToken = default)
+            => throw new InvalidOperationException();
+
+        public Task SaveSettingsAsync(UserSettings settings, CancellationToken cancellationToken = default)
+            => throw new InvalidOperationException();
     }
 
     private sealed class ThrowingOllamaClientService : IOllamaClientService

--- a/ChatClient.Tests/ChatServiceTests.cs
+++ b/ChatClient.Tests/ChatServiceTests.cs
@@ -5,8 +5,8 @@ using ChatClient.Shared.Services;
 using Microsoft.Extensions.AI;
 using Microsoft.Extensions.Logging;
 using Microsoft.SemanticKernel;
-using Microsoft.SemanticKernel.ChatCompletion;
 using Microsoft.SemanticKernel.Agents.Orchestration.GroupChat;
+using Microsoft.SemanticKernel.ChatCompletion;
 using OllamaSharp;
 using System;
 using System.Threading.Tasks;
@@ -41,8 +41,11 @@ public class ChatServiceTests
 
     private class MockUserSettingsService : IUserSettingsService
     {
-        public Task<UserSettings> GetSettingsAsync() => Task.FromResult(new UserSettings());
-        public Task SaveSettingsAsync(UserSettings settings) => Task.CompletedTask;
+        public Task<UserSettings> GetSettingsAsync(CancellationToken cancellationToken = default)
+            => Task.FromResult(new UserSettings());
+
+        public Task SaveSettingsAsync(UserSettings settings, CancellationToken cancellationToken = default)
+            => Task.CompletedTask;
     }
 
     private class MockLlmServerConfigService : ILlmServerConfigService

--- a/ChatClient.Tests/OllamaServiceTests.cs
+++ b/ChatClient.Tests/OllamaServiceTests.cs
@@ -32,8 +32,11 @@ public class OllamaServiceTests
 
     private sealed class StubUserSettingsService : IUserSettingsService
     {
-        public Task<UserSettings> GetSettingsAsync() => Task.FromResult(new UserSettings());
-        public Task SaveSettingsAsync(UserSettings settings) => Task.CompletedTask;
+        public Task<UserSettings> GetSettingsAsync(CancellationToken cancellationToken = default)
+            => Task.FromResult(new UserSettings());
+
+        public Task SaveSettingsAsync(UserSettings settings, CancellationToken cancellationToken = default)
+            => Task.CompletedTask;
     }
 
     private class MockLlmServerConfigService : ILlmServerConfigService


### PR DESCRIPTION
## Summary
- support cancellation tokens in IUserSettingsService and UserSettingsService
- pass CancellationToken to file I/O and controller actions

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68bd654b7a38832a8995c2fec46d2af0