### PR TITLE
refactor: use HttpClientFactory for Ollama

### DIFF
--- a/ChatClient.Api/Program.cs
+++ b/ChatClient.Api/Program.cs
@@ -13,6 +13,7 @@ using Microsoft.SemanticKernel.Connectors.InMemory;
 using MudBlazor.Services;
 using Serilog;
 using System.Text;
+using System.Net.Http;
 
 // Enable UTF-8 for proper Cyrillic support.
 Console.OutputEncoding = Encoding.UTF8;
@@ -88,7 +89,17 @@ builder.Services.AddSingleton<McpServerConfigSeeder>();
 
 builder.Services.AddRazorPages();
 builder.Services.AddServerSideBlazor();
+
+builder.Services.AddTransient<HttpLoggingHandler>();
 builder.Services.AddHttpClient();
+builder.Services.AddHttpClient("ollama")
+    .AddHttpMessageHandler<HttpLoggingHandler>();
+builder.Services.AddHttpClient("ollama-insecure")
+    .ConfigurePrimaryHttpMessageHandler(() => new HttpClientHandler
+    {
+        ServerCertificateCustomValidationCallback = (_, _, _, _) => true
+    })
+    .AddHttpMessageHandler<HttpLoggingHandler>();
 
 builder.Services.AddMudServices();
 


### PR DESCRIPTION
## Summary
- resolve Ollama clients through `IHttpClientFactory` with explicit cache invalidation
- add named HTTP clients with logging and optional certificate bypass
- update unit tests for new service dependencies

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68c175794f90832a9e92913d78b07714