### PR TITLE
fix: display Cyrillic in console

### DIFF
--- a/ChatClient.Api/Program.cs
+++ b/ChatClient.Api/Program.cs
@@ -7,10 +7,15 @@ using Microsoft.AspNetCore.Components.Server.Circuits;
 using Microsoft.AspNetCore.Hosting.Server;
 using Microsoft.AspNetCore.Hosting.Server.Features;
 using Microsoft.SemanticKernel.Connectors.InMemory;
+using System.Text;
 
 using MudBlazor.Services;
 
 using Serilog;
+
+// Enable UTF-8 for proper Cyrillic support.
+Console.OutputEncoding = Encoding.UTF8;
+Console.InputEncoding = Encoding.UTF8;
 
 Log.Logger = new LoggerConfiguration()
     .WriteTo.Console()


### PR DESCRIPTION
## Summary
- enable UTF-8 input/output for console

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68c03e73512c832a97381c745f99c14b