### PR TITLE
feat: introduce resettable round robin manager

### DIFF
--- a/ChatClient.Api/Client/Services/AppChatService.cs
+++ b/ChatClient.Api/Client/Services/AppChatService.cs
@@ -11,7 +11,6 @@ using Microsoft.SemanticKernel.ChatCompletion;
 using OllamaSharp.Models.Exceptions;
 using System.Collections.ObjectModel;
 using System.Linq;
-using System.Reflection;
 
 namespace ChatClient.Api.Client.Services;
 
@@ -569,8 +568,10 @@ public class AppChatService(
 
     private static void ResetInvocationCount(GroupChatManager manager)
     {
-        var field = typeof(GroupChatManager).GetField("_invocationCount", BindingFlags.Instance | BindingFlags.NonPublic);
-        field?.SetValue(manager, 0);
+        if (manager is ResettableRoundRobinGroupChatManager resettable)
+        {
+            resettable.ResetInvocationCount();
+        }
     }
 
     private void UpdateAnsweringState(bool isAnswering)

--- a/ChatClient.Api/Client/Services/BridgingRoundRobinManager.cs
+++ b/ChatClient.Api/Client/Services/BridgingRoundRobinManager.cs
@@ -5,7 +5,7 @@ using Microsoft.SemanticKernel.ChatCompletion;
 namespace ChatClient.Api.Client.Services;
 
 
-public sealed class BridgingRoundRobinManager : RoundRobinGroupChatManager
+public sealed class BridgingRoundRobinManager : ResettableRoundRobinGroupChatManager
 {
     private ChatMessageContent? _fixedAgentMessage = null;
     private AuthorRole _fixedMessageRole = AuthorRole.Assistant;

--- a/ChatClient.Api/Client/Services/ReasonableRoundRobinGroupChatManager.cs
+++ b/ChatClient.Api/Client/Services/ReasonableRoundRobinGroupChatManager.cs
@@ -7,7 +7,7 @@ namespace ChatClient.Api.Client.Services;
 
 internal sealed class ReasonableRoundRobinGroupChatManager(
     string stopAgentName,
-    string stopPhrase) : RoundRobinGroupChatManager
+    string stopPhrase) : ResettableRoundRobinGroupChatManager
 {
     private readonly StopPhraseEvaluator _stopEvaluator = new(stopAgentName, stopPhrase);
 

--- a/ChatClient.Api/Client/Services/ResettableRoundRobinGroupChatManager.cs
+++ b/ChatClient.Api/Client/Services/ResettableRoundRobinGroupChatManager.cs
@@ -1,0 +1,68 @@
+using Microsoft.SemanticKernel.Agents.Orchestration.GroupChat;
+using Microsoft.SemanticKernel.ChatCompletion;
+
+namespace ChatClient.Api.Client.Services;
+
+public class ResettableRoundRobinGroupChatManager : GroupChatManager
+{
+    private int _currentAgentIndex;
+    private int _invocationCount;
+    private int _maximumInvocationCount = 1;
+
+    public new int MaximumInvocationCount
+    {
+        get => _maximumInvocationCount;
+        set => _maximumInvocationCount = value;
+    }
+
+    public void ResetInvocationCount()
+    {
+        _invocationCount = 0;
+        _currentAgentIndex = 0;
+    }
+
+    public override ValueTask<GroupChatManagerResult<bool>> ShouldTerminate(
+        ChatHistory history,
+        CancellationToken cancellationToken = default)
+    {
+        var terminate = _invocationCount >= _maximumInvocationCount;
+        return ValueTask.FromResult(new GroupChatManagerResult<bool>(terminate)
+        {
+            Reason = terminate ? "Maximum invocation count reached." : "Additional turns available."
+        });
+    }
+
+    public override ValueTask<GroupChatManagerResult<bool>> ShouldRequestUserInput(
+        ChatHistory history,
+        CancellationToken cancellationToken = default)
+    {
+        return ValueTask.FromResult(new GroupChatManagerResult<bool>(false)
+        {
+            Reason = "Round-robin manager does not request user input."
+        });
+    }
+
+    public override ValueTask<GroupChatManagerResult<string>> FilterResults(
+        ChatHistory history,
+        CancellationToken cancellationToken = default)
+    {
+        return ValueTask.FromResult(new GroupChatManagerResult<string>(history.LastOrDefault()?.Content ?? string.Empty)
+        {
+            Reason = "Default result filter provides the final chat message."
+        });
+    }
+
+    public override ValueTask<GroupChatManagerResult<string>> SelectNextAgent(
+        ChatHistory history,
+        GroupChatTeam team,
+        CancellationToken cancellationToken = default)
+    {
+        var key = team.Skip(_currentAgentIndex).First().Key;
+        _currentAgentIndex = (_currentAgentIndex + 1) % team.Count;
+        _invocationCount++;
+        return ValueTask.FromResult(new GroupChatManagerResult<string>(key)
+        {
+            Reason = $"Selected agent at index: {_currentAgentIndex}"
+        });
+    }
+}

--- a/ChatClient.Api/Client/Services/RoundRobinSummaryGroupChatManager.cs
+++ b/ChatClient.Api/Client/Services/RoundRobinSummaryGroupChatManager.cs
@@ -3,7 +3,7 @@ using Microsoft.SemanticKernel.ChatCompletion;
 
 namespace ChatClient.Api.Client.Services;
 
-public sealed class RoundRobinSummaryGroupChatManager(string summaryAgentName) : RoundRobinGroupChatManager, IGroupChatAgentProvider
+public sealed class RoundRobinSummaryGroupChatManager(string summaryAgentName) : ResettableRoundRobinGroupChatManager, IGroupChatAgentProvider
 {
     private readonly string _summaryAgentName = summaryAgentName;
     private bool _summaryPending;

--- a/ChatClient.Tests/ChatServiceTests.cs
+++ b/ChatClient.Tests/ChatServiceTests.cs
@@ -70,7 +70,7 @@ public class ChatServiceTests
             userSettingsService: new MockUserSettingsService(),
             llmServerConfigService: new MockLlmServerConfigService());
 
-        var session = new ChatSessionParameters(new RoundRobinGroupChatManager(), new AppChatConfiguration("m", []), []);
+        var session = new ChatSessionParameters(new ResettableRoundRobinGroupChatManager(), new AppChatConfiguration("m", []), []);
         await Assert.ThrowsAsync<ArgumentException>(() => chatService.StartAsync(session));
     }
 
@@ -88,7 +88,7 @@ public class ChatServiceTests
             llmServerConfigService: new MockLlmServerConfigService());
 
         var prompt = new AgentDescription { AgentName = "Agent", Content = "Hello" };
