### PR TITLE
refactor: remove pass-through methods

### DIFF
--- a/ChatClient.Api/Client/ViewModels/AppChatMessageViewModel.cs
+++ b/ChatClient.Api/Client/ViewModels/AppChatMessageViewModel.cs
@@ -32,7 +32,7 @@ public class AppChatMessageViewModel
         .UseMathematics()
         .UseSlashParensMath()
         .Build();
-    private AppChatMessageViewModel Populate(IAppChatMessage message)
+    public AppChatMessageViewModel UpdateFromDomainModel(IAppChatMessage message)
     {
         Id = message.Id;
         RawContent = message.Content;
@@ -89,7 +89,5 @@ public class AppChatMessageViewModel
         return this;
     }
 
-    public static AppChatMessageViewModel CreateFromDomainModel(IAppChatMessage message) => new AppChatMessageViewModel().Populate(message);
-
-    public void UpdateFromDomainModel(IAppChatMessage message) => Populate(message);
+    public static AppChatMessageViewModel CreateFromDomainModel(IAppChatMessage message) => new AppChatMessageViewModel().UpdateFromDomainModel(message);
 }

--- a/ChatClient.Api/Services/LlmServerConfigHelper.cs
+++ b/ChatClient.Api/Services/LlmServerConfigHelper.cs
@@ -17,19 +17,6 @@ public static class LlmServerConfigHelper
         return GetServerConfig(servers, settings.DefaultModel.ServerId, serverId, serverType);
     }
 
-    /// <summary>
-    /// Temporary solution for compatibility - uses ServiceProvider to resolve dependencies
-    /// </summary>
-    public static async Task<LlmServerConfig?> GetServerConfigAsync(
-        IUserSettingsService userSettingsService,
-        IServiceProvider serviceProvider,
-        Guid? serverId = null,
-        ServerType? serverType = null)
-    {
-        var llmServerConfigService = serviceProvider.GetRequiredService<ILlmServerConfigService>();
-        return await GetServerConfigAsync(llmServerConfigService, userSettingsService, serverId, serverType);
-    }
-
     public static LlmServerConfig? GetServerConfig(
         IEnumerable<LlmServerConfig> servers,
         Guid? defaultLlmId,

--- a/ChatClient.Api/Services/OllamaService.cs
+++ b/ChatClient.Api/Services/OllamaService.cs
@@ -20,7 +20,7 @@ public sealed class OllamaService(
     private readonly object _lock = new();
     private Exception? _embeddingError;
 
-    private async Task<OllamaApiClient> GetOllamaClientAsync(Guid serverId)
+    public async Task<OllamaApiClient> GetClientAsync(Guid serverId)
     {
         lock (_lock)
         {
@@ -39,20 +39,12 @@ public sealed class OllamaService(
         return client;
     }
 
-    public async Task<OllamaApiClient> GetClientAsync(Guid serverId)
-    {
-        return await GetOllamaClientAsync(serverId);
-    }
-
-    public Task<IReadOnlyList<OllamaModel>> GetModelsAsync(Guid serverId) =>
-        GetModelsInternalAsync(serverId);
-
-    private async Task<IReadOnlyList<OllamaModel>> GetModelsInternalAsync(Guid serverId)
+    public async Task<IReadOnlyList<OllamaModel>> GetModelsAsync(Guid serverId)
     {
         if (_modelsCache.TryGetValue(serverId, out var cached))
             return cached;
 
-        var client = await GetOllamaClientAsync(serverId);
+        var client = await GetClientAsync(serverId);
         var models = await client.ListLocalModelsAsync();
         var list = models.Select(m => new OllamaModel
         {
@@ -80,7 +72,7 @@ public sealed class OllamaService(
         if (_embeddingError is not null)
             throw new InvalidOperationException("Embedding service unavailable. Restart the application.", _embeddingError);
 
-        var client = await GetOllamaClientAsync(serverId);
+        var client = await GetClientAsync(serverId);
 
         var request = new EmbedRequest { Model = modelId, Input = new List<string> { input } };
         try


### PR DESCRIPTION
## Summary
- simplify OllamaService by folding internal helpers into public methods
- drop unused overload in LlmServerConfigHelper
- remove redundant UpdateFromDomainModel wrapper in AppChatMessageViewModel

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68c047950398832aa5e1c9a72893744a