### PR TITLE
Не подставлять сервер и модель по умолчанию при редактировании агента

### DIFF
--- a/ChatClient.Api/Client/Components/ServerModelPicker.razor
+++ b/ChatClient.Api/Client/Components/ServerModelPicker.razor
@@ -48,6 +48,7 @@
     [Parameter] public ServerModelSelection Value { get; set; } = new(null, null);
     [Parameter] public EventCallback<ServerModelSelection> ValueChanged { get; set; }
     [Parameter] public bool ShowClearButton { get; set; } = false;
+    [Parameter] public bool UseDefaultsWhenUnset { get; set; } = true;
     [Parameter(CaptureUnmatchedValues = true)] public Dictionary<string, object> Attributes { get; set; } = [];
 
     private Guid? selectedServerId;
@@ -62,13 +63,16 @@
         servers = await LlmServerConfigService.GetAllAsync();
         if (Value.ServerId is null && string.IsNullOrEmpty(Value.ModelName))
         {
-            var settings = await UserSettingsService.GetSettingsAsync();
-            var defaultModel = settings.DefaultModel;
-            selectedServerId = defaultModel.ServerId;
-            selectedModel = defaultModel.ModelName;
-            if (selectedServerId.HasValue)
-                await LoadModelsAsync(selectedServerId.Value);
-            await NotifyValueChanged();
+            if (UseDefaultsWhenUnset)
+            {
+                var settings = await UserSettingsService.GetSettingsAsync();
+                var defaultModel = settings.DefaultModel;
+                selectedServerId = defaultModel.ServerId;
+                selectedModel = defaultModel.ModelName;
+                if (selectedServerId.HasValue)
+                    await LoadModelsAsync(selectedServerId.Value);
+                await NotifyValueChanged();
+            }
             return;
         }
         selectedServerId = Value.ServerId;

--- a/ChatClient.Api/Client/Pages/AgentDescriptions.razor
+++ b/ChatClient.Api/Client/Pages/AgentDescriptions.razor
@@ -204,7 +204,7 @@
                           HelperText="Custom short name for this agent. If empty, uses global agent name from settings."
                           Placeholder="Enter short name..." />
 
-            <ServerModelPicker @bind-Value="editingServerModel" ShowClearButton="true" Class="mt-4" />
+            <ServerModelPicker @bind-Value="editingServerModel" ShowClearButton="true" UseDefaultsWhenUnset="false" Class="mt-4" />
             <MudText Typo="Typo.caption">Leave blank to use chat's default model.</MudText>
 
             <MudNumericField T="double?" @bind-Value="editingAgent.Temperature" Label="Temperature (Optional)" Class="mt-4" Immediate="true" Min="0" Max="2" Step="0.1" />


### PR DESCRIPTION
## Summary
- добавлен параметр `UseDefaultsWhenUnset` в `ServerModelPicker`
- при редактировании агента не подставляются глобальные значения сервера и модели

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68c010e2b4b4832a9304cb196e35954c