### PR TITLE
Fix philosopher workflow agent references and clarify DSL

### DIFF
--- a/ChatClient.Api/AgentWorkflows/WorkflowAgentBuilderSavedAgentExtensions.cs
+++ b/ChatClient.Api/AgentWorkflows/WorkflowAgentBuilderSavedAgentExtensions.cs
@@ -1,0 +1,51 @@
+using ChatClient.Application.Services.AgentRuntime;
+
+namespace ChatClient.Api.AgentWorkflows;
+
+public static class WorkflowAgentBuilderSavedAgentExtensions
+{
+    public static WorkflowAgentBuilder UseAgentById(
+        this WorkflowAgentBuilder builder,
+        Guid agentId)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+
+        return builder.UseDefinition(new AgentDefinitionReference(
+            AgentDefinitionKind.SavedAgent,
+            agentId.ToString("D")));
+    }
+
+    public static WorkflowAgentBuilder UseAgentById(
+        this WorkflowAgentBuilder builder,
+        string agentId)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+
+        if (!Guid.TryParse(RequireValue(agentId, nameof(agentId)), out var parsedAgentId))
+        {
+            throw new ArgumentException("Saved agent id must be a valid GUID.", nameof(agentId));
+        }
+
+        return builder.UseAgentById(parsedAgentId);
+    }
+
+    public static WorkflowAgentBuilder UseAgentByName(
+        this WorkflowAgentBuilder builder,
+        string agentName)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+
+        return builder.UseSource(new SavedAgentNameParticipantSource(
+            RequireValue(agentName, nameof(agentName))));
+    }
+
+    private static string RequireValue(string? value, string paramName)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            throw new ArgumentException("Value is required.", paramName);
+        }
+
+        return value.Trim();
+    }
+}

