### PR TITLE
Show server model picker before chat starts

### DIFF
--- a/ChatClient.Api/Client/Layout/MainLayout.razor
+++ b/ChatClient.Api/Client/Layout/MainLayout.razor
@@ -27,6 +27,9 @@
                        Size="Size.Small"
                        Class="ml-4"
                        Style="flex-shrink: 0;">New Chat</MudButton>
+        }
+        @if (!isLLMAnswering)
+        {
             <div class="ml-2" style="flex-shrink: 1; min-width: 0;">
                 <ServerModelPicker Value="pickerModel" ValueChanged="OnModelChanged" />
             </div>


### PR DESCRIPTION
## Summary
- Ensure server/model picker is visible whenever the app isn't answering
- Keep "New Chat" button tied to existing chats only

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68bf1aa7f2cc832a90787e28eba94a59