### PR TITLE
Remove redundant controller exception handling

### DIFF
--- a/ChatClient.Api/Controllers/McpPlaygroundController.cs
+++ b/ChatClient.Api/Controllers/McpPlaygroundController.cs
@@ -9,7 +9,7 @@ namespace ChatClient.Api.Controllers;
 
 [ApiController]
 [Route("api/mcp-playground")]
-public class McpPlaygroundController(IMcpClientService clientService, ILogger<McpPlaygroundController> logger) : ControllerBase
+public class McpPlaygroundController(IMcpClientService clientService) : ControllerBase
 {
     [HttpGet("servers")]
     public async Task<ActionResult<IEnumerable<string>>> GetServers(CancellationToken cancellationToken)
@@ -42,15 +42,7 @@ public class McpPlaygroundController(IMcpClientService clientService, ILogger<Mc
         if (tool == null)
             return NotFound($"Function {request.Function} not found");
         var args = request.Parameters?.ToDictionary(kv => kv.Key, kv => kv.Value.Deserialize<object?>()) ?? new Dictionary<string, object?>();
-        try
-        {
-            var result = await tool.CallAsync(args, null, null, cancellationToken);
-            return Ok(JsonSerializer.SerializeToElement(result));
-        }
-        catch (Exception ex)
-        {
-            logger.LogError(ex, "Error calling tool {Function} on server {Server}", request.Function, request.Server);
-            return StatusCode(500, JsonSerializer.SerializeToElement(new { error = ex.Message }));
-        }
+        var result = await tool.CallAsync(args, null, null, cancellationToken);
+        return Ok(JsonSerializer.SerializeToElement(result));
     }
 }

--- a/ChatClient.Api/Controllers/McpServersController.cs
+++ b/ChatClient.Api/Controllers/McpServersController.cs
@@ -7,122 +7,82 @@ namespace ChatClient.Api.Controllers;
 
 [ApiController]
 [Route("api/[controller]")]
