### PR TITLE
Fix build and guard missing embedding collections

### DIFF
--- a/ChatClient.Api/ChatClient.Api.csproj
+++ b/ChatClient.Api/ChatClient.Api.csproj
@@ -38,9 +38,9 @@
     </PropertyGroup>
     
     <ItemGroup>
-        <ProjectReference Include="..\ChatClient.Application\ChatClient.Application.csproj" />
-        <ProjectReference Include="..\ChatClient.Domain\ChatClient.Domain.csproj" />
-        <ProjectReference Include="..\ChatClient.Infrastructure\ChatClient.Infrastructure.csproj" />
+        <ProjectReference Include="../ChatClient.Application/ChatClient.Application.csproj" />
+        <ProjectReference Include="../ChatClient.Domain/ChatClient.Domain.csproj" />
+        <ProjectReference Include="../ChatClient.Infrastructure/ChatClient.Infrastructure.csproj" />
     </ItemGroup>
     
 </Project>

--- a/ChatClient.Api/Services/Rag/RagFileService.cs
+++ b/ChatClient.Api/Services/Rag/RagFileService.cs
@@ -16,6 +16,7 @@ public class RagFileService(IRagFileRepository repository, IRagVectorIndexBackgr
     {
         var files = await _repository.GetFilesAsync(agentId);
         var collection = CollectionName(agentId);
+        await _memoryStore.CreateCollectionAsync(collection, cancellationToken: default);
         foreach (var f in files)
         {
             var key = Key(f.FileName, 0);
@@ -30,8 +31,10 @@ public class RagFileService(IRagFileRepository repository, IRagVectorIndexBackgr
         var file = await _repository.GetFileAsync(agentId, fileName);
         if (file is null)
             return null;
+        var collection = CollectionName(agentId);
+        await _memoryStore.CreateCollectionAsync(collection, cancellationToken: default);
         var key = Key(fileName, 0);
-        file.HasIndex = await _memoryStore.GetAsync(CollectionName(agentId), key, withEmbedding: false, cancellationToken: default) is not null;
+        file.HasIndex = await _memoryStore.GetAsync(collection, key, withEmbedding: false, cancellationToken: default) is not null;
         return file;
     }
 
@@ -54,6 +57,7 @@ public class RagFileService(IRagFileRepository repository, IRagVectorIndexBackgr
     private async Task RemoveEmbeddingsAsync(Guid agentId, string fileName)
     {
         var collection = CollectionName(agentId);
+        await _memoryStore.CreateCollectionAsync(collection, cancellationToken: default);
         for (var i = 0; ; i++)
         {
             var key = Key(fileName, i);

--- a/ChatClient.Application/ChatClient.Application.csproj
+++ b/ChatClient.Application/ChatClient.Application.csproj
@@ -5,7 +5,7 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
-    <ProjectReference Include="..\ChatClient.Domain\ChatClient.Domain.csproj" />
+    <ProjectReference Include="../ChatClient.Domain/ChatClient.Domain.csproj" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.8" />
   </ItemGroup>
 </Project>

--- a/ChatClient.Infrastructure/ChatClient.Infrastructure.csproj
+++ b/ChatClient.Infrastructure/ChatClient.Infrastructure.csproj
@@ -7,8 +7,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\ChatClient.Application\ChatClient.Application.csproj" />
-    <ProjectReference Include="..\ChatClient.Domain\ChatClient.Domain.csproj" />
+    <ProjectReference Include="../ChatClient.Application/ChatClient.Application.csproj" />
+    <ProjectReference Include="../ChatClient.Domain/ChatClient.Domain.csproj" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="9.0.8" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.8" />
   </ItemGroup>

--- a/ChatClient.Tests/ChatClient.Tests.csproj
+++ b/ChatClient.Tests/ChatClient.Tests.csproj
@@ -28,10 +28,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\ChatClient.Api\ChatClient.Api.csproj" />
-    <ProjectReference Include="..\ChatClient.Application\ChatClient.Application.csproj" />
-    <ProjectReference Include="..\ChatClient.Domain\ChatClient.Domain.csproj" />
-    <ProjectReference Include="..\ChatClient.Infrastructure\ChatClient.Infrastructure.csproj" />
+    <ProjectReference Include="../ChatClient.Api/ChatClient.Api.csproj" />
+    <ProjectReference Include="../ChatClient.Application/ChatClient.Application.csproj" />
+    <ProjectReference Include="../ChatClient.Domain/ChatClient.Domain.csproj" />
+    <ProjectReference Include="../ChatClient.Infrastructure/ChatClient.Infrastructure.csproj" />
   </ItemGroup>
 
 </Project>

--- a/OllamaChat.sln
+++ b/OllamaChat.sln
@@ -3,20 +3,20 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.0.31903.59
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ChatClient.Api", "ChatClient.Api\ChatClient.Api.csproj", "{72EF2A5C-ACC5-41B0-A413-BB326220C8BB}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ChatClient.Api", "ChatClient.Api/ChatClient.Api.csproj", "{72EF2A5C-ACC5-41B0-A413-BB326220C8BB}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ChatClient.Tests", "ChatClient.Tests\ChatClient.Tests.csproj", "{5A530922-A79E-402F-AD88-998A75CB1E83}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ChatClient.Tests", "ChatClient.Tests/ChatClient.Tests.csproj", "{5A530922-A79E-402F-AD88-998A75CB1E83}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ChatClient.Domain", "ChatClient.Domain\ChatClient.Domain.csproj", "{BB4E085C-F898-4614-AEAA-8D30A48B77EC}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ChatClient.Domain", "ChatClient.Domain/ChatClient.Domain.csproj", "{BB4E085C-F898-4614-AEAA-8D30A48B77EC}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ChatClient.Application", "ChatClient.Application\ChatClient.Application.csproj", "{6BE41D0E-CB3F-47F0-8AE3-8F659E55D94B}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ChatClient.Application", "ChatClient.Application/ChatClient.Application.csproj", "{6BE41D0E-CB3F-47F0-8AE3-8F659E55D94B}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Infos", "Infos", "{02EA681E-C7D8-13C7-8484-4AC65E1B71E8}"
 	ProjectSection(SolutionItems) = preProject
 		Art Director stats.txt = Art Director stats.txt
 	EndProjectSection
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ChatClient.Infrastructure", "ChatClient.Infrastructure\ChatClient.Infrastructure.csproj", "{3F5880DC-A747-49D4-8F31-FB1E85FCA4E9}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ChatClient.Infrastructure", "ChatClient.Infrastructure/ChatClient.Infrastructure.csproj", "{3F5880DC-A747-49D4-8F31-FB1E85FCA4E9}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -51,8 +51,9 @@ Global
 		{5A530922-A79E-402F-AD88-998A75CB1E83}.Release|x64.ActiveCfg = Release|Any CPU
 		{5A530922-A79E-402F-AD88-998A75CB1E83}.Release|x64.Build.0 = Release|Any CPU
 		{5A530922-A79E-402F-AD88-998A75CB1E83}.Release|x86.ActiveCfg = Release|Any CPU
-		{BB4E085C-F898-4614-AEAA-8D30A48B77EC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{BB4E085C-F898-4614-AEAA-8D30A48B77EC}.Debug|x64.ActiveCfg = Debug|Any CPU
+            {BB4E085C-F898-4614-AEAA-8D30A48B77EC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+            {BB4E085C-F898-4614-AEAA-8D30A48B77EC}.Debug|Any CPU.Build.0 = Debug|Any CPU
+            {BB4E085C-F898-4614-AEAA-8D30A48B77EC}.Debug|x64.ActiveCfg = Debug|Any CPU
 		{BB4E085C-F898-4614-AEAA-8D30A48B77EC}.Debug|x64.Build.0 = Debug|Any CPU
 		{BB4E085C-F898-4614-AEAA-8D30A48B77EC}.Debug|x86.ActiveCfg = Debug|Any CPU
 		{BB4E085C-F898-4614-AEAA-8D30A48B77EC}.Debug|x86.Build.0 = Debug|Any CPU


### PR DESCRIPTION
## Summary
- ensure memory collections exist before querying the memory store
- fix cross-platform build by using POSIX project references and enabling Domain project build

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68c53f6b8b44832ab4c1dab83f054054