-        var session = new ChatSessionParameters(new RoundRobinGroupChatManager(), new AppChatConfiguration("m", []), [prompt]);
+        var session = new ChatSessionParameters(new ResettableRoundRobinGroupChatManager(), new AppChatConfiguration("m", []), [prompt]);
         await chatService.StartAsync(session);
 
         Assert.Empty(chatService.Messages);
@@ -108,7 +108,7 @@ public class ChatServiceTests
             llmServerConfigService: new MockLlmServerConfigService());
 
         var prompt = new AgentDescription { AgentName = "Agent", Content = "Hello" };
-        var session = new ChatSessionParameters(new RoundRobinGroupChatManager(), new AppChatConfiguration("m", []), [prompt]);
+        var session = new ChatSessionParameters(new ResettableRoundRobinGroupChatManager(), new AppChatConfiguration("m", []), [prompt]);
         await chatService.StartAsync(session);
         Assert.Single(chatService.AgentDescriptions);
 

--- a/ChatClient.Tests/PhilosopherDebateTests.cs
+++ b/ChatClient.Tests/PhilosopherDebateTests.cs
@@ -76,7 +76,7 @@ public partial class PhilosopherDebateTests
         };
 
         GroupChatOrchestration chat = new(
-            new RoundRobinGroupChatManager { MaximumInvocationCount = 8 },
+            new ResettableRoundRobinGroupChatManager { MaximumInvocationCount = 8 },
             kant,
             bentham);
 

--- a/docs/multi-agent-chat.md
+++ b/docs/multi-agent-chat.md
@@ -1,7 +1,7 @@
 # Multi-Agent Chat
 
 OllamaChat uses Semantic Kernel's `GroupChatOrchestration` to coordinate
-selected `ChatCompletionAgent` instances. A `RoundRobinGroupChatManager`
+selected `ChatCompletionAgent` instances. A `ResettableRoundRobinGroupChatManager`
 cycles through agents; increase `MaximumInvocationCount` to let them
 auto‑continue without extra user messages.
 
@@ -13,7 +13,7 @@ final agent reply as a user message (`AuthorName="user"`).
 
 ```csharp
 var orchestrator = new GroupChatOrchestration(
-    new RoundRobinGroupChatManager { MaximumInvocationCount = 2 },
+    new ResettableRoundRobinGroupChatManager { MaximumInvocationCount = 2 },
     agents);
 ```
 


### PR DESCRIPTION
## Summary
- add ResettableRoundRobinGroupChatManager with public reset API
- implement round-robin selection and invocation counting directly
- update chat service and custom managers to use ResettableRoundRobinGroupChatManager
- document new manager in multi-agent chat guide

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68bedd464154832ab110acc2be3aa2c0