### PR TITLE
Fix Markdig namespace usage in chat message view model

### DIFF
--- a/ChatClient.Api/Client/ViewModels/AppChatMessageViewModel.cs
+++ b/ChatClient.Api/Client/ViewModels/AppChatMessageViewModel.cs
@@ -2,6 +2,7 @@ using ChatClient.Api.Client.Markdown;
 using ChatClient.Domain.Models;
 using DimonSmart.AiUtils;
 using Markdig;
+using MarkdigMarkdown = Markdig.Markdown;
 using Microsoft.Extensions.AI;
 using System.Collections.Generic;
 using System.Linq;
@@ -48,11 +49,11 @@ public class AppChatMessageViewModel
 
         ThinkSegments = result.ThoughtSegments;
         HtmlThinkSegments = result.ThoughtSegments
-            .Select(segment => Markdown.ToHtml(segment, Pipeline))
+            .Select(segment => MarkdigMarkdown.ToHtml(segment, Pipeline))
             .ToList()
             .AsReadOnly();
         Content = result.Answer;
-        HtmlContent = Markdown.ToHtml(result.Answer, Pipeline);
+        HtmlContent = MarkdigMarkdown.ToHtml(result.Answer, Pipeline);
 
         HtmlFunctionCalls = FunctionCalls
             .Select(call =>
@@ -81,7 +82,7 @@ public class AppChatMessageViewModel
                 sb.AppendLine("```");
                 sb.AppendLine(call.Response);
                 sb.AppendLine("```");
-                return Markdown.ToHtml(sb.ToString(), Pipeline);
+                return MarkdigMarkdown.ToHtml(sb.ToString(), Pipeline);
             })
             .ToList()
             .AsReadOnly();


### PR DESCRIPTION
## Summary
- resolve namespace conflict by aliasing Markdig Markdown

## Testing
- `dotnet build`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68c18c234b24832aa9bcbdfbedb854b3