### PR TITLE
Clarify agent ID naming in RAG file services

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -60,6 +60,7 @@
 - Use primary constructors when appropriate (C# 12+).
 - Prefer `System.Threading.Lock` over `object` for synchronization.
 - **Parameter naming**: Parameter names must match their semantic purpose in the method. Avoid generic names that don't reflect the actual data type or business meaning.
+- Use descriptive ID names (e.g., `agentId`, `fileId`) instead of generic `id`.
 - Return `IReadOnlyCollection<T>` instead of `List<T>` when modification isn't required.
 
 ### Error Handling

--- a/ChatClient.Api/Client/Pages/AgentDescriptions.razor
+++ b/ChatClient.Api/Client/Pages/AgentDescriptions.razor
@@ -411,10 +411,10 @@
             .ToList();
     }
 
-    private async Task LoadRagFiles(Guid id)
+    private async Task LoadRagFiles(Guid agentId)
     {
-        ragFiles = (await RagFileService.GetFilesAsync(id)).ToList();
-        ragCounts[id] = ragFiles.Count;
+        ragFiles = (await RagFileService.GetFilesAsync(agentId)).ToList();
+        ragCounts[agentId] = ragFiles.Count;
     }
 
     private async Task UploadFiles(InputFileChangeEventArgs e)

--- a/ChatClient.Api/Controllers/RagFilesController.cs
+++ b/ChatClient.Api/Controllers/RagFilesController.cs
@@ -6,7 +6,7 @@ using Microsoft.AspNetCore.Mvc;
 namespace ChatClient.Api.Controllers;
 
 [ApiController]
-[Route("api/agents/{id:guid}/files")]
+[Route("api/agents/{agentId:guid}/files")]
 public class RagFilesController : ControllerBase
 {
     private readonly IRagFileService _fileService;
@@ -19,11 +19,11 @@ public class RagFilesController : ControllerBase
     }
 
     [HttpGet]
-    public async Task<ActionResult<IEnumerable<RagFile>>> GetFiles(Guid id)
-        => Ok(await _fileService.GetFilesAsync(id));
+    public async Task<ActionResult<IEnumerable<RagFile>>> GetFiles(Guid agentId)
+        => Ok(await _fileService.GetFilesAsync(agentId));
 
     [HttpGet("{fileName}")]
