### PR TITLE
Use read-only collections for query results

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -59,6 +59,7 @@
 - Prefix interfaces with `I` (e.g., `IUserService`).
 - Use primary constructors when appropriate (C# 12+).
 - **Parameter naming**: Parameter names must match their semantic purpose in the method. Avoid generic names that don't reflect the actual data type or business meaning.
+- Return `IReadOnlyCollection<T>` instead of `List<T>` when modification isn't required.
 
 ### Error Handling
 - Return empty collections (`[]`) instead of null when no data is available.

--- a/ChatClient.Api/Client/Components/ServerModelPicker.razor
+++ b/ChatClient.Api/Client/Components/ServerModelPicker.razor
@@ -60,7 +60,7 @@
 
     protected override async Task OnInitializedAsync()
     {
-        servers = await LlmServerConfigService.GetAllAsync();
+        servers = (await LlmServerConfigService.GetAllAsync()).ToList();
         if (Value.ServerId is null && string.IsNullOrEmpty(Value.ModelName))
         {
             if (UseDefaultsWhenUnset)

--- a/ChatClient.Api/Client/Pages/AgentDescriptions.razor
+++ b/ChatClient.Api/Client/Pages/AgentDescriptions.razor
@@ -311,7 +311,7 @@
     protected override async Task OnInitializedAsync()
     {
         await LoadAgents();
-        servers = await LlmServerConfigService.GetAllAsync();
+        servers = (await LlmServerConfigService.GetAllAsync()).ToList();
         await LoadAvailableFunctions();
     }
 
@@ -322,7 +322,7 @@
             loading = true;
             StateHasChanged();
 
-            agents = await AgentService.GetAllAsync() ?? new();
+            agents = (await AgentService.GetAllAsync()).ToList();
             filteredAgents = agents;
 
             ragCounts.Clear();
@@ -413,7 +413,7 @@
 
     private async Task LoadRagFiles(Guid id)
     {
-        ragFiles = await RagFileService.GetFilesAsync(id);
+        ragFiles = (await RagFileService.GetFilesAsync(id)).ToList();
         ragCounts[id] = ragFiles.Count;
     }
 

--- a/ChatClient.Api/Client/Pages/Chat.razor
+++ b/ChatClient.Api/Client/Pages/Chat.razor
@@ -319,7 +319,7 @@
 
     private async Task LoadAgents()
     {
-        agents = await AgentService.GetAllAsync();
+        agents = (await AgentService.GetAllAsync()).ToList();
         if (agents.Count == 0)
             agents.Add(AgentService.GetDefaultAgentDescription());
         selectedAgent = null;

--- a/ChatClient.Api/Client/Pages/LlmServers.razor
+++ b/ChatClient.Api/Client/Pages/LlmServers.razor
@@ -114,7 +114,7 @@
         try
         {
             loading = true;
-            servers = await LlmServerConfigService.GetAllAsync();
+            servers = (await LlmServerConfigService.GetAllAsync()).ToList();
         }
         catch (Exception ex)
         {

--- a/ChatClient.Api/Client/Pages/McpServers.razor
+++ b/ChatClient.Api/Client/Pages/McpServers.razor
@@ -266,7 +266,7 @@
             loading = true;
             StateHasChanged();
 
-            servers = await McpServerConfigService.GetAllAsync() ?? new();
+            servers = (await McpServerConfigService.GetAllAsync()).ToList();
             filteredServers = servers;
         }
         catch (Exception ex)

--- a/ChatClient.Api/Client/Pages/MultiAgentChat.razor
+++ b/ChatClient.Api/Client/Pages/MultiAgentChat.razor
@@ -367,7 +367,7 @@
 
     private async Task LoadAgents()
     {
-        agents = await AgentService.GetAllAsync();
+        agents = (await AgentService.GetAllAsync()).ToList();
         if (agents.Count == 0)
             agents.Add(AgentService.GetDefaultAgentDescription());
         selectedAgents = new List<AgentDescription>();

--- a/ChatClient.Api/Client/Pages/SavedChats.razor
+++ b/ChatClient.Api/Client/Pages/SavedChats.razor
@@ -72,8 +72,8 @@
         loading = true;
         StateHasChanged();
         chats = string.IsNullOrWhiteSpace(query)
-            ? await SavedChatService.GetAllAsync()
-            : await SavedChatService.SearchAsync(query);
+            ? (await SavedChatService.GetAllAsync()).ToList()
+            : (await SavedChatService.SearchAsync(query)).ToList();
         loading = false;
         StateHasChanged();
     }

--- a/ChatClient.Api/Client/Pages/VectorSearch.razor
+++ b/ChatClient.Api/Client/Pages/VectorSearch.razor
@@ -89,7 +89,7 @@
 
     protected override async Task OnInitializedAsync()
     {
-        agents = await AgentService.GetAllAsync();
+        agents = (await AgentService.GetAllAsync()).ToList();
         foreach (var agent in agents)
         {
             var files = await RagFileService.GetFilesAsync(agent.Id);

--- a/ChatClient.Api/Client/Services/AppChatService.cs
+++ b/ChatClient.Api/Client/Services/AppChatService.cs
@@ -262,7 +262,7 @@ public class AppChatService(
         return new ChatSessionParameters(_parameters.GroupChatManager, _parameters.Configuration, _chat.AgentDescriptions, _chat.Messages);
     }
 
-    private async Task<List<ChatCompletionAgent>> CreateAgentsAsync(
+    private async Task<IReadOnlyCollection<ChatCompletionAgent>> CreateAgentsAsync(
         string userMessage,
         TrackingFiltersScope trackingScope,
         AppChatConfiguration chatConfiguration,
@@ -359,7 +359,7 @@ public class AppChatService(
 
     private GroupChatOrchestration CreateChatOrchestration(
         GroupChatManager groupChatManager,
-        List<ChatCompletionAgent> agents,
+        IReadOnlyCollection<ChatCompletionAgent> agents,
         int functionCount,
         TrackingFiltersScope trackingScope,
         OrchestrationInputTransform<string> inputTransform)

--- a/ChatClient.Api/Services/AgentDescriptionService.cs
+++ b/ChatClient.Api/Services/AgentDescriptionService.cs
@@ -8,9 +8,9 @@ public class AgentDescriptionService(IAgentDescriptionRepository repository) : I
 {
     private readonly IAgentDescriptionRepository _repository = repository;
 
-    public async Task<List<AgentDescription>> GetAllAsync()
+    public async Task<IReadOnlyCollection<AgentDescription>> GetAllAsync()
     {
-        var agents = await _repository.GetAllAsync();
+        var agents = (await _repository.GetAllAsync()).ToList();
         var updated = false;
         foreach (var agent in agents.Where(a => a.Id == Guid.Empty))
         {
@@ -30,7 +30,7 @@ public class AgentDescriptionService(IAgentDescriptionRepository repository) : I
 
     public async Task CreateAsync(AgentDescription agentDescription)
     {
-        var agents = await _repository.GetAllAsync();
+        var agents = (await _repository.GetAllAsync()).ToList();
         if (agentDescription.Id == Guid.Empty)
             agentDescription.Id = Guid.NewGuid();
         agentDescription.CreatedAt = DateTime.UtcNow;
@@ -41,7 +41,7 @@ public class AgentDescriptionService(IAgentDescriptionRepository repository) : I
 
     public async Task UpdateAsync(AgentDescription agentDescription)
     {
-        var agents = await _repository.GetAllAsync();
+        var agents = (await _repository.GetAllAsync()).ToList();
         var index = agents.FindIndex(p => p.Id == agentDescription.Id);
         if (index == -1)
             throw new KeyNotFoundException($"Agent with ID {agentDescription.Id} not found");
@@ -52,7 +52,7 @@ public class AgentDescriptionService(IAgentDescriptionRepository repository) : I
 
     public async Task DeleteAsync(Guid id)
     {
-        var agents = await _repository.GetAllAsync();
+        var agents = (await _repository.GetAllAsync()).ToList();
         var existing = agents.FirstOrDefault(p => p.Id == id) ??
                        throw new KeyNotFoundException($"Agent with ID {id} not found");
         agents.Remove(existing);

--- a/ChatClient.Api/Services/ILlmServerConfigService.cs
+++ b/ChatClient.Api/Services/ILlmServerConfigService.cs
@@ -4,7 +4,7 @@ namespace ChatClient.Api.Services;
 
 public interface ILlmServerConfigService
 {
-    Task<List<LlmServerConfig>> GetAllAsync();
+    Task<IReadOnlyCollection<LlmServerConfig>> GetAllAsync();
     Task<LlmServerConfig?> GetByIdAsync(Guid id);
     Task CreateAsync(LlmServerConfig serverConfig);
     Task UpdateAsync(LlmServerConfig serverConfig);

--- a/ChatClient.Api/Services/IOpenAIClientService.cs
+++ b/ChatClient.Api/Services/IOpenAIClientService.cs
@@ -6,6 +6,6 @@ namespace ChatClient.Api.Services;
 public interface IOpenAIClientService
 {
     Task<IChatCompletionService> GetClientAsync(ServerModel serverModel, CancellationToken cancellationToken = default);
-    Task<List<string>> GetAvailableModelsAsync(Guid serverId, CancellationToken cancellationToken = default);
+    Task<IReadOnlyCollection<string>> GetAvailableModelsAsync(Guid serverId, CancellationToken cancellationToken = default);
     Task<bool> IsAvailableAsync(Guid serverId, CancellationToken cancellationToken = default);
 }

--- a/ChatClient.Api/Services/LlmServerConfigService.cs
+++ b/ChatClient.Api/Services/LlmServerConfigService.cs
@@ -7,7 +7,7 @@ public class LlmServerConfigService(ILlmServerConfigRepository repository) : ILl
 {
     private readonly ILlmServerConfigRepository _repository = repository;
 
-    public Task<List<LlmServerConfig>> GetAllAsync() => _repository.GetAllAsync();
+    public Task<IReadOnlyCollection<LlmServerConfig>> GetAllAsync() => _repository.GetAllAsync();
 
     public async Task<LlmServerConfig?> GetByIdAsync(Guid id)
     {
@@ -17,7 +17,7 @@ public class LlmServerConfigService(ILlmServerConfigRepository repository) : ILl
 
     public async Task CreateAsync(LlmServerConfig serverConfig)
     {
-        var servers = await _repository.GetAllAsync();
+        var servers = (await _repository.GetAllAsync()).ToList();
         serverConfig.Id ??= Guid.NewGuid();
         serverConfig.CreatedAt = DateTime.UtcNow;
         serverConfig.UpdatedAt = DateTime.UtcNow;
@@ -27,7 +27,7 @@ public class LlmServerConfigService(ILlmServerConfigRepository repository) : ILl
 
     public async Task UpdateAsync(LlmServerConfig serverConfig)
     {
-        var servers = await _repository.GetAllAsync();
+        var servers = (await _repository.GetAllAsync()).ToList();
         var index = servers.FindIndex(s => s.Id == serverConfig.Id);
         if (index == -1)
             throw new KeyNotFoundException($"LLM server config with ID {serverConfig.Id} not found");
@@ -38,7 +38,7 @@ public class LlmServerConfigService(ILlmServerConfigRepository repository) : ILl
 
     public async Task DeleteAsync(Guid id)
     {
-        var servers = await _repository.GetAllAsync();
+        var servers = (await _repository.GetAllAsync()).ToList();
         var existing = servers.FirstOrDefault(s => s.Id == id) ??
                        throw new KeyNotFoundException($"LLM server config with ID {id} not found");
         servers.Remove(existing);

--- a/ChatClient.Api/Services/McpServerConfigService.cs
+++ b/ChatClient.Api/Services/McpServerConfigService.cs
@@ -8,7 +8,7 @@ public class McpServerConfigService(IMcpServerConfigRepository repository) : IMc
 {
     private readonly IMcpServerConfigRepository _repository = repository;
 
-    public Task<List<McpServerConfig>> GetAllAsync() => _repository.GetAllAsync();
+    public Task<IReadOnlyCollection<McpServerConfig>> GetAllAsync() => _repository.GetAllAsync();
 
     public async Task<McpServerConfig?> GetByIdAsync(Guid id)
     {
@@ -18,7 +18,7 @@ public class McpServerConfigService(IMcpServerConfigRepository repository) : IMc
 
     public async Task CreateAsync(McpServerConfig serverConfig)
     {
-        var servers = await _repository.GetAllAsync();
+        var servers = (await _repository.GetAllAsync()).ToList();
         serverConfig.Id ??= Guid.NewGuid();
         serverConfig.CreatedAt = DateTime.UtcNow;
         serverConfig.UpdatedAt = DateTime.UtcNow;
@@ -28,7 +28,7 @@ public class McpServerConfigService(IMcpServerConfigRepository repository) : IMc
 
     public async Task UpdateAsync(McpServerConfig serverConfig)
     {
-        var servers = await _repository.GetAllAsync();
+        var servers = (await _repository.GetAllAsync()).ToList();
         var index = servers.FindIndex(s => s.Id == serverConfig.Id);
         if (index == -1)
             throw new KeyNotFoundException($"MCP server config with ID {serverConfig.Id} not found");
@@ -39,7 +39,7 @@ public class McpServerConfigService(IMcpServerConfigRepository repository) : IMc
 
     public async Task DeleteAsync(Guid id)
     {
-        var servers = await _repository.GetAllAsync();
+        var servers = (await _repository.GetAllAsync()).ToList();
         var existing = servers.FirstOrDefault(s => s.Id == id) ??
                        throw new KeyNotFoundException($"MCP server config with ID {id} not found");
         servers.Remove(existing);

--- a/ChatClient.Api/Services/OpenAIClientService.cs
+++ b/ChatClient.Api/Services/OpenAIClientService.cs
@@ -37,7 +37,7 @@ public class OpenAIClientService(
         return openAIClient;
     }
 
-    public async Task<List<string>> GetAvailableModelsAsync(Guid serverId, CancellationToken cancellationToken = default)
+    public async Task<IReadOnlyCollection<string>> GetAvailableModelsAsync(Guid serverId, CancellationToken cancellationToken = default)
     {
         if (serverId == Guid.Empty)
             throw new ArgumentException("ServerId cannot be empty", nameof(serverId));

--- a/ChatClient.Api/Services/Rag/RagFileService.cs
+++ b/ChatClient.Api/Services/Rag/RagFileService.cs
@@ -10,7 +10,7 @@ public class RagFileService(IRagFileRepository repository, IRagVectorIndexBackgr
     private readonly IRagFileRepository _repository = repository;
     private readonly IRagVectorIndexBackgroundService _indexBackgroundService = indexBackgroundService;
 
-    public Task<List<RagFile>> GetFilesAsync(Guid id) => _repository.GetFilesAsync(id);
+    public Task<IReadOnlyCollection<RagFile>> GetFilesAsync(Guid id) => _repository.GetFilesAsync(id);
 
     public Task<RagFile?> GetFileAsync(Guid id, string fileName)
     {

--- a/ChatClient.Api/Services/SavedChatService.cs
+++ b/ChatClient.Api/Services/SavedChatService.cs
@@ -9,10 +9,10 @@ public class SavedChatService(ISavedChatRepository repository) : ISavedChatServi
 {
     private readonly ISavedChatRepository _repository = repository;
 
-    public Task<List<SavedChat>> GetAllAsync(CancellationToken cancellationToken = default) =>
+    public Task<IReadOnlyCollection<SavedChat>> GetAllAsync(CancellationToken cancellationToken = default) =>
         _repository.GetAllAsync(cancellationToken);
 
-    public async Task<List<SavedChat>> SearchAsync(string query, CancellationToken cancellationToken = default)
+    public async Task<IReadOnlyCollection<SavedChat>> SearchAsync(string query, CancellationToken cancellationToken = default)
     {
         var chats = await _repository.GetAllAsync(cancellationToken);
         if (string.IsNullOrWhiteSpace(query))

--- a/ChatClient.Application/Repositories/IAgentDescriptionRepository.cs
+++ b/ChatClient.Application/Repositories/IAgentDescriptionRepository.cs
@@ -4,7 +4,7 @@ using ChatClient.Domain.Models;
 
 public interface IAgentDescriptionRepository
 {
-    Task<List<AgentDescription>> GetAllAsync(CancellationToken cancellationToken = default);
+    Task<IReadOnlyCollection<AgentDescription>> GetAllAsync(CancellationToken cancellationToken = default);
     Task SaveAllAsync(List<AgentDescription> agents, CancellationToken cancellationToken = default);
 }
 

--- a/ChatClient.Application/Repositories/ILlmServerConfigRepository.cs
+++ b/ChatClient.Application/Repositories/ILlmServerConfigRepository.cs
@@ -4,7 +4,7 @@ using ChatClient.Domain.Models;
 
 public interface ILlmServerConfigRepository
 {
-    Task<List<LlmServerConfig>> GetAllAsync(CancellationToken cancellationToken = default);
+    Task<IReadOnlyCollection<LlmServerConfig>> GetAllAsync(CancellationToken cancellationToken = default);
     Task SaveAllAsync(List<LlmServerConfig> servers, CancellationToken cancellationToken = default);
 }
 

--- a/ChatClient.Application/Repositories/IMcpServerConfigRepository.cs
+++ b/ChatClient.Application/Repositories/IMcpServerConfigRepository.cs
@@ -4,7 +4,7 @@ using ChatClient.Domain.Models;
 
 public interface IMcpServerConfigRepository
 {
-    Task<List<McpServerConfig>> GetAllAsync(CancellationToken cancellationToken = default);
+    Task<IReadOnlyCollection<McpServerConfig>> GetAllAsync(CancellationToken cancellationToken = default);
     Task SaveAllAsync(List<McpServerConfig> servers, CancellationToken cancellationToken = default);
 }
 

--- a/ChatClient.Application/Repositories/IRagFileRepository.cs
+++ b/ChatClient.Application/Repositories/IRagFileRepository.cs
@@ -4,7 +4,7 @@ using ChatClient.Domain.Models;
 
 public interface IRagFileRepository
 {
-    Task<List<RagFile>> GetFilesAsync(Guid id);
+    Task<IReadOnlyCollection<RagFile>> GetFilesAsync(Guid id);
     Task<RagFile?> GetFileAsync(Guid id, string fileName);
     Task AddOrUpdateFileAsync(Guid id, RagFile file);
     Task DeleteFileAsync(Guid id, string fileName);

--- a/ChatClient.Application/Repositories/ISavedChatRepository.cs
+++ b/ChatClient.Application/Repositories/ISavedChatRepository.cs
@@ -4,7 +4,7 @@ using ChatClient.Domain.Models;
 
 public interface ISavedChatRepository
 {
-    Task<List<SavedChat>> GetAllAsync(CancellationToken cancellationToken = default);
+    Task<IReadOnlyCollection<SavedChat>> GetAllAsync(CancellationToken cancellationToken = default);
     Task<SavedChat?> GetByIdAsync(Guid id, CancellationToken cancellationToken = default);
     Task SaveAsync(SavedChat chat, CancellationToken cancellationToken = default);
     Task DeleteAsync(Guid id, CancellationToken cancellationToken = default);

--- a/ChatClient.Application/Services/IAgentDescriptionService.cs
+++ b/ChatClient.Application/Services/IAgentDescriptionService.cs
@@ -4,7 +4,7 @@ namespace ChatClient.Application.Services;
 
 public interface IAgentDescriptionService
 {
-    Task<List<AgentDescription>> GetAllAsync();
+    Task<IReadOnlyCollection<AgentDescription>> GetAllAsync();
     Task<AgentDescription?> GetByIdAsync(Guid id);
     Task CreateAsync(AgentDescription agentDescription);
     Task UpdateAsync(AgentDescription agentDescription);

--- a/ChatClient.Application/Services/IMcpServerConfigService.cs
+++ b/ChatClient.Application/Services/IMcpServerConfigService.cs
@@ -4,7 +4,7 @@ namespace ChatClient.Application.Services;
 
 public interface IMcpServerConfigService
 {
-    Task<List<McpServerConfig>> GetAllAsync();
+    Task<IReadOnlyCollection<McpServerConfig>> GetAllAsync();
     Task<McpServerConfig?> GetByIdAsync(Guid id);
     Task CreateAsync(McpServerConfig serverConfig);
     Task UpdateAsync(McpServerConfig serverConfig);

--- a/ChatClient.Application/Services/IRagFileService.cs
+++ b/ChatClient.Application/Services/IRagFileService.cs
@@ -4,7 +4,7 @@ namespace ChatClient.Application.Services;
 
 public interface IRagFileService
 {
-    Task<List<RagFile>> GetFilesAsync(Guid id);
+    Task<IReadOnlyCollection<RagFile>> GetFilesAsync(Guid id);
     Task<RagFile?> GetFileAsync(Guid id, string fileName);
     Task AddOrUpdateFileAsync(Guid id, RagFile file);
     Task DeleteFileAsync(Guid id, string fileName);

--- a/ChatClient.Application/Services/ISavedChatService.cs
+++ b/ChatClient.Application/Services/ISavedChatService.cs
@@ -4,11 +4,11 @@ namespace ChatClient.Application.Services;
 
 public interface ISavedChatService
 {
-    Task<List<SavedChat>> GetAllAsync(CancellationToken cancellationToken = default);
+    Task<IReadOnlyCollection<SavedChat>> GetAllAsync(CancellationToken cancellationToken = default);
     /// <summary>
     /// Returns saved chats matching the specified query in title or participant names.
     /// </summary>
-    Task<List<SavedChat>> SearchAsync(string query, CancellationToken cancellationToken = default);
+    Task<IReadOnlyCollection<SavedChat>> SearchAsync(string query, CancellationToken cancellationToken = default);
     Task<SavedChat?> GetByIdAsync(Guid id, CancellationToken cancellationToken = default);
     Task SaveAsync(SavedChat savedChat, CancellationToken cancellationToken = default);
     Task DeleteAsync(Guid id, CancellationToken cancellationToken = default);

--- a/ChatClient.Infrastructure/Repositories/AgentDescriptionRepository.cs
+++ b/ChatClient.Infrastructure/Repositories/AgentDescriptionRepository.cs
@@ -16,7 +16,7 @@ public class AgentDescriptionRepository : IAgentDescriptionRepository
         _repo = new JsonFileRepository<List<AgentDescription>>(filePath, logger);
     }
 
-    public async Task<List<AgentDescription>> GetAllAsync(CancellationToken cancellationToken = default) =>
+    public async Task<IReadOnlyCollection<AgentDescription>> GetAllAsync(CancellationToken cancellationToken = default) =>
         await _repo.ReadAsync(cancellationToken) ?? [];
 
     public Task SaveAllAsync(List<AgentDescription> agents, CancellationToken cancellationToken = default) =>

--- a/ChatClient.Infrastructure/Repositories/LlmServerConfigRepository.cs
+++ b/ChatClient.Infrastructure/Repositories/LlmServerConfigRepository.cs
@@ -16,7 +16,7 @@ public class LlmServerConfigRepository : ILlmServerConfigRepository
         _repo = new JsonFileRepository<List<LlmServerConfig>>(filePath, logger);
     }
 
-    public async Task<List<LlmServerConfig>> GetAllAsync(CancellationToken cancellationToken = default) =>
+    public async Task<IReadOnlyCollection<LlmServerConfig>> GetAllAsync(CancellationToken cancellationToken = default) =>
         await _repo.ReadAsync(cancellationToken) ?? [];
 
     public Task SaveAllAsync(List<LlmServerConfig> servers, CancellationToken cancellationToken = default) =>

--- a/ChatClient.Infrastructure/Repositories/McpServerConfigRepository.cs
+++ b/ChatClient.Infrastructure/Repositories/McpServerConfigRepository.cs
@@ -16,7 +16,7 @@ public class McpServerConfigRepository : IMcpServerConfigRepository
         _repo = new JsonFileRepository<List<McpServerConfig>>(filePath, logger);
     }
 
-    public async Task<List<McpServerConfig>> GetAllAsync(CancellationToken cancellationToken = default) =>
+    public async Task<IReadOnlyCollection<McpServerConfig>> GetAllAsync(CancellationToken cancellationToken = default) =>
         await _repo.ReadAsync(cancellationToken) ?? [];
 
     public Task SaveAllAsync(List<McpServerConfig> servers, CancellationToken cancellationToken = default) =>

--- a/ChatClient.Infrastructure/Repositories/RagFileRepository.cs
+++ b/ChatClient.Infrastructure/Repositories/RagFileRepository.cs
@@ -8,7 +8,7 @@ public class RagFileRepository(IConfiguration configuration) : IRagFileRepositor
 {
     private readonly string _basePath = configuration["RagFiles:BasePath"] ?? Path.Combine("Data", "agents");
 
-    public async Task<List<RagFile>> GetFilesAsync(Guid id)
+    public async Task<IReadOnlyCollection<RagFile>> GetFilesAsync(Guid id)
     {
         var agentFolder = GetAgentFolder(id);
         var filesDir = Path.Combine(agentFolder, "files");

--- a/ChatClient.Infrastructure/Repositories/SavedChatRepository.cs
+++ b/ChatClient.Infrastructure/Repositories/SavedChatRepository.cs
@@ -27,7 +27,7 @@ public class SavedChatRepository : ISavedChatRepository
         Directory.CreateDirectory(_directoryPath);
     }
 
-    public async Task<List<SavedChat>> GetAllAsync(CancellationToken cancellationToken = default)
+    public async Task<IReadOnlyCollection<SavedChat>> GetAllAsync(CancellationToken cancellationToken = default)
     {
         try
         {

--- a/ChatClient.Tests/AppChatHistoryBuilderTests.cs
+++ b/ChatClient.Tests/AppChatHistoryBuilderTests.cs
@@ -37,7 +37,7 @@ public class AppChatHistoryBuilderTests
 
     private sealed class ThrowingRagFileService : IRagFileService
     {
-        public Task<List<RagFile>> GetFilesAsync(Guid id) => throw new InvalidOperationException();
+        public Task<IReadOnlyCollection<RagFile>> GetFilesAsync(Guid id) => throw new InvalidOperationException();
         public Task<RagFile?> GetFileAsync(Guid id, string fileName) => throw new InvalidOperationException();
         public Task AddOrUpdateFileAsync(Guid id, RagFile file) => throw new InvalidOperationException();
         public Task DeleteFileAsync(Guid id, string fileName) => throw new InvalidOperationException();

--- a/ChatClient.Tests/ChatServiceTests.cs
+++ b/ChatClient.Tests/ChatServiceTests.cs
@@ -32,8 +32,8 @@ public class ChatServiceTests
         public Task<IChatCompletionService> GetClientAsync(ServerModel serverModel, CancellationToken cancellationToken = default)
             => Task.FromResult<IChatCompletionService>(null!);
 
-        public Task<List<string>> GetAvailableModelsAsync(Guid serverId, CancellationToken cancellationToken = default)
-            => Task.FromResult<List<string>>([]);
+        public Task<IReadOnlyCollection<string>> GetAvailableModelsAsync(Guid serverId, CancellationToken cancellationToken = default)
+            => Task.FromResult<IReadOnlyCollection<string>>([]);
 
         public Task<bool> IsAvailableAsync(Guid serverId, CancellationToken cancellationToken = default)
             => Task.FromResult(false);
@@ -50,7 +50,7 @@ public class ChatServiceTests
 
     private class MockLlmServerConfigService : ILlmServerConfigService
     {
-        public Task<List<LlmServerConfig>> GetAllAsync() => Task.FromResult<List<LlmServerConfig>>([]);
+        public Task<IReadOnlyCollection<LlmServerConfig>> GetAllAsync() => Task.FromResult<IReadOnlyCollection<LlmServerConfig>>([]);
         public Task<LlmServerConfig?> GetByIdAsync(Guid id) => Task.FromResult<LlmServerConfig?>(null);
         public Task CreateAsync(LlmServerConfig serverConfig) => Task.CompletedTask;
         public Task UpdateAsync(LlmServerConfig serverConfig) => Task.CompletedTask;

--- a/ChatClient.Tests/OllamaServiceTests.cs
+++ b/ChatClient.Tests/OllamaServiceTests.cs
@@ -33,9 +33,9 @@ public class OllamaServiceTests
 
     private class MockLlmServerConfigService : ILlmServerConfigService
     {
-        public Task<List<LlmServerConfig>> GetAllAsync()
+        public Task<IReadOnlyCollection<LlmServerConfig>> GetAllAsync()
         {
-            return Task.FromResult<List<LlmServerConfig>>([]);
+            return Task.FromResult<IReadOnlyCollection<LlmServerConfig>>([]);
         }
 
         public Task<LlmServerConfig?> GetByIdAsync(Guid id)

--- a/ChatClient.Tests/PhilosopherDebateTests.cs
+++ b/ChatClient.Tests/PhilosopherDebateTests.cs
@@ -53,7 +53,7 @@ public partial class PhilosopherDebateTests
         builder.Services.AddLogging();
         Kernel kernel = builder.Build();
 
-        List<AgentDescription> descriptions = await LoadDescriptionsAsync();
+        var descriptions = await LoadDescriptionsAsync();
         AgentDescription kantDesc = descriptions.First(a => a.AgentName == "Immanuel Kant");
         AgentDescription benthamDesc = descriptions.First(a => a.AgentName == "Jeremy Bentham");
 
@@ -106,7 +106,7 @@ public partial class PhilosopherDebateTests
         }
     }
 
-    private static async Task<List<AgentDescription>> LoadDescriptionsAsync()
+    private static async Task<IReadOnlyCollection<AgentDescription>> LoadDescriptionsAsync()
     {
         string currentDir = Directory.GetCurrentDirectory();
         string[] paths =

--- a/ChatClient.Tests/SavedChatServiceTests.cs
+++ b/ChatClient.Tests/SavedChatServiceTests.cs
@@ -4,6 +4,7 @@ using ChatClient.Domain.Models;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using System.Text.Json;
+using System.Linq;
 
 namespace ChatClient.Tests;
 
@@ -102,11 +103,11 @@ public class SavedChatServiceTests
 
             var byTitle = await service.SearchAsync("First");
             Assert.Single(byTitle);
-            Assert.Equal(chat1.Id, byTitle[0].Id);
+            Assert.Equal(chat1.Id, byTitle.First().Id);
 
             var byParticipant = await service.SearchAsync("beta");
             Assert.Single(byParticipant);
-            Assert.Equal(chat2.Id, byParticipant[0].Id);
+            Assert.Equal(chat2.Id, byParticipant.First().Id);
         }
         finally
         {

--- a/ChatClient.Tests/UserSettingsServiceTests.cs
+++ b/ChatClient.Tests/UserSettingsServiceTests.cs
@@ -12,9 +12,9 @@ public class UserSettingsServiceTests
 {
     private class MockLlmServerConfigService : ILlmServerConfigService
     {
-        public Task<List<LlmServerConfig>> GetAllAsync()
+        public Task<IReadOnlyCollection<LlmServerConfig>> GetAllAsync()
         {
-            return Task.FromResult<List<LlmServerConfig>>([]);
+            return Task.FromResult<IReadOnlyCollection<LlmServerConfig>>([]);
         }
 
         public Task<LlmServerConfig?> GetByIdAsync(Guid id)


### PR DESCRIPTION
## Summary
- return `IReadOnlyCollection<T>` from query-like services and repositories
- update callers to handle read-only collections
- document preference for read-only returns

## Testing
- `dotnet test -v normal`

------
https://chatgpt.com/codex/tasks/task_e_68c1601eda1c832abff391557f751517