### PR TITLE
Sanitize think tags from request history

### DIFF
--- a/ChatClient.Tests/AppChatHistoryBuilderTests.cs
+++ b/ChatClient.Tests/AppChatHistoryBuilderTests.cs
@@ -89,4 +89,26 @@ public class AppChatHistoryBuilderTests
         Assert.Single(history);
         Assert.Equal(AuthorRole.Tool, history.First().Role);
     }
+
+    [Fact]
+    public void BuildBaseHistory_RemovesThinkSegments()
+    {
+        var builder = new AppChatHistoryBuilder(
+            new ThrowingUserSettingsService(),
+            new LoggerFactory().CreateLogger<AppChatHistoryBuilder>(),
+            new AppForceLastUserReducer(),
+            new ThrowingOllamaClientService(),
+            new ThrowingRagVectorSearchService(),
+            new ThrowingRagFileService(),
+            new ConfigurationBuilder().Build());
+
+        var messages = new List<IAppChatMessage>
+        {
+            new AppChatMessage("<think>t</think>answer", DateTime.UtcNow, ChatRole.Assistant)
+        };
+
+        var history = builder.BuildBaseHistory(messages);
+        var text = history.First().Items.OfType<Microsoft.SemanticKernel.TextContent>().FirstOrDefault()?.Text ?? string.Empty;
+        Assert.Equal("answer", text.Trim());
+    }
 }


### PR DESCRIPTION
## Summary
- rely on history builder to strip `<think>` segments
- remove redundant think-tag cleanup from chat service

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68c1dd2f8014832a9389418336470338