--- a/ChatClient.Api/Data/workflows/philosopher-battle-group-chat.workflow.csx
+++ b/ChatClient.Api/Data/workflows/philosopher-battle-group-chat.workflow.csx
@@ -32,7 +32,7 @@ You speak only in the opening turn. Do not summarize the debate.")
                 .AutoSelectTools(0)
                 .Build()))
     .Agent("debater_a", agent => agent
-        .UseAgent("ab38adc6-74a2-4ccc-924b-eb1bce9d0985")
+        .UseAgentById("ab38adc6-74a2-4ccc-924b-eb1bce9d0985")
         .Role("Kantian philosopher")
         .OverrideAvatarText("K")
         .AppendInstructions(
@@ -41,7 +41,7 @@ You speak only in the opening turn. Do not summarize the debate.")
 - Speak to the other participants, not to the user.
 - Do not ask the user for input or summarize the whole debate."))
     .Agent("debater_b", agent => agent
-        .UseAgent("8bb2a12d-d5fd-440b-b622-b46d8897556a")
+        .UseAgentById("8bb2a12d-d5fd-440b-b622-b46d8897556a")
         .Role("Nietzschean philosopher")
         .OverrideAvatarText("N")
         .AppendInstructions(

--- a/ChatClient.Api/Data/workflows/philosopher-battle-group-chat.workflow.csx
+++ b/ChatClient.Api/Data/workflows/philosopher-battle-group-chat.workflow.csx
@@ -32,7 +32,7 @@ You speak only in the opening turn. Do not summarize the debate.")
                 .AutoSelectTools(0)
                 .Build()))
     .Agent("debater_a", agent => agent
-        .FromSavedAgent("Immanuel Kant")
+        .UseAgent("ab38adc6-74a2-4ccc-924b-eb1bce9d0985")
         .Role("Kantian philosopher")
         .OverrideAvatarText("K")
         .AppendInstructions(
@@ -41,7 +41,7 @@ You speak only in the opening turn. Do not summarize the debate.")
 - Speak to the other participants, not to the user.
 - Do not ask the user for input or summarize the whole debate."))
     .Agent("debater_b", agent => agent
-        .FromSavedAgent("Friedrich Nietzsche")
+        .UseAgent("8bb2a12d-d5fd-440b-b622-b46d8897556a")
         .Role("Nietzschean philosopher")
         .OverrideAvatarText("N")
         .AppendInstructions(

--- a/ChatClient.Tests/PhilosopherWorkflowDefinitionTests.cs
+++ b/ChatClient.Tests/PhilosopherWorkflowDefinitionTests.cs
@@ -23,7 +23,33 @@ public sealed class PhilosopherWorkflowDefinitionTests
 
         AssertSavedAgentReference(workflow, "debater_a", KantAgentId);
         AssertSavedAgentReference(workflow, "debater_b", NietzscheAgentId);
+        Assert.Contains("UseAgentById", sourceCode, StringComparison.Ordinal);
         Assert.DoesNotContain("FromSavedAgent", sourceCode, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task UseAgentByName_PreservesExpressiveNameBasedReference()
+    {
+        const string sourceCode =
+            """
+            var workflow = WorkflowDefinitionBuilder
+                .New("name-based-demo", "Name-based Demo")
+                .Agent("kant", agent => agent
+                    .UseAgentByName("Immanuel Kant")
+                    .Role("Kantian philosopher"))
+                .UseSequential(sequential => sequential
+                    .Order("kant"))
+                .Build();
+
+            workflow
+            """;
+
+        var compiled = await new WorkflowDefinitionCompiler().CompileAsync(sourceCode);
+        var workflow = Assert.IsType<SequentialWorkflowDefinition>(compiled.Workflow);
+        var participant = Assert.Single(workflow.Participants);
+        var source = Assert.IsType<SavedAgentNameParticipantSource>(participant.Source);
+
+        Assert.Equal("Immanuel Kant", source.SavedAgentName);
     }
 
     private static void AssertSavedAgentReference(

--- a/ChatClient.Tests/PhilosopherWorkflowDefinitionTests.cs
+++ b/ChatClient.Tests/PhilosopherWorkflowDefinitionTests.cs
@@ -1,0 +1,47 @@
+using ChatClient.Api.AgentWorkflows;
+using ChatClient.Application.Services.AgentRuntime;
+
+namespace ChatClient.Tests;
+
+public sealed class PhilosopherWorkflowDefinitionTests
+{
+    private static readonly Guid KantAgentId = Guid.Parse("ab38adc6-74a2-4ccc-924b-eb1bce9d0985");
+    private static readonly Guid NietzscheAgentId = Guid.Parse("8bb2a12d-d5fd-440b-b622-b46d8897556a");
+
+    [Fact]
+    public async Task BuiltInWorkflow_UsesStableSavedAgentIds()
+    {
+        var sourcePath = Path.Combine(
+            GetApiRoot(),
+            "Data",
+            "workflows",
+            "philosopher-battle-group-chat.workflow.csx");
+        var sourceCode = await File.ReadAllTextAsync(sourcePath);
+
+        var compiled = await new WorkflowDefinitionCompiler().CompileAsync(sourceCode);
+        var workflow = Assert.IsType<GroupChatWorkflowDefinition>(compiled.Workflow);
+
+        AssertSavedAgentReference(workflow, "debater_a", KantAgentId);
+        AssertSavedAgentReference(workflow, "debater_b", NietzscheAgentId);
+        Assert.DoesNotContain("FromSavedAgent", sourceCode, StringComparison.Ordinal);
+    }
+
+    private static void AssertSavedAgentReference(
+        GroupChatWorkflowDefinition workflow,
+        string participantId,
+        Guid expectedAgentId)
+    {
+        var participant = Assert.Single(
+            workflow.Participants,
+            candidate => string.Equals(candidate.Id, participantId, StringComparison.Ordinal));
+        var source = Assert.IsType<SavedDefinitionParticipantSource>(participant.Source);
+
+        Assert.Equal(AgentDefinitionKind.SavedAgent, source.Reference.Kind);
+        Assert.Equal(expectedAgentId.ToString("D"), source.Reference.Id);
+    }
+
+    private static string GetApiRoot()
+    {
+        return Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "..", "ChatClient.Api"));
+    }
+}


### PR DESCRIPTION
## Root cause

The built-in philosopher battle workflow referenced saved agents through the obsolete `FromSavedAgent(string)` API. Name resolution happens against the current user agent catalog, so a renamed, stale, or locally edited seeded agent can cause the workflow to fail with `Saved agent 'Immanuel Kant' was not found`.

## DSL changes

The workflow DSL now exposes two explicit saved-agent lookup forms:

- `UseAgentById(Guid|string)` for stable persisted references;
- `UseAgentByName(string)` for readable demo and authoring scenarios.

The methods are intentionally explicit about lookup semantics. Existing builder methods remain available for compatibility, while new workflows can use the clearer names.

## Philosopher workflow

- Replace the Kant and Nietzsche name references with stable seeded GUIDs via `UseAgentById(...)`.
- Keep name-based lookup supported and covered through a separate `UseAgentByName("Immanuel Kant")` compilation test.
- Add regression coverage verifying that the shipped workflow resolves both philosophers as saved-agent ID references.

## Existing installations

The normal workflow seeder intentionally does not overwrite an existing built-in workflow. After updating to this change, open **Workflow Definitions** and run **Restore Built-ins** once so the persisted philosopher workflow source is refreshed. Custom workflows are preserved.

## Validation

The PR includes focused compiler-level tests for both ID-based and name-based DSL forms. GitHub Actions have not reported a status for the latest commit yet, and tests could not be executed locally because this environment has no repository checkout or GitHub CLI.