-public class McpServersController(IMcpServerConfigService mcpServerConfigService, ILogger<McpServersController> logger) : ControllerBase
+public class McpServersController(IMcpServerConfigService mcpServerConfigService) : ControllerBase
 {
     [HttpGet]
     public async Task<ActionResult<IEnumerable<McpServerConfig>>> GetAllServers()
     {
-        try
-        {
-            var servers = await mcpServerConfigService.GetAllAsync();
-            return Ok(servers);
-        }
-        catch (Exception ex)
-        {
-            logger.LogError(ex, "Error retrieving all MCP server configs");
-            return StatusCode(500, "An error occurred while retrieving MCP server configs");
-        }
+        var servers = await mcpServerConfigService.GetAllAsync();
+        return Ok(servers);
     }
 
     [HttpGet("{id}")]
     public async Task<ActionResult<McpServerConfig>> GetServerById(Guid id)
     {
-        try
+        var server = await mcpServerConfigService.GetByIdAsync(id);
+        if (server == null)
         {
-            var server = await mcpServerConfigService.GetByIdAsync(id);
-            if (server == null)
-            {
-                return NotFound($"MCP server config with ID {id} not found");
-            }
+            return NotFound($"MCP server config with ID {id} not found");
+        }
 
-            return Ok(server);
-        }
-        catch (Exception ex)
-        {
-            logger.LogError(ex, "Error retrieving MCP server config with ID {Id}", id);
-            return StatusCode(500, "An error occurred while retrieving the MCP server config");
-        }
+        return Ok(server);
     }
 
     [HttpPost]
     public async Task<ActionResult<McpServerConfig>> CreateServer([FromBody] McpServerConfig server)
     {
-        try
+        if (string.IsNullOrWhiteSpace(server.Name))
         {
-            if (string.IsNullOrWhiteSpace(server.Name))
-            {
-                return BadRequest("Server name is required");
-            }
-
-            if (string.IsNullOrWhiteSpace(server.Command) && string.IsNullOrWhiteSpace(server.Sse))
-            {
-                return BadRequest("Either Command or Sse must be specified");
-            }
-
-            var createdServer = await mcpServerConfigService.CreateAsync(server);
-            return CreatedAtAction(nameof(GetServerById), new { id = createdServer.Id }, createdServer);
+            return BadRequest("Server name is required");
         }
-        catch (Exception ex)
+
+        if (string.IsNullOrWhiteSpace(server.Command) && string.IsNullOrWhiteSpace(server.Sse))
         {
-            logger.LogError(ex, "Error creating MCP server config");
-            return StatusCode(500, "An error occurred while creating the MCP server config");
+            return BadRequest("Either Command or Sse must be specified");
         }
+
+        var createdServer = await mcpServerConfigService.CreateAsync(server);
+        return CreatedAtAction(nameof(GetServerById), new { id = createdServer.Id }, createdServer);
     }
 
     [HttpPut("{id}")]
     public async Task<ActionResult<McpServerConfig>> UpdateServer(Guid id, [FromBody] McpServerConfig server)
     {
-        try
+        if (id != server.Id)
         {
-            if (id != server.Id)
-            {
-                return BadRequest("ID in URL does not match ID in request body");
-            }
-
-            if (string.IsNullOrWhiteSpace(server.Name))
-            {
-                return BadRequest("Server name is required");
-            }
-
-            if (string.IsNullOrWhiteSpace(server.Command) && string.IsNullOrWhiteSpace(server.Sse))
-            {
-                return BadRequest("Either Command or Sse must be specified");
-            }
-
-            var existingServer = await mcpServerConfigService.GetByIdAsync(id);
-            if (existingServer == null)
-            {
-                return NotFound($"MCP server config with ID {id} not found");
-            }
-
-            var updatedServer = await mcpServerConfigService.UpdateAsync(server);
-            return Ok(updatedServer);
+            return BadRequest("ID in URL does not match ID in request body");
         }
-        catch (Exception ex)
+
+        if (string.IsNullOrWhiteSpace(server.Name))
         {
-            logger.LogError(ex, "Error updating MCP server config with ID {Id}", id);
-            return StatusCode(500, "An error occurred while updating the MCP server config");
+            return BadRequest("Server name is required");
         }
+
+        if (string.IsNullOrWhiteSpace(server.Command) && string.IsNullOrWhiteSpace(server.Sse))
+        {
+            return BadRequest("Either Command or Sse must be specified");
+        }
+
+        var existingServer = await mcpServerConfigService.GetByIdAsync(id);
+        if (existingServer == null)
+        {
+            return NotFound($"MCP server config with ID {id} not found");
+        }
+
+        var updatedServer = await mcpServerConfigService.UpdateAsync(server);
+        return Ok(updatedServer);
     }
 
     [HttpDelete("{id}")]
     public async Task<ActionResult> DeleteServer(Guid id)
     {
-        try
+        var existingServer = await mcpServerConfigService.GetByIdAsync(id);
+        if (existingServer == null)
         {
-            var existingServer = await mcpServerConfigService.GetByIdAsync(id);
-            if (existingServer == null)
-            {
-                return NotFound($"MCP server config with ID {id} not found");
-            }
+            return NotFound($"MCP server config with ID {id} not found");
+        }
 
-            await mcpServerConfigService.DeleteAsync(id);
-            return NoContent();
-        }
-        catch (Exception ex)
-        {
-            logger.LogError(ex, "Error deleting MCP server config with ID {Id}", id);
-            return StatusCode(500, "An error occurred while deleting the MCP server config");
-        }
+        await mcpServerConfigService.DeleteAsync(id);
+        return NoContent();
     }
 }

--- a/ChatClient.Api/Controllers/SettingsController.cs
+++ b/ChatClient.Api/Controllers/SettingsController.cs
@@ -10,41 +10,23 @@ namespace ChatClient.Api.Controllers;
 public class SettingsController : ControllerBase
 {
     private readonly IUserSettingsService _settingsService;
-    private readonly ILogger<SettingsController> _logger;
 
-    public SettingsController(IUserSettingsService settingsService, ILogger<SettingsController> logger)
+    public SettingsController(IUserSettingsService settingsService)
     {
         _settingsService = settingsService;
-        _logger = logger;
     }
 
     [HttpGet]
     public async Task<ActionResult<UserSettings>> GetSettings(CancellationToken cancellationToken)
     {
-        try
-        {
-            var settings = await _settingsService.GetSettingsAsync(cancellationToken);
-            return Ok(settings);
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Error retrieving user settings");
-            return StatusCode(500, "An error occurred while retrieving settings");
-        }
+        var settings = await _settingsService.GetSettingsAsync(cancellationToken);
+        return Ok(settings);
     }
 
     [HttpPost]
     public async Task<ActionResult> SaveSettings([FromBody] UserSettings settings, CancellationToken cancellationToken)
     {
-        try
-        {
-            await _settingsService.SaveSettingsAsync(settings, cancellationToken);
-            return Ok();
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Error saving user settings");
-            return StatusCode(500, "An error occurred while saving settings");
-        }
+        await _settingsService.SaveSettingsAsync(settings, cancellationToken);
+        return Ok();
     }
 }


### PR DESCRIPTION
## Summary
- Drop per-action try-catch blocks and unused loggers from API controllers to rely on global `ApiExceptionFilter`
- Simplify model validation and error handling

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68bd69aa4590832abfa0414243397cd4