### PR TITLE
feat: unify rag content import with url support

### DIFF
--- a/ChatClient.Api/ChatClient.Api.csproj
+++ b/ChatClient.Api/ChatClient.Api.csproj
@@ -4,11 +4,12 @@
         <Nullable>enable</Nullable>
         <ImplicitUsings>enable</ImplicitUsings>
         <!-- Use both NoWarn and WarningsNotAsErrors to handle the experimental API warning -->
-        <NoWarn>$(NoWarn);SKEXP0070;SKEXP0110</NoWarn>
-        <WarningsNotAsErrors>$(WarningsNotAsErrors);SKEXP0070</WarningsNotAsErrors>
+        <NoWarn>$(NoWarn);SKEXP0070;SKEXP0110;SKEXP0050</NoWarn>
+        <WarningsNotAsErrors>$(WarningsNotAsErrors);SKEXP0070;SKEXP0050</WarningsNotAsErrors>
       <UserSecretsId>4a3297bb-431d-45ef-b95d-3d5c01782724</UserSecretsId>
   </PropertyGroup>
             <ItemGroup>
+        <PackageReference Include="HtmlAgilityPack" Version="1.12.2" />
         <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.8" />
         <PackageReference Include="Microsoft.Extensions.Http" Version="9.0.8" />
         <PackageReference Include="Microsoft.Extensions.AI" Version="9.8.0" />
@@ -21,6 +22,7 @@
         <PackageReference Include="Microsoft.SemanticKernel.Connectors.Sqlite" Version="1.51.0-preview" />
         <PackageReference Include="Microsoft.SemanticKernel.Plugins.Core" Version="1.64.0-preview" />
         <PackageReference Include="Microsoft.SemanticKernel.Plugins.Memory" Version="1.64.0-alpha" />
+        <PackageReference Include="Microsoft.SemanticKernel.Plugins.Web" Version="1.64.0-alpha" />
         <PackageReference Include="Microsoft.SemanticKernel.Agents.Abstractions" Version="1.64.0" />
         <PackageReference Include="Microsoft.SemanticKernel.Agents.Core" Version="1.64.0" />
         <PackageReference Include="Microsoft.Data.Sqlite" Version="9.0.0" />

--- a/ChatClient.Api/Controllers/WebPageImportRequest.cs
+++ b/ChatClient.Api/Controllers/WebPageImportRequest.cs
@@ -1,0 +1,4 @@
+namespace ChatClient.Api.Controllers;
+
+public sealed record WebPageImportRequest(string Url);
+

--- a/ChatClient.Api/Program.cs
+++ b/ChatClient.Api/Program.cs
@@ -80,6 +80,7 @@ builder.Services.AddSingleton<IRagVectorIndexRepository, RagVectorIndexRepositor
 builder.Services.AddSingleton<ChatClient.Application.Services.IUserSettingsService, ChatClient.Api.Services.UserSettingsService>();
 builder.Services.AddSingleton<ChatClient.Application.Services.ISavedChatService, ChatClient.Api.Services.SavedChatService>();
 builder.Services.AddSingleton<ChatClient.Application.Services.IRagFileService, RagFileService>();
+builder.Services.AddSingleton<ChatClient.Application.Services.IRagContentImportService, RagContentImportService>();
 builder.Services.AddSingleton<ChatClient.Application.Services.IRagVectorIndexService, RagVectorIndexService>();
 builder.Services.AddSingleton<RagVectorIndexBackgroundService>();
 builder.Services.AddSingleton<ChatClient.Application.Services.IRagVectorIndexBackgroundService>(sp => sp.GetRequiredService<RagVectorIndexBackgroundService>());

--- a/ChatClient.Api/Services/Rag/RagContentImportService.cs
+++ b/ChatClient.Api/Services/Rag/RagContentImportService.cs
@@ -1,0 +1,13 @@
+using System;
+using ChatClient.Application.Services;
+using ChatClient.Domain.Models;
+
+namespace ChatClient.Api.Services.Rag;
+
+public class RagContentImportService(IRagFileService fileService) : IRagContentImportService
+{
+    private readonly IRagFileService _fileService = fileService;
+
+    public Task AddContentAsync(Guid agentId, string content, string sourceName)
+        => _fileService.AddOrUpdateFileAsync(agentId, new RagFile { FileName = sourceName, Content = content });
+}

--- a/ChatClient.Application/Services/IRagContentImportService.cs
+++ b/ChatClient.Application/Services/IRagContentImportService.cs
@@ -1,0 +1,8 @@
+using System;
+
+namespace ChatClient.Application.Services;
+
+public interface IRagContentImportService
+{
+    Task AddContentAsync(Guid agentId, string content, string sourceName);
+}


### PR DESCRIPTION
## Summary
- remove custom web page ingestion and leverage Semantic Kernel web plugin
- streamline IRagContentImportService to handle only raw text
- update RagFilesController to download URLs and pass text via unified importer

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68c6aeade7ec832aa3e5b0678335cea0