### PR TITLE
Use System.Threading.Lock for synchronization

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -58,6 +58,7 @@
 - Use camelCase for parameters, local variables, and private fields.
 - Prefix interfaces with `I` (e.g., `IUserService`).
 - Use primary constructors when appropriate (C# 12+).
+- Prefer `System.Threading.Lock` over `object` for synchronization.
 - **Parameter naming**: Parameter names must match their semantic purpose in the method. Avoid generic names that don't reflect the actual data type or business meaning.
 - Return `IReadOnlyCollection<T>` instead of `List<T>` when modification isn't required.
 

--- a/ChatClient.Api/Services/OllamaService.cs
+++ b/ChatClient.Api/Services/OllamaService.cs
@@ -6,6 +6,7 @@ using OllamaSharp.Models;
 using System.Collections.Concurrent;
 using System.Net.Http.Headers;
 using System.Text;
+using System.Threading;
 
 namespace ChatClient.Api.Services;
 
@@ -17,7 +18,7 @@ public sealed class OllamaService(
 {
     private readonly Dictionary<Guid, (OllamaApiClient Client, HttpClient HttpClient)> _clients = new();
     private readonly ConcurrentDictionary<Guid, IReadOnlyList<OllamaModel>> _modelsCache = new();
-    private readonly object _lock = new();
+    private readonly Lock _lock = new();
     private Exception? _embeddingError;
 
     public async Task<OllamaApiClient> GetClientAsync(Guid serverId)


### PR DESCRIPTION
## Summary
- Replace object lock with System.Threading.Lock in OllamaService
- Update Copilot instructions to prefer System.Threading.Lock for synchronization

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68c164ed0298832a8ad519e46ebf8c7c