-    public async Task<ActionResult<RagFile>> GetFile(Guid id, string fileName)
+    public async Task<ActionResult<RagFile>> GetFile(Guid agentId, string fileName)
     {
         try
         {
@@ -33,14 +33,14 @@ public class RagFilesController : ControllerBase
         {
             return BadRequest("Invalid file name.");
         }
-        var file = await _fileService.GetFileAsync(id, fileName);
+        var file = await _fileService.GetFileAsync(agentId, fileName);
         if (file is null)
             return NotFound();
         return Ok(file);
     }
 
     [HttpPost]
-    public async Task<ActionResult> Upload(Guid id, [FromForm] IFormFile file)
+    public async Task<ActionResult> Upload(Guid agentId, [FromForm] IFormFile file)
     {
         try
         {
@@ -55,12 +55,12 @@ public class RagFilesController : ControllerBase
             return BadRequest($"Unsupported file type {ext}");
 
         var content = await _converter.ConvertToTextAsync(file);
-        await _fileService.AddOrUpdateFileAsync(id, new RagFile { FileName = file.FileName, Content = content });
+        await _fileService.AddOrUpdateFileAsync(agentId, new RagFile { FileName = file.FileName, Content = content });
         return Ok();
     }
 
     [HttpPut("{fileName}")]
-    public async Task<ActionResult> Update(Guid id, string fileName, [FromForm] IFormFile file)
+    public async Task<ActionResult> Update(Guid agentId, string fileName, [FromForm] IFormFile file)
     {
         try
         {
@@ -76,12 +76,12 @@ public class RagFilesController : ControllerBase
             return BadRequest($"Unsupported file type {ext}");
 
         var content = await _converter.ConvertToTextAsync(file);
-        await _fileService.AddOrUpdateFileAsync(id, new RagFile { FileName = fileName, Content = content });
+        await _fileService.AddOrUpdateFileAsync(agentId, new RagFile { FileName = fileName, Content = content });
         return Ok();
     }
 
     [HttpDelete("{fileName}")]
-    public async Task<ActionResult> Delete(Guid id, string fileName)
+    public async Task<ActionResult> Delete(Guid agentId, string fileName)
     {
         try
         {
@@ -91,7 +91,7 @@ public class RagFilesController : ControllerBase
         {
             return BadRequest("Invalid file name.");
         }
-        await _fileService.DeleteFileAsync(id, fileName);
+        await _fileService.DeleteFileAsync(agentId, fileName);
         return NoContent();
     }
 }

--- a/ChatClient.Api/Services/Rag/RagFileService.cs
+++ b/ChatClient.Api/Services/Rag/RagFileService.cs
@@ -10,25 +10,25 @@ public class RagFileService(IRagFileRepository repository, IRagVectorIndexBackgr
     private readonly IRagFileRepository _repository = repository;
     private readonly IRagVectorIndexBackgroundService _indexBackgroundService = indexBackgroundService;
 
-    public Task<IReadOnlyCollection<RagFile>> GetFilesAsync(Guid id) => _repository.GetFilesAsync(id);
+    public Task<IReadOnlyCollection<RagFile>> GetFilesAsync(Guid agentId) => _repository.GetFilesAsync(agentId);
 
-    public Task<RagFile?> GetFileAsync(Guid id, string fileName)
+    public Task<RagFile?> GetFileAsync(Guid agentId, string fileName)
     {
         FileNameValidator.Validate(fileName);
-        return _repository.GetFileAsync(id, fileName);
+        return _repository.GetFileAsync(agentId, fileName);
     }
 
-    public async Task AddOrUpdateFileAsync(Guid id, RagFile file)
+    public async Task AddOrUpdateFileAsync(Guid agentId, RagFile file)
     {
         FileNameValidator.Validate(file.FileName);
-        await _repository.AddOrUpdateFileAsync(id, file);
+        await _repository.AddOrUpdateFileAsync(agentId, file);
         _indexBackgroundService.RequestRebuild();
     }
 
-    public async Task DeleteFileAsync(Guid id, string fileName)
+    public async Task DeleteFileAsync(Guid agentId, string fileName)
     {
         FileNameValidator.Validate(fileName);
-        await _repository.DeleteFileAsync(id, fileName);
+        await _repository.DeleteFileAsync(agentId, fileName);
         _indexBackgroundService.RequestRebuild();
     }
 }

--- a/ChatClient.Api/Services/Rag/RagVectorSearchService.cs
+++ b/ChatClient.Api/Services/Rag/RagVectorSearchService.cs
@@ -109,7 +109,7 @@ public sealed class RagVectorSearchService(
         return success;
     }
 
-    private static string CollectionName(Guid id) => $"agent_{id:N}";
+    private static string CollectionName(Guid agentId) => $"agent_{agentId:N}";
 
     private static Piece ToPiece(RagVectorRecord record, double score)
         => new(record.File, record.Index, record.Text, score);

--- a/ChatClient.Application/Repositories/IRagFileRepository.cs
+++ b/ChatClient.Application/Repositories/IRagFileRepository.cs
@@ -4,8 +4,8 @@ using ChatClient.Domain.Models;
 
 public interface IRagFileRepository
 {
-    Task<IReadOnlyCollection<RagFile>> GetFilesAsync(Guid id);
-    Task<RagFile?> GetFileAsync(Guid id, string fileName);
-    Task AddOrUpdateFileAsync(Guid id, RagFile file);
-    Task DeleteFileAsync(Guid id, string fileName);
+    Task<IReadOnlyCollection<RagFile>> GetFilesAsync(Guid agentId);
+    Task<RagFile?> GetFileAsync(Guid agentId, string fileName);
+    Task AddOrUpdateFileAsync(Guid agentId, RagFile file);
+    Task DeleteFileAsync(Guid agentId, string fileName);
 }

--- a/ChatClient.Application/Services/IRagFileService.cs
+++ b/ChatClient.Application/Services/IRagFileService.cs
@@ -4,9 +4,9 @@ namespace ChatClient.Application.Services;
 
 public interface IRagFileService
 {
-    Task<IReadOnlyCollection<RagFile>> GetFilesAsync(Guid id);
-    Task<RagFile?> GetFileAsync(Guid id, string fileName);
-    Task AddOrUpdateFileAsync(Guid id, RagFile file);
-    Task DeleteFileAsync(Guid id, string fileName);
+    Task<IReadOnlyCollection<RagFile>> GetFilesAsync(Guid agentId);
+    Task<RagFile?> GetFileAsync(Guid agentId, string fileName);
+    Task AddOrUpdateFileAsync(Guid agentId, RagFile file);
+    Task DeleteFileAsync(Guid agentId, string fileName);
 }
 

--- a/ChatClient.Infrastructure/Repositories/RagFileRepository.cs
+++ b/ChatClient.Infrastructure/Repositories/RagFileRepository.cs
@@ -8,9 +8,9 @@ public class RagFileRepository(IConfiguration configuration) : IRagFileRepositor
 {
     private readonly string _basePath = configuration["RagFiles:BasePath"] ?? Path.Combine("Data", "agents");
 
-    public async Task<IReadOnlyCollection<RagFile>> GetFilesAsync(Guid id)
+    public async Task<IReadOnlyCollection<RagFile>> GetFilesAsync(Guid agentId)
     {
-        var agentFolder = GetAgentFolder(id);
+        var agentFolder = GetAgentFolder(agentId);
         var filesDir = Path.Combine(agentFolder, "files");
         if (!Directory.Exists(filesDir))
             return [];
@@ -34,9 +34,9 @@ public class RagFileRepository(IConfiguration configuration) : IRagFileRepositor
         return result;
     }
 
-    public async Task<RagFile?> GetFileAsync(Guid id, string fileName)
+    public async Task<RagFile?> GetFileAsync(Guid agentId, string fileName)
     {
-        var agentFolder = GetAgentFolder(id);
+        var agentFolder = GetAgentFolder(agentId);
         var filePath = Path.Combine(agentFolder, "files", fileName);
         if (!File.Exists(filePath))
             return null;
@@ -53,9 +53,9 @@ public class RagFileRepository(IConfiguration configuration) : IRagFileRepositor
         };
     }
 
-    public async Task AddOrUpdateFileAsync(Guid id, RagFile file)
+    public async Task AddOrUpdateFileAsync(Guid agentId, RagFile file)
     {
-        var agentFolder = GetAgentFolder(id);
+        var agentFolder = GetAgentFolder(agentId);
         Directory.CreateDirectory(Path.Combine(agentFolder, "files"));
         Directory.CreateDirectory(Path.Combine(agentFolder, "index"));
 
@@ -67,9 +67,9 @@ public class RagFileRepository(IConfiguration configuration) : IRagFileRepositor
             File.Delete(indexPath);
     }
 
-    public Task DeleteFileAsync(Guid id, string fileName)
+    public Task DeleteFileAsync(Guid agentId, string fileName)
     {
-        var agentFolder = GetAgentFolder(id);
+        var agentFolder = GetAgentFolder(agentId);
         var indexPath = Path.Combine(agentFolder, "index", Path.ChangeExtension(fileName, ".idx"));
         if (File.Exists(indexPath))
             File.Delete(indexPath);
@@ -80,5 +80,5 @@ public class RagFileRepository(IConfiguration configuration) : IRagFileRepositor
         return Task.CompletedTask;
     }
 
-    private string GetAgentFolder(Guid id) => Path.Combine(_basePath, id.ToString());
+    private string GetAgentFolder(Guid agentId) => Path.Combine(_basePath, agentId.ToString());
 }

--- a/ChatClient.Tests/AppChatHistoryBuilderTests.cs
+++ b/ChatClient.Tests/AppChatHistoryBuilderTests.cs
@@ -37,10 +37,10 @@ public class AppChatHistoryBuilderTests
 
     private sealed class ThrowingRagFileService : IRagFileService
     {
-        public Task<IReadOnlyCollection<RagFile>> GetFilesAsync(Guid id) => throw new InvalidOperationException();
-        public Task<RagFile?> GetFileAsync(Guid id, string fileName) => throw new InvalidOperationException();
-        public Task AddOrUpdateFileAsync(Guid id, RagFile file) => throw new InvalidOperationException();
-        public Task DeleteFileAsync(Guid id, string fileName) => throw new InvalidOperationException();
+        public Task<IReadOnlyCollection<RagFile>> GetFilesAsync(Guid agentId) => throw new InvalidOperationException();
+        public Task<RagFile?> GetFileAsync(Guid agentId, string fileName) => throw new InvalidOperationException();
+        public Task AddOrUpdateFileAsync(Guid agentId, RagFile file) => throw new InvalidOperationException();
+        public Task DeleteFileAsync(Guid agentId, string fileName) => throw new InvalidOperationException();
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- rename ambiguous `id` parameters to `agentId` in RAG file interfaces, services, and controller
- update Razor components and tests to the new naming
- document requirement for descriptive ID names in coding instructions

## Testing
- `dotnet test` *(fails: The type or namespace name 'ToHtml' does not exist in the namespace 'ChatClient.Api.Client.Markdown')*

------
https://chatgpt.com/codex/tasks/task_e_68c189267fb4832aa37e44fa9d78590f